### PR TITLE
feat: solana base58 address format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -977,6 +977,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.10.8",
+ "solana-sdk",
  "stellar-xdr",
  "strum 0.25.0",
  "sui-types 1.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -977,7 +977,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.10.8",
- "solana-sdk",
+ "solana-program",
  "stellar-xdr",
  "strum 0.25.0",
  "sui-types 1.0.0",
@@ -6294,7 +6294,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate 3.2.0",
  "proc-macro2 1.0.86",
  "quote 1.0.37",
  "syn 2.0.77",
@@ -7252,7 +7252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "proc-macro2 1.0.86",
  "quote 1.0.37",
  "syn 2.0.77",
@@ -11785,7 +11785,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -977,7 +977,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.10.8",
- "solana-program",
  "stellar-xdr",
  "strum 0.25.0",
  "sui-types 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ tokio = "1.38.0"
 tokio-stream = "0.1.11"
 tokio-util = "0.7.11"
 voting-verifier = { version = "^1.0.0", path = "contracts/voting-verifier" }
-solana-sdk = { version = "2.0.1", default-features = false }
+solana-program = { version = "2", default-features = false }
 
 [workspace.lints.clippy]
 arithmetic_side_effects = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ cosmwasm-std = "1.5.5"
 cw-multi-test = "1.2.0"
 cw-storage-plus = { version = "1.2.0", features = ["iterator", "macro"] }
 cw2 = "1.1.0"
+bs58 = "0.5.1"
 ed25519-dalek = { version = "2.1.1", default-features = false }
 error-stack = { version = "0.4.0", features = ["eyre"] }
 ethers-contract = { version = "2.0.14", default-features = false, features = ["abigen"] }
@@ -72,7 +73,6 @@ tokio = "1.38.0"
 tokio-stream = "0.1.11"
 tokio-util = "0.7.11"
 voting-verifier = { version = "^1.0.0", path = "contracts/voting-verifier" }
-solana-program = { version = "2", default-features = false }
 
 [workspace.lints.clippy]
 arithmetic_side_effects = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [workspace]
 members = [
-    "ampd",
-    "contracts/*",
-    "external-gateways/*",
-    "integration-tests",
-    "packages/*"
+  "ampd",
+  "contracts/*",
+  "external-gateways/*",
+  "integration-tests",
+  "packages/*",
 ]
 resolver = "2"
 
@@ -72,6 +72,7 @@ tokio = "1.38.0"
 tokio-stream = "0.1.11"
 tokio-util = "0.7.11"
 voting-verifier = { version = "^1.0.0", path = "contracts/voting-verifier" }
+solana-sdk = { version = "2.0.1", default-features = false }
 
 [workspace.lints.clippy]
 arithmetic_side_effects = "deny"

--- a/packages/axelar-wasm-std/Cargo.toml
+++ b/packages/axelar-wasm-std/Cargo.toml
@@ -50,7 +50,7 @@ stellar-xdr = { workspace = true }
 strum = { workspace = true }
 sui-types = { workspace = true }
 thiserror = { workspace = true }
-solana-sdk = { workspace = true }
+solana-program = { workspace = true }
 valuable = { version = "0.1.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/packages/axelar-wasm-std/Cargo.toml
+++ b/packages/axelar-wasm-std/Cargo.toml
@@ -6,8 +6,8 @@ edition = { workspace = true }
 description = "Axelar cosmwasm standard library crate"
 
 exclude = [
-    "contract.wasm",
-    "hash.txt"
+  "contract.wasm",
+  "hash.txt",
 ]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -50,6 +50,7 @@ stellar-xdr = { workspace = true }
 strum = { workspace = true }
 sui-types = { workspace = true }
 thiserror = { workspace = true }
+solana-sdk = { workspace = true }
 valuable = { version = "0.1.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/packages/axelar-wasm-std/Cargo.toml
+++ b/packages/axelar-wasm-std/Cargo.toml
@@ -29,7 +29,7 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 [dependencies]
 alloy-primitives = { workspace = true }
 axelar-wasm-std-derive = { workspace = true, optional = true }
-bs58 = "0.5.1"
+bs58 = { workspace = true }
 cosmwasm-schema = { workspace = true }
 cosmwasm-std = { workspace = true }
 cw-storage-plus = { workspace = true }
@@ -50,7 +50,6 @@ stellar-xdr = { workspace = true }
 strum = { workspace = true }
 sui-types = { workspace = true }
 thiserror = { workspace = true }
-solana-program = { workspace = true }
 valuable = { version = "0.1.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/packages/axelar-wasm-std/src/address.rs
+++ b/packages/axelar-wasm-std/src/address.rs
@@ -4,7 +4,6 @@ use alloy_primitives::Address;
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Api};
 use error_stack::{bail, Result, ResultExt};
-use solana_program::pubkey::Pubkey;
 use stellar_xdr::curr::ScAddress;
 use sui_types::SuiAddress;
 
@@ -41,7 +40,12 @@ pub fn validate_address(address: &str, format: &AddressFormat) -> Result<(), Err
                 .change_context(Error::InvalidAddress(address.to_string()))?;
         }
         AddressFormat::Base58Solana => {
-            Pubkey::from_str(address).change_context(Error::InvalidAddress(address.to_string()))?;
+            let pubkey_vec = bs58::decode(address)
+                .into_vec()
+                .change_context(Error::InvalidAddress(address.to_string()))?;
+            if pubkey_vec.len() != 32 {
+                bail!(Error::InvalidAddress(address.to_string()))
+            }
         }
     }
 

--- a/packages/axelar-wasm-std/src/address.rs
+++ b/packages/axelar-wasm-std/src/address.rs
@@ -4,6 +4,7 @@ use alloy_primitives::Address;
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Api};
 use error_stack::{bail, Result, ResultExt};
+use solana_sdk::pubkey::Pubkey;
 use stellar_xdr::curr::ScAddress;
 use sui_types::SuiAddress;
 
@@ -19,6 +20,7 @@ pub enum AddressFormat {
     Eip55,
     Sui,
     Stellar,
+    Base58Solana,
 }
 
 pub fn validate_address(address: &str, format: &AddressFormat) -> Result<(), Error> {
@@ -37,6 +39,9 @@ pub fn validate_address(address: &str, format: &AddressFormat) -> Result<(), Err
             }
             ScAddress::from_str(address)
                 .change_context(Error::InvalidAddress(address.to_string()))?;
+        }
+        AddressFormat::Base58Solana => {
+            Pubkey::from_str(address).change_context(Error::InvalidAddress(address.to_string()))?;
         }
     }
 
@@ -183,6 +188,59 @@ mod tests {
         let invalid = "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLK";
         assert_err_contains!(
             address::validate_address(invalid, &address::AddressFormat::Stellar),
+            address::Error,
+            address::Error::InvalidAddress(..)
+        );
+    }
+
+    #[test]
+    fn validate_solana_address() {
+        use crate::{address, assert_err_contains};
+
+        // Valid Solana address
+        let addr = "4f3J7t1HgX1t36k6rph2pYJrWxk9uT1RrB2K3nVHDh8D";
+
+        assert_ok!(address::validate_address(
+            addr,
+            &address::AddressFormat::Base58Solana
+        ));
+
+        // Invalid address: contains invalid character '0' (zero)
+        let invalid_char_addr = "4f3J7t1HgX1t36k6rph2pYJrWxk9uT1RrB2K3nVHDh8D0";
+        assert_err_contains!(
+            address::validate_address(invalid_char_addr, &address::AddressFormat::Base58Solana),
+            address::Error,
+            address::Error::InvalidAddress(..)
+        );
+
+        // Invalid address: contains invalid character 'O'
+        let invalid_char_addr2 = "4f3J7t1HgX1t36k6rph2pYJrWxk9uT1RrB2K3nVHDh8DO";
+        assert_err_contains!(
+            address::validate_address(invalid_char_addr2, &address::AddressFormat::Base58Solana),
+            address::Error,
+            address::Error::InvalidAddress(..)
+        );
+
+        // Invalid address: incorrect length (too short)
+        let short_addr = "4f3J7t1HgX1t36k6rph2pYJrWxk9uT1RrB2K3nVHDh";
+        assert_err_contains!(
+            address::validate_address(short_addr, &address::AddressFormat::Base58Solana),
+            address::Error,
+            address::Error::InvalidAddress(..)
+        );
+
+        // Invalid address: incorrect length (too long)
+        let long_addr = format!("{}A", addr);
+        assert_err_contains!(
+            address::validate_address(&long_addr, &address::AddressFormat::Base58Solana),
+            address::Error,
+            address::Error::InvalidAddress(..)
+        );
+
+        // Invalid address: contains invalid character 'I'
+        let invalid_char_addr3 = "4f3J7t1HgX1t36k6rph2pYJrWxk9uT1RrB2K3nVHDh8DI";
+        assert_err_contains!(
+            address::validate_address(invalid_char_addr3, &address::AddressFormat::Base58Solana),
             address::Error,
             address::Error::InvalidAddress(..)
         );

--- a/packages/axelar-wasm-std/src/address.rs
+++ b/packages/axelar-wasm-std/src/address.rs
@@ -4,7 +4,7 @@ use alloy_primitives::Address;
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Api};
 use error_stack::{bail, Result, ResultExt};
-use solana_sdk::pubkey::Pubkey;
+use solana_program::pubkey::Pubkey;
 use stellar_xdr::curr::ScAddress;
 use sui_types::SuiAddress;
 


### PR DESCRIPTION
## Description

Adds the Base58 verification for Solana based pubkeys. 
This is used for address verification on the voting verifier.
