### PR TITLE
feat: add CallContract starknet event parsing logic

### DIFF
--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -40,7 +40,7 @@ mod handlers;
 mod health_check;
 mod json_rpc;
 mod queue;
-mod starknet;
+pub mod starknet;
 pub mod state;
 mod sui;
 mod tm_client;

--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -20,7 +20,7 @@ use tokio::signal::unix::{signal, SignalKind};
 use tokio::sync::oneshot;
 use tokio_stream::Stream;
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::info;
 use types::TMAddress;
 
 use crate::asyncutil::task::{CancellableTask, TaskError, TaskGroup};

--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -20,7 +20,7 @@ use tokio::signal::unix::{signal, SignalKind};
 use tokio::sync::oneshot;
 use tokio_stream::Stream;
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{info, warn};
 use types::TMAddress;
 
 use crate::asyncutil::task::{CancellableTask, TaskError, TaskGroup};
@@ -40,7 +40,7 @@ mod handlers;
 mod health_check;
 mod json_rpc;
 mod queue;
-pub mod starknet;
+mod starknet;
 pub mod state;
 mod sui;
 mod tm_client;

--- a/ampd/src/starknet/events/contract_call.rs
+++ b/ampd/src/starknet/events/contract_call.rs
@@ -1,4 +1,3 @@
-use std::fmt;
 use std::num::TryFromIntError;
 
 use ethers::types::H256;

--- a/ampd/src/starknet/events/contract_call.rs
+++ b/ampd/src/starknet/events/contract_call.rs
@@ -31,6 +31,8 @@ pub enum ContractCallError {
     FeltOutOfRange(#[from] ValueOutOfRangeError),
     #[error("Failed int conversion: {0}")]
     TryFromConversion(#[from] TryFromIntError),
+    #[error("Event data/keys array index is out of bounds")]
+    OutOfBound,
     #[error("ByteArray type error: {0}")]
     ByteArray(#[from] ByteArrayError),
 }
@@ -83,7 +85,11 @@ impl TryFrom<starknet_core::types::Event> for ContractCallEvent {
         let da_elements_start_index: usize = 1;
         let da_elements_end_index: usize = da_chunks_count.wrapping_add(3);
         let destination_address_byte_array: ByteArray = ByteArray::try_from(
-            starknet_event.data[da_elements_start_index..=da_elements_end_index].to_vec(),
+            starknet_event
+                .data
+                .get(da_elements_start_index..=da_elements_end_index)
+                .ok_or(ContractCallError::OutOfBound)?
+                .to_vec(),
         )?;
         let destination_address = destination_address_byte_array.try_to_string()?;
 

--- a/ampd/src/starknet/events/contract_call.rs
+++ b/ampd/src/starknet/events/contract_call.rs
@@ -1,0 +1,108 @@
+use std::fmt;
+use std::num::TryFromIntError;
+
+use ethers::types::H256;
+use starknet_core::types::ValueOutOfRangeError;
+use starknet_core::utils::{parse_cairo_short_string, ParseCairoShortStringError};
+use thiserror::Error;
+
+use crate::starknet::events::EventType;
+use crate::starknet::types::byte_array::{ByteArray, ByteArrayError};
+use crate::types::Hash;
+
+/// This is the event emitted by the gateway cairo contract on Starknet,
+/// when the call_contract method is called from a third party.
+#[derive(Debug)]
+pub struct ContractCallEvent {
+    pub destination_address: String,
+    pub destination_chain: String,
+    pub source_address: String,
+    pub payload_hash: Hash,
+}
+
+/// An error, representing failure to convert/parse a starknet event
+/// to some specific event.
+#[derive(Error, Debug)]
+pub enum ContractCallError {
+    #[error("Invalid ContractCall event: {0}")]
+    InvalidEvent(String),
+    #[error("Cairo short string parse error: {0}")]
+    Cairo(#[from] ParseCairoShortStringError),
+    #[error("FieldElement operation errored with out of range: {0}")]
+    FeltOutOfRange(#[from] ValueOutOfRangeError),
+    #[error("Failed int conversion: {0}")]
+    TryFromConversion(#[from] TryFromIntError),
+    #[error("ByteArray type error: {0}")]
+    ByteArray(#[from] ByteArrayError),
+}
+
+impl TryFrom<starknet_core::types::Event> for ContractCallEvent {
+    type Error = ContractCallError;
+
+    fn try_from(starknet_event: starknet_core::types::Event) -> Result<Self, Self::Error> {
+        if starknet_event.keys.len() != 2 {
+            return Err(ContractCallError::InvalidEvent(
+                "ContractCall should have exactly 2 event keys - event_type and destination_chain"
+                    .to_owned(),
+            ));
+        }
+
+        // first key is always the event type
+        let event_type_felt = starknet_event.keys[0];
+        if !matches!(
+            EventType::parse(event_type_felt),
+            Some(EventType::ContractCall)
+        ) {
+            return Err(ContractCallError::InvalidEvent(
+                "not a ContractCall event".to_owned(),
+            ));
+        }
+
+        // destination_chain is the second key in the event keys list (the first key
+        // defined from the event)
+        //
+        // This field, should not exceed 252 bits (a felt's length)
+        let destination_chain = parse_cairo_short_string(&starknet_event.keys[1])?;
+
+        // source_address represents the original callContract sender and
+        // is the first field in data, by the order defined in the event.
+        let source_address = parse_cairo_short_string(&starknet_event.data[0])?;
+
+        // destination_contract_address (ByteArray) is composed of FieldElements
+        // from the second element to elemet X.
+        let destination_address_chunks_count_felt = starknet_event.data[1];
+        let destination_address_chunks_count =
+            u32::try_from(destination_address_chunks_count_felt)?;
+        let da_chunks_count_usize = usize::try_from(destination_address_chunks_count)?;
+
+        // It's + 3, because we need to offset the 0th element, pending_word and
+        // pending_word_count, in addition to all chunks (da_chunks_count_usize)
+        let da_elements_start_index: usize = 1;
+        let da_elements_end_index: usize = da_chunks_count_usize + 3;
+        let destination_address_byte_array: ByteArray = ByteArray::try_from(
+            starknet_event.data[da_elements_start_index..=da_elements_end_index].to_vec(),
+        )?;
+        let destination_address = destination_address_byte_array.try_to_string()?;
+
+        // payload_hash is a keccak256, which is a combination of two felts (chunks)
+        // - first felt contains the 128 least significat bits (LSB)
+        // - second felt contains the 128 most significat bits (MSG)
+        let ph_chunk1_index: usize = da_elements_end_index + 1;
+        let ph_chunk2_index: usize = ph_chunk1_index + 1;
+        let mut payload_hash = [0; 32];
+        let lsb: [u8; 32] = starknet_event.data[ph_chunk1_index].to_bytes_be();
+        let msb: [u8; 32] = starknet_event.data[ph_chunk2_index].to_bytes_be();
+
+        // most significat bits, go before least significant bits for u256 construction
+        // check - https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/serialization_of_Cairo_types/#serialization_in_u256_values
+        payload_hash[..16].copy_from_slice(&msb[16..]);
+        payload_hash[16..].copy_from_slice(&lsb[16..]);
+
+        Ok(ContractCallEvent {
+            destination_address,
+            destination_chain,
+            source_address,
+            payload_hash: H256::from_slice(&payload_hash),
+        })
+    }
+}

--- a/ampd/src/starknet/events/contract_call.rs
+++ b/ampd/src/starknet/events/contract_call.rs
@@ -76,14 +76,12 @@ impl TryFrom<starknet_core::types::Event> for ContractCallEvent {
         // destination_contract_address (ByteArray) is composed of FieldElements
         // from the second element to elemet X.
         let destination_address_chunks_count_felt = starknet_event.data[1];
-        let destination_address_chunks_count_u32 =
-            u32::try_from(destination_address_chunks_count_felt)?;
-        let da_chunks_count = usize::try_from(destination_address_chunks_count_u32)?;
+        let da_chunks_count: usize = u8::try_from(destination_address_chunks_count_felt)?.into();
 
         // It's + 3, because we need to offset the 0th element, pending_word and
         // pending_word_count, in addition to all chunks (da_chunks_count_usize)
         let da_elements_start_index: usize = 1;
-        let da_elements_end_index: usize = da_chunks_count + 3;
+        let da_elements_end_index: usize = da_chunks_count.wrapping_add(3);
         let destination_address_byte_array: ByteArray = ByteArray::try_from(
             starknet_event.data[da_elements_start_index..=da_elements_end_index].to_vec(),
         )?;
@@ -92,8 +90,8 @@ impl TryFrom<starknet_core::types::Event> for ContractCallEvent {
         // payload_hash is a keccak256, which is a combination of two felts (chunks)
         // - first felt contains the 128 least significat bits (LSB)
         // - second felt contains the 128 most significat bits (MSG)
-        let ph_chunk1_index: usize = da_elements_end_index + 1;
-        let ph_chunk2_index: usize = ph_chunk1_index + 1;
+        let ph_chunk1_index: usize = da_elements_end_index.wrapping_add(1);
+        let ph_chunk2_index: usize = ph_chunk1_index.wrapping_add(1);
         let mut payload_hash = [0; 32];
         let lsb: [u8; 32] = starknet_event
             .data

--- a/ampd/src/starknet/events/mod.rs
+++ b/ampd/src/starknet/events/mod.rs
@@ -10,7 +10,7 @@ pub mod contract_call;
 static CALL_CONTRACT_FELT: OnceLock<FieldElement> = OnceLock::new();
 
 /// All Axelar event types supported by starknet
-#[derive(Eq, PartialEq)]
+#[derive(Debug)]
 pub enum EventType {
     ContractCall,
 }
@@ -25,5 +25,27 @@ impl EventType {
         } else {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod event_type_tests {
+    use starknet_core::utils::starknet_keccak;
+
+    use crate::starknet::events::EventType;
+
+    #[test]
+    fn parse_contract_call() {
+        let contract_call_felt = starknet_keccak("ContractCall".as_bytes());
+        assert!(matches!(
+            EventType::parse(contract_call_felt),
+            Some(EventType::ContractCall)
+        ));
+    }
+
+    #[test]
+    fn parse_unknown_event() {
+        let contract_call_felt = starknet_keccak("UnknownEvent".as_bytes());
+        assert!(EventType::parse(contract_call_felt).is_none());
     }
 }

--- a/ampd/src/starknet/events/mod.rs
+++ b/ampd/src/starknet/events/mod.rs
@@ -1,4 +1,4 @@
-use std::cell::OnceCell;
+use std::sync::OnceLock;
 
 use starknet_core::types::FieldElement;
 use starknet_core::utils::starknet_keccak;
@@ -6,8 +6,8 @@ use starknet_core::utils::starknet_keccak;
 pub mod contract_call;
 
 // Since a keccak hash over a string is a deterministic operation,
-// we can use `OnceCall` to eliminate useless hash calculations.
-const CALL_CONTRACT_FELT: OnceCell<FieldElement> = OnceCell::new();
+// we can use `OnceLock` to eliminate useless hash calculations.
+static CALL_CONTRACT_FELT: OnceLock<FieldElement> = OnceLock::new();
 
 /// All Axelar event types supported by starknet
 #[derive(Eq, PartialEq)]
@@ -17,8 +17,8 @@ pub enum EventType {
 
 impl EventType {
     fn parse(event_type_felt: FieldElement) -> Option<Self> {
-        let binding = CALL_CONTRACT_FELT;
-        let contract_call_type = binding.get_or_init(|| starknet_keccak("ContractCall".as_bytes()));
+        let contract_call_type =
+            CALL_CONTRACT_FELT.get_or_init(|| starknet_keccak("ContractCall".as_bytes()));
 
         if event_type_felt == *contract_call_type {
             Some(EventType::ContractCall)

--- a/ampd/src/starknet/events/mod.rs
+++ b/ampd/src/starknet/events/mod.rs
@@ -1,0 +1,28 @@
+use std::cell::OnceCell;
+
+use starknet_core::types::FieldElement;
+use starknet_core::utils::starknet_keccak;
+
+pub mod contract_call;
+
+/// All Axelar event types supported by starknet
+#[derive(Eq, PartialEq)]
+pub enum EventType {
+    ContractCall,
+}
+
+impl EventType {
+    fn parse(event_type_felt: FieldElement) -> Option<Self> {
+        // Since a keccak hash over a string is a deterministic operation,
+        // we can use `OnceCell` to eliminate useless hash calculations.
+        let call_contract_felt: OnceCell<FieldElement> = OnceCell::new();
+        let contract_call_type =
+            call_contract_felt.get_or_init(|| starknet_keccak("ContractCall".as_bytes()));
+
+        if event_type_felt == *contract_call_type {
+            Some(EventType::ContractCall)
+        } else {
+            None
+        }
+    }
+}

--- a/ampd/src/starknet/events/mod.rs
+++ b/ampd/src/starknet/events/mod.rs
@@ -5,6 +5,10 @@ use starknet_core::utils::starknet_keccak;
 
 pub mod contract_call;
 
+// Since a keccak hash over a string is a deterministic operation,
+// we can use `OnceCall` to eliminate useless hash calculations.
+const CALL_CONTRACT_FELT: OnceCell<FieldElement> = OnceCell::new();
+
 /// All Axelar event types supported by starknet
 #[derive(Eq, PartialEq)]
 pub enum EventType {
@@ -13,11 +17,8 @@ pub enum EventType {
 
 impl EventType {
     fn parse(event_type_felt: FieldElement) -> Option<Self> {
-        // Since a keccak hash over a string is a deterministic operation,
-        // we can use `OnceCell` to eliminate useless hash calculations.
-        let call_contract_felt: OnceCell<FieldElement> = OnceCell::new();
-        let contract_call_type =
-            call_contract_felt.get_or_init(|| starknet_keccak("ContractCall".as_bytes()));
+        let binding = CALL_CONTRACT_FELT;
+        let contract_call_type = binding.get_or_init(|| starknet_keccak("ContractCall".as_bytes()));
 
         if event_type_felt == *contract_call_type {
             Some(EventType::ContractCall)

--- a/ampd/src/starknet/mod.rs
+++ b/ampd/src/starknet/mod.rs
@@ -1,1 +1,2 @@
+pub mod events;
 pub mod types;

--- a/ampd/src/starknet/types/array_span.rs
+++ b/ampd/src/starknet/types/array_span.rs
@@ -1,7 +1,50 @@
 use starknet_core::types::{FieldElement, ValueOutOfRangeError};
 use thiserror::Error;
 
-/// Applies for bot a cairo Array and a Span
+/// Represents Cairo's Array and Span types.
+/// Implements `TryFrom<Vec<FieldElement>>`, which is the way to create it.
+///
+/// ## Example usage with the strging "hello"
+///
+/// ```rust
+/// use ampd::starknet::types::array_span::ArraySpan;
+/// use std::str::FromStr;
+/// use starknet_core::types::FieldElement;
+///
+/// let data = vec![
+///     FieldElement::from_str(
+///         "0x0000000000000000000000000000000000000000000000000000000000000005",
+///     )
+///     .unwrap(),
+///     FieldElement::from_str(
+///         "0x0000000000000000000000000000000000000000000000000000000000000068",
+///     )
+///     .unwrap(),
+///     FieldElement::from_str(
+///         "0x0000000000000000000000000000000000000000000000000000000000000065",
+///     )
+///     .unwrap(),
+///     FieldElement::from_str(
+///         "0x000000000000000000000000000000000000000000000000000000000000006c",
+///     )
+///     .unwrap(),
+///     FieldElement::from_str(
+///         "0x000000000000000000000000000000000000000000000000000000000000006c",
+///     )
+///     .unwrap(),
+///     FieldElement::from_str(
+///         "0x000000000000000000000000000000000000000000000000000000000000006f",
+///     )
+///     .unwrap(),
+/// ];
+///
+/// let array_span = ArraySpan::try_from(data).unwrap();
+/// assert_eq!(array_span.bytes, vec![104, 101, 108, 108, 111]);
+/// assert_eq!(String::from_utf8(array_span.bytes).unwrap(), "hello");
+/// ```
+///
+/// For more info:
+/// https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/serialization_of_Cairo_types/#serialization_of_byte_arrays
 #[derive(Debug)]
 pub struct ArraySpan {
     pub bytes: Vec<u8>,

--- a/ampd/src/starknet/types/array_span.rs
+++ b/ampd/src/starknet/types/array_span.rs
@@ -38,16 +38,16 @@ use thiserror::Error;
 ///     .unwrap(),
 /// ];
 ///
-/// let array_span = ArraySpan::try_from(data).unwrap();
-/// assert_eq!(array_span.bytes, vec![104, 101, 108, 108, 111]);
-/// assert_eq!(String::from_utf8(array_span.bytes).unwrap(), "hello");
+/// let array_span = ArraySpan::<u8>::try_from(data).unwrap();
+/// assert_eq!(array_span.data, vec![104, 101, 108, 108, 111]);
+/// assert_eq!(String::from_utf8(array_span.data).unwrap(), "hello");
 /// ```
 ///
 /// For more info:
 /// https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/serialization_of_Cairo_types/#serialization_of_byte_arrays
 #[derive(Debug)]
-pub struct ArraySpan {
-    pub bytes: Vec<u8>,
+pub struct ArraySpan<T> {
+    pub data: Vec<T>,
 }
 
 #[derive(Error, Debug)]
@@ -58,7 +58,7 @@ pub enum ArraySpanError {
     ParsingFelt(#[from] ValueOutOfRangeError),
 }
 
-impl TryFrom<Vec<FieldElement>> for ArraySpan {
+impl TryFrom<Vec<FieldElement>> for ArraySpan<u8> {
     type Error = ArraySpanError;
 
     fn try_from(data: Vec<FieldElement>) -> Result<Self, Self::Error> {
@@ -79,7 +79,7 @@ impl TryFrom<Vec<FieldElement>> for ArraySpan {
             .map(|e| e.try_into().map_err(ArraySpanError::ParsingFelt))
             .collect();
 
-        Ok(ArraySpan { bytes: bytes? })
+        Ok(ArraySpan { data: bytes? })
     }
 }
 
@@ -99,8 +99,8 @@ mod array_span_tests {
         )
         .unwrap()];
 
-        let array_span = ArraySpan::try_from(data).unwrap();
-        assert_eq!(array_span.bytes, Vec::<u8>::new());
+        let array_span = ArraySpan::<u8>::try_from(data).unwrap();
+        assert_eq!(array_span.data, Vec::<u8>::new());
     }
 
     #[test]
@@ -133,7 +133,7 @@ mod array_span_tests {
             .unwrap(),
         ];
 
-        let array_span = ArraySpan::try_from(data);
+        let array_span = ArraySpan::<u8>::try_from(data);
         assert!(array_span.is_err());
     }
 
@@ -167,7 +167,7 @@ mod array_span_tests {
             .unwrap(),
         ];
 
-        let array_span = ArraySpan::try_from(data);
+        let array_span = ArraySpan::<u8>::try_from(data);
         assert!(array_span.is_err());
     }
 
@@ -197,7 +197,7 @@ mod array_span_tests {
             .unwrap(),
         ];
 
-        let array_span = ArraySpan::try_from(data);
+        let array_span = ArraySpan::<u8>::try_from(data);
         assert!(array_span.is_err());
     }
 
@@ -232,7 +232,7 @@ mod array_span_tests {
             .unwrap(),
         ];
 
-        let array_span = ArraySpan::try_from(data);
+        let array_span = ArraySpan::<u8>::try_from(data);
         assert!(array_span.is_err());
     }
 
@@ -266,7 +266,7 @@ mod array_span_tests {
             .unwrap(),
         ];
 
-        let array_span = ArraySpan::try_from(data).unwrap();
-        assert_eq!(array_span.bytes, vec![104, 101, 108, 108, 111]);
+        let array_span = ArraySpan::<u8>::try_from(data).unwrap();
+        assert_eq!(array_span.data, vec![104, 101, 108, 108, 111]);
     }
 }

--- a/ampd/src/starknet/types/array_span.rs
+++ b/ampd/src/starknet/types/array_span.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 /// Represents Cairo's Array and Span types.
 /// Implements `TryFrom<Vec<FieldElement>>`, which is the way to create it.
 ///
-/// ## Example usage with the strging "hello"
+/// ## Example usage with the string "hello"
 ///
 /// ```rust
 /// use ampd::starknet::types::array_span::ArraySpan;
@@ -65,10 +65,7 @@ impl TryFrom<Vec<FieldElement>> for ArraySpan {
         // First element is always the array length.
         // We also have to go from `u32` to usize, because
         // there's no direct `usize` From impl.
-        let arr_length: u32 = match data[0].try_into() {
-            Ok(al) => al,
-            Err(err) => return Err(ArraySpanError::ParsingFelt(err)),
-        };
+        let arr_length = u32::try_from(data[0])?;
 
         // -1 because we have to offset the first element (the length itself)
         let is_arr_el_count_valid = usize::try_from(arr_length)
@@ -79,7 +76,7 @@ impl TryFrom<Vec<FieldElement>> for ArraySpan {
             return Err(ArraySpanError::InvalidLength);
         }
 
-        let bytes_parse: Result<Vec<u8>, ArraySpanError> = match data.get(1..) {
+        let bytes: Result<Vec<u8>, ArraySpanError> = match data.get(1..) {
             Some(b) => b,
             None => return Err(ArraySpanError::InvalidLength),
         }
@@ -95,12 +92,7 @@ impl TryFrom<Vec<FieldElement>> for ArraySpan {
         })
         .collect();
 
-        let bytes = match bytes_parse {
-            Ok(b) => b,
-            Err(e) => return Err(e),
-        };
-
-        Ok(ArraySpan { bytes })
+        Ok(ArraySpan { bytes: bytes? })
     }
 }
 

--- a/ampd/src/starknet/types/array_span.rs
+++ b/ampd/src/starknet/types/array_span.rs
@@ -87,7 +87,7 @@ impl TryFrom<Vec<FieldElement>> for ArraySpan<u8> {
 mod array_span_tests {
     use std::str::FromStr;
 
-    use starknet_core::types::FieldElement;
+    use starknet_core::types::{FieldElement, FromStrError};
 
     use crate::starknet::types::array_span::ArraySpan;
 
@@ -106,98 +106,56 @@ mod array_span_tests {
     #[test]
     fn try_from_failed_to_parse_element_to_u8() {
         // the string "hello", but FieldElement is bigger than u8::max
-        let data = vec![
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000005",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000065",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x000000000000000000000000000000000000000000000000000000000000006c",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x000000000000000000000000000000000000000000000000000000000000006c",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x000000000000000000000000000000000000000000000000000000000000006f",
-            )
-            .unwrap(),
-        ];
+        let data: Result<Vec<FieldElement>, FromStrError> = vec![
+            "0x0000000000000000000000000000000000000000000000000000000000000005",
+            "0x00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+            "0x0000000000000000000000000000000000000000000000000000000000000065",
+            "0x000000000000000000000000000000000000000000000000000000000000006c",
+            "0x000000000000000000000000000000000000000000000000000000000000006c",
+            "0x000000000000000000000000000000000000000000000000000000000000006f",
+        ]
+        .into_iter()
+        .map(FieldElement::from_str)
+        .collect();
 
-        let array_span = ArraySpan::<u8>::try_from(data);
+        let array_span = ArraySpan::<u8>::try_from(data.unwrap());
         assert!(array_span.is_err());
     }
 
     #[test]
     fn try_from_failed_to_parse_elements_length_to_u32() {
         // the string "hello", but element counte bigger than u32::max
-        let data = vec![
-            FieldElement::from_str(
-                "0x00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000068",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000065",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x000000000000000000000000000000000000000000000000000000000000006c",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x000000000000000000000000000000000000000000000000000000000000006c",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x000000000000000000000000000000000000000000000000000000000000006f",
-            )
-            .unwrap(),
-        ];
+        let data: Result<Vec<FieldElement>, FromStrError> = vec![
+            "0x00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+            "0x0000000000000000000000000000000000000000000000000000000000000068",
+            "0x0000000000000000000000000000000000000000000000000000000000000065",
+            "0x000000000000000000000000000000000000000000000000000000000000006c",
+            "0x000000000000000000000000000000000000000000000000000000000000006c",
+            "0x000000000000000000000000000000000000000000000000000000000000006f",
+        ]
+        .into_iter()
+        .map(FieldElement::from_str)
+        .collect();
 
-        let array_span = ArraySpan::<u8>::try_from(data);
+        let array_span = ArraySpan::<u8>::try_from(data.unwrap());
         assert!(array_span.is_err());
     }
 
     #[test]
     fn try_from_invalid_number_of_elements() {
         // the string "hello", but with only 4 bytes
-        let data = vec![
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000005",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000068",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000065",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x000000000000000000000000000000000000000000000000000000000000006c",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x000000000000000000000000000000000000000000000000000000000000006c",
-            )
-            .unwrap(),
-        ];
+        let data: Result<Vec<FieldElement>, FromStrError> = vec![
+            "0x0000000000000000000000000000000000000000000000000000000000000005",
+            "0x0000000000000000000000000000000000000000000000000000000000000068",
+            "0x0000000000000000000000000000000000000000000000000000000000000065",
+            "0x000000000000000000000000000000000000000000000000000000000000006c",
+            "0x000000000000000000000000000000000000000000000000000000000000006c",
+        ]
+        .into_iter()
+        .map(FieldElement::from_str)
+        .collect();
 
-        let array_span = ArraySpan::<u8>::try_from(data);
+        let array_span = ArraySpan::<u8>::try_from(data.unwrap());
         assert!(array_span.is_err());
     }
 
@@ -205,68 +163,38 @@ mod array_span_tests {
     fn try_from_invalid_declared_length() {
         // the string "hello", with correct number of bytes, but only 4 declared,
         // instead of 5
-        let data = vec![
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000004",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000068",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000065",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x000000000000000000000000000000000000000000000000000000000000006c",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x000000000000000000000000000000000000000000000000000000000000006c",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x000000000000000000000000000000000000000000000000000000000000006f",
-            )
-            .unwrap(),
-        ];
+        let data: Result<Vec<FieldElement>, FromStrError> = vec![
+            "0x0000000000000000000000000000000000000000000000000000000000000004",
+            "0x0000000000000000000000000000000000000000000000000000000000000068",
+            "0x0000000000000000000000000000000000000000000000000000000000000065",
+            "0x000000000000000000000000000000000000000000000000000000000000006c",
+            "0x000000000000000000000000000000000000000000000000000000000000006c",
+            "0x000000000000000000000000000000000000000000000000000000000000006f",
+        ]
+        .into_iter()
+        .map(FieldElement::from_str)
+        .collect();
 
-        let array_span = ArraySpan::<u8>::try_from(data);
+        let array_span = ArraySpan::<u8>::try_from(data.unwrap());
         assert!(array_span.is_err());
     }
 
     #[test]
     fn try_from_valid() {
         // the string "hello"
-        let data = vec![
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000005",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000068",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000065",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x000000000000000000000000000000000000000000000000000000000000006c",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x000000000000000000000000000000000000000000000000000000000000006c",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x000000000000000000000000000000000000000000000000000000000000006f",
-            )
-            .unwrap(),
-        ];
+        let data: Result<Vec<FieldElement>, FromStrError> = vec![
+            "0x0000000000000000000000000000000000000000000000000000000000000005",
+            "0x0000000000000000000000000000000000000000000000000000000000000068",
+            "0x0000000000000000000000000000000000000000000000000000000000000065",
+            "0x000000000000000000000000000000000000000000000000000000000000006c",
+            "0x000000000000000000000000000000000000000000000000000000000000006c",
+            "0x000000000000000000000000000000000000000000000000000000000000006f",
+        ]
+        .into_iter()
+        .map(FieldElement::from_str)
+        .collect();
 
-        let array_span = ArraySpan::<u8>::try_from(data).unwrap();
+        let array_span = ArraySpan::<u8>::try_from(data.unwrap()).unwrap();
         assert_eq!(array_span.data, vec![104, 101, 108, 108, 111]);
     }
 }

--- a/ampd/src/starknet/types/byte_array.rs
+++ b/ampd/src/starknet/types/byte_array.rs
@@ -4,6 +4,37 @@ use starknet_core::types::{FieldElement, ValueOutOfRangeError};
 use starknet_core::utils::parse_cairo_short_string;
 use thiserror::Error;
 
+/// Represents Cairo's ByteArray type.
+/// Implements `TryFrom<Vec<FieldElement>>`, which is the way to create it.
+///
+/// ## Example usage with the strging "hello"
+///
+/// ```rust
+/// use ampd::starknet::types::byte_array::ByteArray;
+/// use std::str::FromStr;
+/// use starknet_core::types::FieldElement;
+///
+/// let data = vec![
+///     FieldElement::from_str(
+///         "0x0000000000000000000000000000000000000000000000000000000000000000",
+///     )
+///     .unwrap(),
+///     FieldElement::from_str(
+///         "0x00000000000000000000000000000000000000000000000000000068656c6c6f",
+///     )
+///     .unwrap(),
+///     FieldElement::from_str(
+///         "0x0000000000000000000000000000000000000000000000000000000000000005",
+///     )
+///     .unwrap(),
+/// ];
+///
+/// let byte_array = ByteArray::try_from(data);
+/// assert!(byte_array.is_ok());
+/// ```
+///
+/// For more info:
+/// https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/serialization_of_Cairo_types/#serialization_of_byte_arrays
 #[derive(Debug)]
 pub struct ByteArray {
     /// The data byte array. Contains 31-byte chunks of the byte array.
@@ -35,35 +66,6 @@ pub enum ByteArrayError {
     ToString,
 }
 
-/// The Vec<FieldElement> should be the elements representing the ByteArray
-/// type as described in this document:
-/// https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/serialization_of_Cairo_types/#serialization_of_byte_arrays
-///
-/// ## Example usage
-///
-/// ```rust
-/// use amd::starknet::types::ByteArray;
-/// use std::str::FromStr;
-/// use starknet_core::types::FieldElement;
-///
-/// let data = vec![
-///     FieldElement::from_str(
-///         "0x0000000000000000000000000000000000000000000000000000000000000000",
-///     )
-///     .unwrap(),
-///     FieldElement::from_str(
-///         "0x00000000000000000000000000000000000000000000000000000068656c6c6f",
-///     )
-///     .unwrap(),
-///     FieldElement::from_str(
-///         "0x0000000000000000000000000000000000000000000000000000000000000005",
-///     )
-///     .unwrap(),
-/// ];
-///
-/// let byte_array = ByteArray::try_from(data).unwrap();
-/// assert_eq!("hello", byte_array.is_ok());
-/// ```
 impl TryFrom<Vec<FieldElement>> for ByteArray {
     type Error = ByteArrayError;
 
@@ -137,23 +139,6 @@ impl TryFrom<Vec<FieldElement>> for ByteArray {
         }
 
         Ok(byte_array)
-
-        // TODO:
-        // - If word count is 0 - convert the pending word to a string
-        // - If word count > 0:
-        //   - for i=2; i < 2+eventData[1]; i++
-        //     - cut all leading 0s
-        //     - concatenate all field element hex bytes resulting in
-        //       31_word_bytes
-        //     - parse felt 1 to u32 and take element parsedFelt+2 which is the
-        //       pending_word
-        //       - parse elelemtn parsedFelt+3 as u8, which is
-        //         pending_word_bytes_length
-        //       - take pending_words_byte_length worth of bytes from the
-        //         pending_word
-        //     - take the pending_word bytes and concatenate them with the
-        //       previous 31_word_bytes
-        //     - Convert those bytes to a string
     }
 }
 
@@ -163,7 +148,7 @@ impl ByteArray {
     /// ## Example usage with the string "hello"
     ///
     /// ```rust
-    /// use ampd::starknet::types::ByteArray;
+    /// use ampd::starknet::types::byte_array::ByteArray;
     /// use std::str::FromStr;
     /// use starknet_core::types::FieldElement;
     ///

--- a/ampd/src/starknet/types/byte_array.rs
+++ b/ampd/src/starknet/types/byte_array.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 /// Represents Cairo's ByteArray type.
 /// Implements `TryFrom<Vec<FieldElement>>`, which is the way to create it.
 ///
-/// ## Example usage with the strging "hello"
+/// ## Example usage with the string "hello"
 ///
 /// ```rust
 /// use ampd::starknet::types::byte_array::ByteArray;
@@ -60,7 +60,7 @@ impl Default for ByteArray {
 pub enum ByteArrayError {
     #[error("Invalid byte array - {0}")]
     InvalidByteArray(String),
-    #[error("Failed to parse felt - {0}")]
+    #[error("Failed to convert felt - {0}")]
     ParsingFelt(#[from] ValueOutOfRangeError),
     #[error("Failed to convert the byte array into a string")]
     ToString,
@@ -81,10 +81,7 @@ impl TryFrom<Vec<FieldElement>> for ByteArray {
         }
 
         // word count is always the first element
-        let word_count: u32 = match data[0].try_into() {
-            Ok(wc) => wc,
-            Err(err) => return Err(ByteArrayError::ParsingFelt(err)),
-        };
+        let word_count = u32::try_from(data[0])?;
 
         // vec element count should be whatever the word count is + 3
         // the 3 stands for the minimum 3 elements:
@@ -101,10 +98,7 @@ impl TryFrom<Vec<FieldElement>> for ByteArray {
         }
 
         // pending word byte count is always the last element
-        let pending_word_length: u8 = match data[data.len() - 1].try_into() {
-            Ok(bc) => bc,
-            Err(err) => return Err(ByteArrayError::ParsingFelt(err)),
-        };
+        let pending_word_length = u8::try_from(data[data.len() - 1])?;
         byte_array.pending_word_length = pending_word_length;
 
         // pending word is always the next to last element

--- a/ampd/src/starknet/types/byte_array.rs
+++ b/ampd/src/starknet/types/byte_array.rs
@@ -13,23 +13,18 @@ use thiserror::Error;
 /// use ampd::starknet::types::byte_array::ByteArray;
 /// use std::str::FromStr;
 /// use starknet_core::types::FieldElement;
+/// use starknet_core::types::FromStrError;
 ///
-/// let data = vec![
-///     FieldElement::from_str(
+/// let data: Result<Vec<FieldElement>, FromStrError> = vec![
 ///         "0x0000000000000000000000000000000000000000000000000000000000000000",
-///     )
-///     .unwrap(),
-///     FieldElement::from_str(
 ///         "0x00000000000000000000000000000000000000000000000000000068656c6c6f",
-///     )
-///     .unwrap(),
-///     FieldElement::from_str(
 ///         "0x0000000000000000000000000000000000000000000000000000000000000005",
-///     )
-///     .unwrap(),
-/// ];
+/// ]
+/// .into_iter()
+/// .map(FieldElement::from_str)
+/// .collect();
 ///
-/// let byte_array = ByteArray::try_from(data);
+/// let byte_array = ByteArray::try_from(data.unwrap());
 /// assert!(byte_array.is_ok());
 /// ```
 ///
@@ -144,23 +139,18 @@ impl ByteArray {
     /// use ampd::starknet::types::byte_array::ByteArray;
     /// use std::str::FromStr;
     /// use starknet_core::types::FieldElement;
+    /// use starknet_core::types::FromStrError;
     ///
-    /// let data = vec![
-    ///     FieldElement::from_str(
+    /// let data: Result<Vec<FieldElement>, FromStrError> = vec![
     ///         "0x0000000000000000000000000000000000000000000000000000000000000000",
-    ///     )
-    ///     .unwrap(),
-    ///     FieldElement::from_str(
     ///         "0x00000000000000000000000000000000000000000000000000000068656c6c6f",
-    ///     )
-    ///     .unwrap(),
-    ///     FieldElement::from_str(
     ///         "0x0000000000000000000000000000000000000000000000000000000000000005",
-    ///     )
-    ///     .unwrap(),
-    /// ];
+    /// ]
+    /// .into_iter()
+    /// .map(FieldElement::from_str)
+    /// .collect();
     ///
-    /// let byte_array = ByteArray::try_from(data).unwrap();
+    /// let byte_array = ByteArray::try_from(data.unwrap()).unwrap();
     /// assert_eq!("hello", byte_array.try_to_string().unwrap());
     /// ```
     ///
@@ -184,7 +174,7 @@ impl ByteArray {
 mod byte_array_tests {
     use std::str::FromStr;
 
-    use starknet_core::types::FieldElement;
+    use starknet_core::types::{FieldElement, FromStrError};
 
     use crate::starknet::types::byte_array::ByteArray;
 
@@ -194,24 +184,18 @@ mod byte_array_tests {
         // https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/serialization_of_Cairo_types/#serialization_of_byte_arrays
         //
         // So this is the string "hello"
-        let data = vec![
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000000",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000068656c6c6f",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                // Should be of length 5 bytes, but we put 6 bytes, in order to fail
-                // the parsing
-                "0x0000000000000000000000000000000000000000000000000000000000000020",
-            )
-            .unwrap(),
-        ];
+        let data: Result<Vec<FieldElement>, FromStrError> = vec![
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "0x0000000000000000000000000000000000000000000000000000068656c6c6f",
+            // Should be of length 5 bytes, but we put 6 bytes, in order to fail
+            // the parsing
+            "0x0000000000000000000000000000000000000000000000000000000000000020",
+        ]
+        .into_iter()
+        .map(FieldElement::from_str)
+        .collect();
 
-        let byte_array = ByteArray::try_from(data);
+        let byte_array = ByteArray::try_from(data.unwrap());
         assert!(byte_array.is_err());
     }
 
@@ -221,25 +205,19 @@ mod byte_array_tests {
         // https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/serialization_of_Cairo_types/#serialization_of_byte_arrays
         //
         // So this is the string "hello"
-        let data = vec![
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000000",
-            )
-            .unwrap(),
+        let data: Result<Vec<FieldElement>, FromStrError> = vec![
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
             // Note the 01 in the beginning. This is what causes the parse
             // function to error.
-            FieldElement::from_str(
-                "0x01000000000000000000000000000000000000000000000000000068656c6c6f",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                // 32(0x20) bytes long pending_word
-                "0x0000000000000000000000000000000000000000000000000000000000000020",
-            )
-            .unwrap(),
-        ];
+            "0x01000000000000000000000000000000000000000000000000000068656c6c6f",
+            // 32(0x20) bytes long pending_word
+            "0x0000000000000000000000000000000000000000000000000000000000000020",
+        ]
+        .into_iter()
+        .map(FieldElement::from_str)
+        .collect();
 
-        let byte_array = ByteArray::try_from(data).unwrap();
+        let byte_array = ByteArray::try_from(data.unwrap()).unwrap();
         assert!(byte_array.try_to_string().is_err());
     }
 
@@ -249,22 +227,16 @@ mod byte_array_tests {
         // https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/serialization_of_Cairo_types/#serialization_of_byte_arrays
         //
         // So this is the string "hello"
-        let data = vec![
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000000",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x00000000000000000000000000000000000000000000000000000068656c6c6f",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000005",
-            )
-            .unwrap(),
-        ];
+        let data: Result<Vec<FieldElement>, FromStrError> = vec![
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "0x00000000000000000000000000000000000000000000000000000068656c6c6f",
+            "0x0000000000000000000000000000000000000000000000000000000000000005",
+        ]
+        .into_iter()
+        .map(FieldElement::from_str)
+        .collect();
 
-        let byte_array = ByteArray::try_from(data).unwrap();
+        let byte_array = ByteArray::try_from(data.unwrap()).unwrap();
         assert_eq!("hello", byte_array.try_to_string().unwrap());
     }
 
@@ -276,94 +248,65 @@ mod byte_array_tests {
         // So this is the string "Long long string, a lot more than 31 characters that
         // wouldn't even fit in two felts, so we'll have at least two felts and a
         // pending word."
-        let data = vec![
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000004",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x00004c6f6e67206c6f6e6720737472696e672c2061206c6f74206d6f72652074",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x000068616e2033312063686172616374657273207468617420776f756c646e27",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x000074206576656e2066697420696e2074776f2066656c74732c20736f207765",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x0000276c6c2068617665206174206c656173742074776f2066656c747320616e",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x0000000000000000000000000000006420612070656e64696e6720776f72642e",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000011",
-            )
-            .unwrap(),
-        ];
+        let data: Result<Vec<FieldElement>, FromStrError> = vec![
+            "0x0000000000000000000000000000000000000000000000000000000000000004",
+            "0x00004c6f6e67206c6f6e6720737472696e672c2061206c6f74206d6f72652074",
+            "0x000068616e2033312063686172616374657273207468617420776f756c646e27",
+            "0x000074206576656e2066697420696e2074776f2066656c74732c20736f207765",
+            "0x0000276c6c2068617665206174206c656173742074776f2066656c747320616e",
+            "0x0000000000000000000000000000006420612070656e64696e6720776f72642e",
+            "0x0000000000000000000000000000000000000000000000000000000000000011",
+        ]
+        .into_iter()
+        .map(FieldElement::from_str)
+        .collect();
 
-        let byte_array = ByteArray::try_from(data).unwrap();
+        let byte_array = ByteArray::try_from(data.unwrap()).unwrap();
         assert_eq!("Long long string, a lot more than 31 characters that wouldn't even fit in two felts, so we'll have at least two felts and a pending word.", byte_array.try_to_string().unwrap());
     }
 
     #[test]
     fn try_from_vec_count_less_then_3() {
-        let data = vec![FieldElement::from_str(
-            "0x0000000000000000000000000000000000000000000000000000000000000005",
-        )
-        .unwrap()];
+        let data: Result<Vec<FieldElement>, FromStrError> =
+            vec!["0x0000000000000000000000000000000000000000000000000000000000000005"]
+                .into_iter()
+                .map(FieldElement::from_str)
+                .collect();
 
-        let byte_array_err = ByteArray::try_from(data);
+        let byte_array_err = ByteArray::try_from(data.unwrap());
         assert!(byte_array_err.is_err());
     }
 
     #[test]
     fn try_from_non_u32_word_count() {
-        let data = vec![
+        let data: Result<Vec<FieldElement>, FromStrError> = vec![
             // should be 0, because the message is short
             // enough to fit in a single FieldElement
-            FieldElement::from_str(
-                "0x00000000000000000000000000000000000000000000000000000068656c6c6f",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x00000000000000000000000000000000000000000000000000000068656c6c6f",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000005",
-            )
-            .unwrap(),
-        ];
+            "0x00000000000000000000000000000000000000000000000000000068656c6c6f",
+            "0x00000000000000000000000000000000000000000000000000000068656c6c6f",
+            "0x0000000000000000000000000000000000000000000000000000000000000005",
+        ]
+        .into_iter()
+        .map(FieldElement::from_str)
+        .collect();
 
-        let byte_array_err = ByteArray::try_from(data);
+        let byte_array_err = ByteArray::try_from(data.unwrap());
         assert!(byte_array_err.is_err());
     }
     #[test]
     fn try_from_invalid_byte_array_element_count() {
-        let data = vec![
+        let data: Result<Vec<FieldElement>, FromStrError> = vec![
             // should be 0, because the message is short
             // enough to fit in a single FieldElement
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000005",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x00000000000000000000000000000000000000000000000000000068656c6c6f",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000005",
-            )
-            .unwrap(),
-        ];
+            "0x0000000000000000000000000000000000000000000000000000000000000005",
+            "0x00000000000000000000000000000000000000000000000000000068656c6c6f",
+            "0x0000000000000000000000000000000000000000000000000000000000000005",
+        ]
+        .into_iter()
+        .map(FieldElement::from_str)
+        .collect();
 
-        let byte_array_err = ByteArray::try_from(data);
+        let byte_array_err = ByteArray::try_from(data.unwrap());
         assert!(byte_array_err.is_err());
     }
 
@@ -373,22 +316,16 @@ mod byte_array_tests {
         // https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/serialization_of_Cairo_types/#serialization_of_byte_arrays
         //
         // So this is the string "hello"
-        let data = vec![
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000000",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x00000000000000000000000000000000000000000000000000000068656c6c6f",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x00000000000000000000000000000000000000000000000000000068656c6c6f",
-            )
-            .unwrap(),
-        ];
+        let data: Result<Vec<FieldElement>, FromStrError> = vec![
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "0x00000000000000000000000000000000000000000000000000000068656c6c6f",
+            "0x00000000000000000000000000000000000000000000000000000068656c6c6f",
+        ]
+        .into_iter()
+        .map(FieldElement::from_str)
+        .collect();
 
-        let byte_array = ByteArray::try_from(data);
+        let byte_array = ByteArray::try_from(data.unwrap());
         assert!(byte_array.is_err());
     }
 
@@ -398,22 +335,16 @@ mod byte_array_tests {
         // https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/serialization_of_Cairo_types/#serialization_of_byte_arrays
         //
         // So this is the string "hello"
-        let data = vec![
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000000",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x00000000000000000000000000000000000000000000000000000068656c6c6f",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000005",
-            )
-            .unwrap(),
-        ];
+        let data: Result<Vec<FieldElement>, FromStrError> = vec![
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "0x00000000000000000000000000000000000000000000000000000068656c6c6f",
+            "0x0000000000000000000000000000000000000000000000000000000000000005",
+        ]
+        .into_iter()
+        .map(FieldElement::from_str)
+        .collect();
 
-        let byte_array = ByteArray::try_from(data).unwrap();
+        let byte_array = ByteArray::try_from(data.unwrap()).unwrap();
 
         assert_eq!(byte_array.data, vec![]);
         assert_eq!(
@@ -434,38 +365,20 @@ mod byte_array_tests {
         // So this is the string "Long long string, a lot more than 31 characters that
         // wouldn't even fit in two felts, so we'll have at least two felts and a
         // pending word."
-        let data = vec![
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000004",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x00004c6f6e67206c6f6e6720737472696e672c2061206c6f74206d6f72652074",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x000068616e2033312063686172616374657273207468617420776f756c646e27",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x000074206576656e2066697420696e2074776f2066656c74732c20736f207765",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x0000276c6c2068617665206174206c656173742074776f2066656c747320616e",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x0000000000000000000000000000006420612070656e64696e6720776f72642e",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000011",
-            )
-            .unwrap(),
-        ];
+        let data: Result<Vec<FieldElement>, FromStrError> = vec![
+            "0x0000000000000000000000000000000000000000000000000000000000000004",
+            "0x00004c6f6e67206c6f6e6720737472696e672c2061206c6f74206d6f72652074",
+            "0x000068616e2033312063686172616374657273207468617420776f756c646e27",
+            "0x000074206576656e2066697420696e2074776f2066656c74732c20736f207765",
+            "0x0000276c6c2068617665206174206c656173742074776f2066656c747320616e",
+            "0x0000000000000000000000000000006420612070656e64696e6720776f72642e",
+            "0x0000000000000000000000000000000000000000000000000000000000000011",
+        ]
+        .into_iter()
+        .map(FieldElement::from_str)
+        .collect();
 
-        let byte_array = ByteArray::try_from(data).unwrap();
+        let byte_array = ByteArray::try_from(data.unwrap()).unwrap();
 
         assert_eq!(
             byte_array.data,
@@ -504,26 +417,17 @@ mod byte_array_tests {
         // https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/serialization_of_Cairo_types/#serialization_of_byte_arrays
         //
         // So this is the string "Long string, more than 31 characters."
-        let data = vec![
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000001",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x004c6f6e6720737472696e672c206d6f7265207468616e203331206368617261",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x000000000000000000000000000000000000000000000000000063746572732e",
-            )
-            .unwrap(),
-            FieldElement::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000006",
-            )
-            .unwrap(),
-        ];
+        let data: Result<Vec<FieldElement>, FromStrError> = vec![
+            "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "0x004c6f6e6720737472696e672c206d6f7265207468616e203331206368617261",
+            "0x000000000000000000000000000000000000000000000000000063746572732e",
+            "0x0000000000000000000000000000000000000000000000000000000000000006",
+        ]
+        .into_iter()
+        .map(FieldElement::from_str)
+        .collect();
 
-        let byte_array = ByteArray::try_from(data).unwrap();
+        let byte_array = ByteArray::try_from(data.unwrap()).unwrap();
 
         assert_eq!(
             byte_array.data,


### PR DESCRIPTION
## Description
Implements [78](https://github.com/eigerco/giza-axelar-starknet/issues/78) in the `giza-axelar-starknet` repository.

- Adds CallContract event parsing logic, based on the types implemented in #18 

## Todos

- [x] Unit tests
- [x] Manual tests
- [x] Documentation
- [x] Connect epics/issues

## Steps to Test
Run the unit tests
