### PR TITLE
fix: git ssh deps fetching

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,6 @@ unit-test = "test --lib"
 
 [build]
 rustflags = ["--cfg", "tracing_unstable"]
+
+[net]
+git-fetch-with-cli = true

--- a/ampd/Cargo.toml
+++ b/ampd/Cargo.toml
@@ -61,9 +61,7 @@ sui-types = { git = "https://github.com/mystenlabs/sui", features = ["test-utils
 # Can switch back once https://github.com/informalsystems/tendermint-rs/issues/1216 is resolved.
 # The fix for the issue is at https://github.com/axelarnetwork/tendermint-rs/commit/e97033e20e660a7e707ea86db174ec047bbba50d.
 tendermint = { git = "https://github.com/axelarnetwork/tendermint-rs.git", branch = "v0.33.x" }
-tendermint-rpc = { git = "https://github.com/axelarnetwork/tendermint-rs.git", branch = "v0.33.x", features = [
-  "http-client",
-] }
+tendermint-rpc = { git = "https://github.com/axelarnetwork/tendermint-rs.git", branch = "v0.33.x", features = ["http-client"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["signal"] }
 tokio-stream = { workspace = true, features = ["sync"] }


### PR DESCRIPTION
- Can now fetch git submodules that are specified as ssh deps
- Changed the (deprecated) `.cargo/config` to `.cargo/config.toml`
