### PR TITLE
feat: ampd deployment k8s

### DIFF
--- a/.github/workflows/ampd-deployment.yml
+++ b/.github/workflows/ampd-deployment.yml
@@ -2,7 +2,7 @@ name: Ampd deployment
 on:
   push:
     branches:
-      - "main"
+      - "ampd-deployment-k8s"
     paths:
       - "ampd/**"
 

--- a/.github/workflows/ampd-deployment.yml
+++ b/.github/workflows/ampd-deployment.yml
@@ -1,0 +1,67 @@
+name: Ampd deployment
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "ampd/**"
+
+env:
+  # If one change any variable of this env block, all of them needs to be aligned, as
+  # we cannot re-user them.
+  IMAGE_NAME: ampd
+  IMAGE_VERSION: ${{ github.sha }}
+  IMAGE_ID: solanaaxelartestnetregistry.azurecr.io/solana-axelar/ampd
+  DEPLOYING_IMAGE_FQDN: solanaaxelartestnetregistry.azurecr.io/solana-axelar/ampd:${{ github.sha }}
+
+jobs:
+
+  docker-image:
+    needs: code-checks
+    runs-on: ubuntu-latest
+    name: "Build and push docker image"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: true
+          cache-on-failure: true
+          workspaces: "ampd -> target"
+          shared-key: "ampd"
+
+      - name: Build image
+        run: docker build . --file ampd/Dockerfile --tag $IMAGE_NAME --tag latest
+
+      - name: Login to Azure Container Registry
+        uses: azure/docker-login@v1
+        with:
+          login-server: ${{ secrets.ACR_REGISTRY_NAME }}.azurecr.io
+          username: ${{ secrets.AZ_SP_CLIENT_ID }}
+          password: ${{ secrets.AZ_SP_CLIENT_SECRET }}
+
+      - name: Push image
+        run: |
+          docker tag $IMAGE_NAME $IMAGE_ID:$IMAGE_VERSION
+          docker tag $IMAGE_NAME $IMAGE_ID:latest
+          docker push $DEPLOYING_IMAGE_FQDN
+
+  deployment:
+    needs: docker-image
+    runs-on: ubuntu-latest
+    name: "Deploy to k8s cluster"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: azure/setup-kubectl@v2.0
+
+      - uses: Azure/k8s-set-context@v2
+        with:
+          method: kubeconfig
+          kubeconfig: ${{ secrets.KUBE_CONFIG }}
+          context: solanaaxelartestnetk8s
+
+      - name: Deploy image in k8s
+        run: kubectl set image deployment/ampd ampd=${{ env.DEPLOYING_IMAGE_FQDN }}


### PR DESCRIPTION
**Referenced Issue**
https://github.com/eigerco/solana-axelar/issues/220

**Description**

This PR adds a CI workflow that:

* Creates and pushes a docker image of the `ampd` daemon.
* Deploys the image at Eiger's axelar K8S cluster.

**TODO**

* [ ] Add SSH auth, so we can pull the private dependencies like gmp-gateway.