### PR TITLE
Axelar aleo review

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,12 +25,18 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "gimli",
 ]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "adler2"
@@ -119,6 +125,17 @@ dependencies = [
  "router-api",
  "snarkvm-cosmwasm",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "aleo-parser"
+version = "0.1.0"
+source = "git+ssh://git@github.com/eigerco/axelar-aleo.git?branch=aleo-helper-libs#5ef6f06765628c72f2bcdb864f66226799a84cb3"
+dependencies = [
+ "color-eyre",
+ "nom 8.0.0",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -324,6 +341,7 @@ name = "ampd"
 version = "1.4.0"
 dependencies = [
  "aleo-gateway",
+ "aleo-parser",
  "aleo-types",
  "assert_ok",
  "async-trait",
@@ -360,7 +378,7 @@ dependencies = [
  "move-core-types",
  "multisig",
  "multiversx-sdk",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "openssl",
  "pest",
@@ -378,7 +396,6 @@ dependencies = [
  "serde_with",
  "service-registry-api",
  "sha3",
- "snarkvm",
  "snarkvm-cosmwasm",
  "solabi",
  "stellar",
@@ -791,7 +808,7 @@ dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror 1.0.69",
@@ -1149,17 +1166,17 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
+ "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.4",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1684,7 +1701,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -1835,6 +1852,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "color-eyre"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1859,7 +1903,7 @@ dependencies = [
  "async-trait",
  "json5",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "pathdiff",
  "ron",
  "rust-ini",
@@ -2484,7 +2528,7 @@ checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
 dependencies = [
  "asn1-rs",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint 0.4.6",
  "num-traits",
  "rusticata-macros",
@@ -3489,7 +3533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.8.0",
 ]
 
 [[package]]
@@ -3751,9 +3795,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "glob"
@@ -5041,7 +5085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5227,6 +5271,15 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -5939,6 +5992,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nonempty"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6161,9 +6223,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
@@ -6335,6 +6397,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "p256"
@@ -7844,7 +7912,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -8815,7 +8883,7 @@ checksum = "5949de5252e6d89ce4f516a6613ef415c5de480871b1373e2b14de33d773ac16"
 dependencies = [
  "indexmap 2.7.0",
  "itertools 0.11.0",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "once_cell",
  "snarkvm-algorithms 1.2.1",
@@ -9104,7 +9172,7 @@ dependencies = [
  "anyhow",
  "bech32 0.9.1",
  "itertools 0.11.0",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rand",
  "serde",
@@ -9123,7 +9191,7 @@ dependencies = [
  "anyhow",
  "bech32 0.9.1",
  "itertools 0.11.0",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rand",
  "serde",
@@ -11393,6 +11461,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-futures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12301,7 +12379,7 @@ dependencies = [
  "data-encoding",
  "der-parser",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry",
  "rusticata-macros",
  "thiserror 1.0.69",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,101 @@ dependencies = [
 ]
 
 [[package]]
+name = "aleo-gateway"
+version = "0.1.0"
+dependencies = [
+ "aleo-types",
+ "cosmwasm-std",
+ "error-stack",
+ "hex",
+ "multisig",
+ "rand",
+ "regex",
+ "router-api",
+ "snarkvm-cosmwasm",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "aleo-std"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ec648bb4d936c62d63cb85983059c7fecd92175912c145470da3b03010c7c6"
+dependencies = [
+ "aleo-std-cpu",
+ "aleo-std-profiler",
+ "aleo-std-storage",
+ "aleo-std-time",
+ "aleo-std-timed",
+ "aleo-std-timer",
+]
+
+[[package]]
+name = "aleo-std-cpu"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7527351aa675fdbe6a1902de3cf913ff7d50ccd6822f1562be374bdd85eaefb8"
+
+[[package]]
+name = "aleo-std-profiler"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf055ddb2f54fa86394d19d87e7956df2f3cafff489fc14c0f48f2f80664c3d"
+
+[[package]]
+name = "aleo-std-storage"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453100af40d56582265853ecb2ef660d1bc1ba6920bff020a77ceba1122c8eb5"
+dependencies = [
+ "dirs 4.0.0",
+]
+
+[[package]]
+name = "aleo-std-time"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f2a841f04c2eaeb5a95312e5201a9e4b7c95b64ca99870d6bd2e2376df540a"
+dependencies = [
+ "proc-macro2 1.0.92",
+ "quote 1.0.38",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "aleo-std-timed"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6118baab6285accf088b31d5ea5029c37bbf9d98e62b4d8720a0a5a66bc2e427"
+dependencies = [
+ "proc-macro2 1.0.92",
+ "quote 1.0.38",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "aleo-std-timer"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e4f181fc1a372e8ceff89612e5c9b13f72bff5b066da9f8d6827ae65af492c4"
+
+[[package]]
+name = "aleo-types"
+version = "0.1.0"
+dependencies = [
+ "assert_ok",
+ "axelar-wasm-std",
+ "bech32 0.11.0",
+ "cosmwasm-std",
+ "error-stack",
+ "hex",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "valuable",
+]
+
+[[package]]
 name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +323,8 @@ dependencies = [
 name = "ampd"
 version = "1.4.0"
 dependencies = [
+ "aleo-gateway",
+ "aleo-types",
  "assert_ok",
  "async-trait",
  "axelar-wasm-std",
@@ -240,7 +337,7 @@ dependencies = [
  "cosmwasm-std",
  "der 0.7.9",
  "deref-derive",
- "dirs",
+ "dirs 5.0.1",
  "ed25519-dalek",
  "elliptic-curve",
  "enum-display-derive",
@@ -263,8 +360,11 @@ dependencies = [
  "move-core-types",
  "multisig",
  "multiversx-sdk",
+ "nom",
  "num-traits",
  "openssl",
+ "pest",
+ "pest_derive",
  "prost 0.11.9",
  "prost-types 0.11.9",
  "rand",
@@ -278,6 +378,9 @@ dependencies = [
  "serde_with",
  "service-registry-api",
  "sha3",
+ "snarkvm",
+ "snarkvm-cosmwasm",
+ "solabi",
  "stellar",
  "stellar-rpc-client",
  "stellar-xdr",
@@ -845,6 +948,7 @@ dependencies = [
 name = "axelar-wasm-std"
 version = "1.0.0"
 dependencies = [
+ "aleo-types",
  "alloy-primitives",
  "assert_ok",
  "axelar-wasm-std-derive",
@@ -1185,6 +1289,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.65.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+dependencies = [
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "prettyplease 0.2.25",
+ "proc-macro2 1.0.92",
+ "quote 1.0.38",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.92",
+]
+
+[[package]]
 name = "bip32"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1491,6 +1616,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "camino"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1540,6 +1676,15 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -1604,6 +1749,17 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1675,7 +1831,7 @@ checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1734,6 +1890,7 @@ dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
+ "unicode-width 0.1.14",
  "windows-sys 0.52.0",
 ]
 
@@ -1799,7 +1956,7 @@ dependencies = [
  "semver 1.0.24",
  "service-registry-api",
  "thiserror 1.0.69",
- "tofn",
+ "tofn 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2046,6 +2203,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "curl"
+version = "0.4.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9fb4d13a1be2b58f14d60adba57c9834b78c62fd86c3e76a148f732686e9265"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.78+curl-8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eec768341c5c7789611ae51cf6c459099f22e64a5d5d0ce4892434e33821eaf"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2421,11 +2608,20 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -2436,6 +2632,17 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -2501,6 +2708,12 @@ dependencies = [
  "quote 1.0.38",
  "syn 2.0.96",
 ]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "downcast"
@@ -2679,6 +2892,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c280b9e6b3ae19e152d8e31cf47f18389781e119d4013a2a2bb0180e5facc635"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
+dependencies = [
+ "proc-macro2 1.0.92",
+ "quote 1.0.38",
+ "syn 2.0.92",
+]
+
+[[package]]
 name = "enum_dispatch"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2688,6 +2921,22 @@ dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "enum_index"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5532bdea562e7be83060c36185eecccba82fe16729d2eaad2891d65417656dd"
+
+[[package]]
+name = "enum_index_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ab22c8085548bf06190113dca556e149ecdbb05ae5b972a2b9899f26b944ee4"
+dependencies = [
+ "quote 0.3.15",
+ "syn 0.11.11",
 ]
 
 [[package]]
@@ -2741,6 +2990,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethaddr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecbcc1770d1b2e3fb83915c80c47a10efbe1964544a40e0211fe40274f8363c8"
+dependencies = [
+ "serde",
+ "sha3",
+]
+
+[[package]]
 name = "ethbloom"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2753,6 +3012,16 @@ dependencies = [
  "impl-serde 0.4.0",
  "scale-info",
  "tiny-keccak",
+]
+
+[[package]]
+name = "ethdigest"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cadad23be1ff9cf970f84a87e8e9666c19b4a4393c1acf89a1790d727ae11cc"
+dependencies = [
+ "serde",
+ "sha3",
 ]
 
 [[package]]
@@ -2899,6 +3168,20 @@ name = "ethnum"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "ethprim"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d5d08a4d724b4d10c7f5db832f45298c7418629acf0b17cc265f3f35a00bd79"
+dependencies = [
+ "ethaddr",
+ "ethdigest",
+ "ethnum",
+]
 
 [[package]]
 name = "event-listener"
@@ -3233,6 +3516,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "foreign-types"
@@ -3606,6 +3895,11 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hashers"
@@ -3900,6 +4194,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.31",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -4200,7 +4507,21 @@ checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
+ "rayon",
  "serde",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf675b85ed934d3c67b5c5469701eec7db22689d0a2139d856e0925fa28b281"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width 0.2.0",
+ "web-time",
 ]
 
 [[package]]
@@ -4270,7 +4591,7 @@ dependencies = [
  "service-registry",
  "service-registry-api",
  "sha3",
- "tofn",
+ "tofn 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "voting-verifier",
 ]
 
@@ -4696,6 +5017,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4706,6 +5033,16 @@ name = "libc"
 version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+
+[[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "libm"
@@ -4721,6 +5058,33 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
+]
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.11.0+8.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "glob",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4770,6 +5134,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.2",
+]
+
+[[package]]
 name = "lsp-types"
 version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4780,6 +5153,16 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "url",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -5325,6 +5708,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 name = "multisig"
 version = "1.1.1"
 dependencies = [
+ "aleo-types",
  "axelar-wasm-std",
  "client",
  "cosmwasm-crypto",
@@ -5344,6 +5728,8 @@ dependencies = [
  "itertools 0.11.0",
  "k256",
  "msgs-derive",
+ "multisig-aleo",
+ "rand_chacha",
  "report",
  "rewards",
  "router-api",
@@ -5351,6 +5737,27 @@ dependencies = [
  "serde_json",
  "sha3",
  "signature-verifier-api",
+ "snarkvm-cosmwasm",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "multisig-aleo"
+version = "1.1.1"
+dependencies = [
+ "axelar-wasm-std",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-utils",
+ "enum-display-derive",
+ "error-stack",
+ "getrandom",
+ "hex",
+ "msgs-derive",
+ "report",
+ "serde",
+ "serde_json",
+ "snarkvm-cosmwasm",
  "thiserror 1.0.69",
 ]
 
@@ -5358,10 +5765,12 @@ dependencies = [
 name = "multisig-prover"
 version = "1.1.1"
 dependencies = [
+ "aleo-gateway",
  "anyhow",
  "assert_ok",
  "axelar-wasm-std",
  "bcs",
+ "bincode",
  "client",
  "coordinator",
  "cosmwasm-schema",
@@ -5392,10 +5801,13 @@ dependencies = [
  "service-registry",
  "service-registry-api",
  "sha3",
+ "snarkvm",
+ "snarkvm-cosmwasm",
  "stellar",
  "stellar-xdr",
  "sui-gateway",
  "thiserror 1.0.69",
+ "tofn 1.1.0 (git+https://github.com/eigerco/tofn.git?branch=aleo-schnorr)",
  "voting-verifier",
 ]
 
@@ -5639,6 +6051,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5730,6 +6152,12 @@ dependencies = [
  "quote 1.0.38",
  "syn 2.0.96",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -5937,7 +6365,7 @@ checksum = "ae7891b22598926e4398790c8fe6447930c72a67d36d983a49d6ce682ce83290"
 dependencies = [
  "bytecount",
  "fnv",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -6083,6 +6511,12 @@ dependencies = [
  "digest 0.10.7",
  "hmac",
 ]
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "peg"
@@ -6352,6 +6786,12 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "powerfmt"
@@ -6733,6 +7173,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quick-xml"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11bafc859c6815fbaffbbbf4229ecb767ac913fecb27f9ad4343662e9ef099ea"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6784,6 +7233,12 @@ dependencies = [
  "tracing",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
@@ -7027,10 +7482,12 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.31",
  "hyper-rustls 0.24.2",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -7043,6 +7500,7 @@ dependencies = [
  "sync_wrapper 0.1.2",
  "system-configuration 0.5.1",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.24.1",
  "tower-service",
  "url",
@@ -7071,7 +7529,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.5.1",
  "hyper-rustls 0.27.3",
- "hyper-tls",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -7201,6 +7659,16 @@ checksum = "41589aba99537475bf697f2118357cad1c31590c5a1b9f6d9fc4ad6d07503661"
 dependencies = [
  "bytemuck",
  "byteorder",
+]
+
+[[package]]
+name = "rocksdb"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
 ]
 
 [[package]]
@@ -7677,6 +8145,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "self-replace"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+dependencies = [
+ "fastrand 2.3.0",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "self_update"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b3c585a1ced6b97ac13bd5e56f66559e5a75f477da5913f70df98e114518446"
+dependencies = [
+ "hyper 0.14.31",
+ "indicatif",
+ "log",
+ "quick-xml",
+ "regex",
+ "reqwest 0.11.27",
+ "self-replace",
+ "semver 1.0.24",
+ "serde_json",
+ "tempfile",
+ "urlencoding",
+]
+
+[[package]]
 name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8143,10 +8641,1255 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "snap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
+name = "snarkos-account"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680adc14b4416f1c69900a0fd356635f54e53bf22de3739391955496a7e12991"
+dependencies = [
+ "anyhow",
+ "colored",
+ "rand",
+ "snarkvm",
+]
+
+[[package]]
+name = "snarkvm"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72bb6ba1245b0503b03eee6d7577e9809c1980ea869b6b14c16345282c2a4365"
+dependencies = [
+ "anstyle",
+ "anyhow",
+ "clap",
+ "colored",
+ "dotenvy",
+ "indexmap 2.7.0",
+ "num-format",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "rayon",
+ "self_update",
+ "serde_json",
+ "snarkvm-circuit",
+ "snarkvm-console",
+ "snarkvm-ledger",
+ "snarkvm-parameters 1.2.1",
+ "snarkvm-synthesizer",
+ "snarkvm-utilities 1.2.1",
+ "thiserror 1.0.69",
+ "ureq",
+ "walkdir",
+]
+
+[[package]]
+name = "snarkvm-algorithms"
+version = "1.1.0"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#49f3f6f5f1cc63980c6dede6fa9e267de5300619"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "blake2",
+ "cfg-if",
+ "fxhash",
+ "hashbrown 0.14.5",
+ "hex",
+ "indexmap 2.7.0",
+ "itertools 0.11.0",
+ "num-traits",
+ "parking_lot",
+ "rand",
+ "rand_chacha",
+ "rand_core",
+ "rayon",
+ "serde",
+ "sha2 0.10.8",
+ "smallvec",
+ "snarkvm-curves 1.1.0",
+ "snarkvm-fields 1.1.0",
+ "snarkvm-parameters 1.1.0",
+ "snarkvm-utilities 1.1.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "snarkvm-algorithms"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1a76b7f2c6fd6ea37deec9525a67342daff8136429c52ede3eaa87fec7e1"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "blake2",
+ "cfg-if",
+ "fxhash",
+ "hashbrown 0.14.5",
+ "hex",
+ "indexmap 2.7.0",
+ "itertools 0.11.0",
+ "num-traits",
+ "parking_lot",
+ "rand",
+ "rand_chacha",
+ "rand_core",
+ "rayon",
+ "serde",
+ "sha2 0.10.8",
+ "smallvec",
+ "snarkvm-curves 1.2.1",
+ "snarkvm-fields 1.2.1",
+ "snarkvm-parameters 1.2.1",
+ "snarkvm-utilities 1.2.1",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "snarkvm-circuit"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e74f8db7bd43933d614db9cc3cbe678b63098680b92b50f7d9582ba3703d2ac0"
+dependencies = [
+ "snarkvm-circuit-account",
+ "snarkvm-circuit-algorithms",
+ "snarkvm-circuit-collections",
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-network",
+ "snarkvm-circuit-program",
+ "snarkvm-circuit-types",
+]
+
+[[package]]
+name = "snarkvm-circuit-account"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d1f7c3138a21403a805f5eb10518d2ac1c3f7444e285f12296f39174e6f994a"
+dependencies = [
+ "snarkvm-circuit-algorithms",
+ "snarkvm-circuit-network",
+ "snarkvm-circuit-types",
+ "snarkvm-console-account 1.2.1",
+]
+
+[[package]]
+name = "snarkvm-circuit-algorithms"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5431cf26f69ae5120ba0bcf0c4dc8638c10a0598bf024e03fe44e75612901"
+dependencies = [
+ "snarkvm-circuit-types",
+ "snarkvm-console-algorithms 1.2.1",
+ "snarkvm-fields 1.2.1",
+]
+
+[[package]]
+name = "snarkvm-circuit-collections"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcd25c8b293dab47e039d29056c70ec285a79e88bb12eb13e9f29e43482bcea2"
+dependencies = [
+ "snarkvm-circuit-algorithms",
+ "snarkvm-circuit-types",
+ "snarkvm-console-collections 1.2.1",
+]
+
+[[package]]
+name = "snarkvm-circuit-environment"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5949de5252e6d89ce4f516a6613ef415c5de480871b1373e2b14de33d773ac16"
+dependencies = [
+ "indexmap 2.7.0",
+ "itertools 0.11.0",
+ "nom",
+ "num-traits",
+ "once_cell",
+ "snarkvm-algorithms 1.2.1",
+ "snarkvm-circuit-environment-witness",
+ "snarkvm-console-network 1.2.1",
+ "snarkvm-curves 1.2.1",
+ "snarkvm-fields 1.2.1",
+ "snarkvm-utilities 1.2.1",
+]
+
+[[package]]
+name = "snarkvm-circuit-environment-witness"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136c2c0bb066773c040553c99519176e729ea781b84922f9d300b27728c6f37e"
+
+[[package]]
+name = "snarkvm-circuit-network"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95baaa46196143735e954fa9954f1de4cc6c28b20ef3523c7df001742c777ad"
+dependencies = [
+ "snarkvm-circuit-algorithms",
+ "snarkvm-circuit-collections",
+ "snarkvm-circuit-types",
+ "snarkvm-console-network 1.2.1",
+]
+
+[[package]]
+name = "snarkvm-circuit-program"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c20e0a16f7044a69d83bff8898772367da3414e341407619893619fcbaee71f"
+dependencies = [
+ "paste",
+ "snarkvm-circuit-account",
+ "snarkvm-circuit-algorithms",
+ "snarkvm-circuit-collections",
+ "snarkvm-circuit-network",
+ "snarkvm-circuit-types",
+ "snarkvm-console-program 1.2.1",
+ "snarkvm-utilities 1.2.1",
+]
+
+[[package]]
+name = "snarkvm-circuit-types"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0208f7e35c410b3321d792f7a53d1d60812a953defbe0faefe02bc5d9235b9d9"
+dependencies = [
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-address",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-circuit-types-field",
+ "snarkvm-circuit-types-group",
+ "snarkvm-circuit-types-integers",
+ "snarkvm-circuit-types-scalar",
+ "snarkvm-circuit-types-string",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cbbcdd65caa8a2658baed95d6a9eb73bbd87f54a3935ad3eff3b566223957f"
+dependencies = [
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-circuit-types-field",
+ "snarkvm-circuit-types-group",
+ "snarkvm-circuit-types-scalar",
+ "snarkvm-console-types-address 1.2.1",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-boolean"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58e23e92d82d449536acef244431ee2c4531a2a2242b0b88e4ecbeeba90f9ae8"
+dependencies = [
+ "snarkvm-circuit-environment",
+ "snarkvm-console-types-boolean 1.2.1",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-field"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47ffacff544fa2e4c0646ef525795da989cc5953a26da08c39423f5779c58b3"
+dependencies = [
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-console-types-field 1.2.1",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-group"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bc941ea8232d22082f51d85d8ee8c5d0ac6c5d7fca56ee25e903e963ad8e87b"
+dependencies = [
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-circuit-types-field",
+ "snarkvm-circuit-types-scalar",
+ "snarkvm-console-types-group 1.2.1",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-integers"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ebf2b911d277845c8b23187dd3e493948e8696712c793f2892e0636747e40df"
+dependencies = [
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-circuit-types-field",
+ "snarkvm-circuit-types-scalar",
+ "snarkvm-console-types-integers 1.2.1",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-scalar"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bbd4aa40001cb188d5049a31ab150103cb9216b90ebe47cc16b8ca7da3b0530"
+dependencies = [
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-circuit-types-field",
+ "snarkvm-console-types-scalar 1.2.1",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-string"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c24f3af8397bed4c7c69fbc092dcae0f99a6593195937ffab340d88a7225caf"
+dependencies = [
+ "snarkvm-circuit-environment",
+ "snarkvm-circuit-types-boolean",
+ "snarkvm-circuit-types-field",
+ "snarkvm-circuit-types-integers",
+ "snarkvm-console-types-string 1.2.1",
+]
+
+[[package]]
+name = "snarkvm-console"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "462c6c10e1dfca654dddb658a6a659242b7ca559d1c1ba0ff5de5a50e78b74a6"
+dependencies = [
+ "snarkvm-console-account 1.2.1",
+ "snarkvm-console-algorithms 1.2.1",
+ "snarkvm-console-collections 1.2.1",
+ "snarkvm-console-network 1.2.1",
+ "snarkvm-console-program 1.2.1",
+ "snarkvm-console-types 1.2.1",
+]
+
+[[package]]
+name = "snarkvm-console-account"
+version = "1.1.0"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#49f3f6f5f1cc63980c6dede6fa9e267de5300619"
+dependencies = [
+ "bs58 0.5.1",
+ "snarkvm-console-network 1.1.0",
+ "snarkvm-console-types 1.1.0",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-console-account"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3489560f22801d64b540a9c2df979e0d56ac12ae1652101e15945391278cccb"
+dependencies = [
+ "bs58 0.5.1",
+ "snarkvm-console-network 1.2.1",
+ "snarkvm-console-types 1.2.1",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-console-algorithms"
+version = "1.1.0"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#49f3f6f5f1cc63980c6dede6fa9e267de5300619"
+dependencies = [
+ "blake2s_simd",
+ "smallvec",
+ "snarkvm-console-types 1.1.0",
+ "snarkvm-fields 1.1.0",
+ "snarkvm-utilities 1.1.0",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "snarkvm-console-algorithms"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3489b70326f3c609060b5c398f55133a6b5d04bfc7f0fd45925afd96785664a"
+dependencies = [
+ "blake2s_simd",
+ "smallvec",
+ "snarkvm-console-types 1.2.1",
+ "snarkvm-fields 1.2.1",
+ "snarkvm-utilities 1.2.1",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "snarkvm-console-collections"
+version = "1.1.0"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#49f3f6f5f1cc63980c6dede6fa9e267de5300619"
+dependencies = [
+ "aleo-std",
+ "rayon",
+ "snarkvm-console-algorithms 1.1.0",
+ "snarkvm-console-types 1.1.0",
+]
+
+[[package]]
+name = "snarkvm-console-collections"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f014e038441e7f2b00e53d4877d5dce509a25c0947622b1fcce54cbc97d88296"
+dependencies = [
+ "aleo-std",
+ "rayon",
+ "snarkvm-console-algorithms 1.2.1",
+ "snarkvm-console-types 1.2.1",
+]
+
+[[package]]
+name = "snarkvm-console-network"
+version = "1.1.0"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#49f3f6f5f1cc63980c6dede6fa9e267de5300619"
+dependencies = [
+ "anyhow",
+ "indexmap 2.7.0",
+ "itertools 0.11.0",
+ "lazy_static",
+ "once_cell",
+ "paste",
+ "serde",
+ "snarkvm-algorithms 1.1.0",
+ "snarkvm-console-algorithms 1.1.0",
+ "snarkvm-console-collections 1.1.0",
+ "snarkvm-console-network-environment 1.1.0",
+ "snarkvm-console-types 1.1.0",
+ "snarkvm-curves 1.1.0",
+ "snarkvm-fields 1.1.0",
+ "snarkvm-parameters 1.1.0",
+ "snarkvm-utilities 1.1.0",
+]
+
+[[package]]
+name = "snarkvm-console-network"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7eb7e4dec0fc861c98e28849277029c4035def65bed406d6b8bd5f2088a546"
+dependencies = [
+ "anyhow",
+ "indexmap 2.7.0",
+ "itertools 0.11.0",
+ "lazy_static",
+ "once_cell",
+ "paste",
+ "serde",
+ "snarkvm-algorithms 1.2.1",
+ "snarkvm-console-algorithms 1.2.1",
+ "snarkvm-console-collections 1.2.1",
+ "snarkvm-console-network-environment 1.2.1",
+ "snarkvm-console-types 1.2.1",
+ "snarkvm-curves 1.2.1",
+ "snarkvm-fields 1.2.1",
+ "snarkvm-parameters 1.2.1",
+ "snarkvm-utilities 1.2.1",
+]
+
+[[package]]
+name = "snarkvm-console-network-environment"
+version = "1.1.0"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#49f3f6f5f1cc63980c6dede6fa9e267de5300619"
+dependencies = [
+ "anyhow",
+ "bech32 0.9.1",
+ "itertools 0.11.0",
+ "nom",
+ "num-traits",
+ "rand",
+ "serde",
+ "snarkvm-curves 1.1.0",
+ "snarkvm-fields 1.1.0",
+ "snarkvm-utilities 1.1.0",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-console-network-environment"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d9c724969c668e20d7d46424309380eefdc185f8466015d9b83a047def091d4"
+dependencies = [
+ "anyhow",
+ "bech32 0.9.1",
+ "itertools 0.11.0",
+ "nom",
+ "num-traits",
+ "rand",
+ "serde",
+ "snarkvm-curves 1.2.1",
+ "snarkvm-fields 1.2.1",
+ "snarkvm-utilities 1.2.1",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-console-program"
+version = "1.1.0"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#49f3f6f5f1cc63980c6dede6fa9e267de5300619"
+dependencies = [
+ "enum-iterator",
+ "enum_index",
+ "enum_index_derive",
+ "indexmap 2.7.0",
+ "num-derive 0.4.2",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "serde_json",
+ "snarkvm-console-account 1.1.0",
+ "snarkvm-console-algorithms 1.1.0",
+ "snarkvm-console-collections 1.1.0",
+ "snarkvm-console-network 1.1.0",
+ "snarkvm-console-types 1.1.0",
+ "snarkvm-utilities 1.1.0",
+]
+
+[[package]]
+name = "snarkvm-console-program"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e97fc2fff9c0771733bcb07fe4a962e98868763dcd46d74662c176b7767e4c0"
+dependencies = [
+ "enum-iterator",
+ "enum_index",
+ "enum_index_derive",
+ "indexmap 2.7.0",
+ "num-derive 0.4.2",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "serde_json",
+ "snarkvm-console-account 1.2.1",
+ "snarkvm-console-algorithms 1.2.1",
+ "snarkvm-console-collections 1.2.1",
+ "snarkvm-console-network 1.2.1",
+ "snarkvm-console-types 1.2.1",
+ "snarkvm-utilities 1.2.1",
+]
+
+[[package]]
+name = "snarkvm-console-types"
+version = "1.1.0"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#49f3f6f5f1cc63980c6dede6fa9e267de5300619"
+dependencies = [
+ "snarkvm-console-network-environment 1.1.0",
+ "snarkvm-console-types-address 1.1.0",
+ "snarkvm-console-types-boolean 1.1.0",
+ "snarkvm-console-types-field 1.1.0",
+ "snarkvm-console-types-group 1.1.0",
+ "snarkvm-console-types-integers 1.1.0",
+ "snarkvm-console-types-scalar 1.1.0",
+ "snarkvm-console-types-string 1.1.0",
+]
+
+[[package]]
+name = "snarkvm-console-types"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc309d4314d33c56a3d52ea959b9b033e4aab5ec4b12246e0d2e8e05c9db1040"
+dependencies = [
+ "snarkvm-console-network-environment 1.2.1",
+ "snarkvm-console-types-address 1.2.1",
+ "snarkvm-console-types-boolean 1.2.1",
+ "snarkvm-console-types-field 1.2.1",
+ "snarkvm-console-types-group 1.2.1",
+ "snarkvm-console-types-integers 1.2.1",
+ "snarkvm-console-types-scalar 1.2.1",
+ "snarkvm-console-types-string 1.2.1",
+]
+
+[[package]]
+name = "snarkvm-console-types-address"
+version = "1.1.0"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#49f3f6f5f1cc63980c6dede6fa9e267de5300619"
+dependencies = [
+ "snarkvm-console-network-environment 1.1.0",
+ "snarkvm-console-types-boolean 1.1.0",
+ "snarkvm-console-types-field 1.1.0",
+ "snarkvm-console-types-group 1.1.0",
+]
+
+[[package]]
+name = "snarkvm-console-types-address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d89592197e343c18562b671e1f3219ab663493c5e56c8c1c546ebfe74e6da45"
+dependencies = [
+ "snarkvm-console-network-environment 1.2.1",
+ "snarkvm-console-types-boolean 1.2.1",
+ "snarkvm-console-types-field 1.2.1",
+ "snarkvm-console-types-group 1.2.1",
+]
+
+[[package]]
+name = "snarkvm-console-types-boolean"
+version = "1.1.0"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#49f3f6f5f1cc63980c6dede6fa9e267de5300619"
+dependencies = [
+ "snarkvm-console-network-environment 1.1.0",
+]
+
+[[package]]
+name = "snarkvm-console-types-boolean"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b9943d17937ef549810fc2b19f73d56920fc52c362ef7048f731b680b308098"
+dependencies = [
+ "snarkvm-console-network-environment 1.2.1",
+]
+
+[[package]]
+name = "snarkvm-console-types-field"
+version = "1.1.0"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#49f3f6f5f1cc63980c6dede6fa9e267de5300619"
+dependencies = [
+ "snarkvm-console-network-environment 1.1.0",
+ "snarkvm-console-types-boolean 1.1.0",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-console-types-field"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad5ea5c7e69153fec1b44980ba6fbb6b09efabb61fb90101a5ea8351fad5ba4f"
+dependencies = [
+ "snarkvm-console-network-environment 1.2.1",
+ "snarkvm-console-types-boolean 1.2.1",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-console-types-group"
+version = "1.1.0"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#49f3f6f5f1cc63980c6dede6fa9e267de5300619"
+dependencies = [
+ "snarkvm-console-network-environment 1.1.0",
+ "snarkvm-console-types-boolean 1.1.0",
+ "snarkvm-console-types-field 1.1.0",
+ "snarkvm-console-types-scalar 1.1.0",
+]
+
+[[package]]
+name = "snarkvm-console-types-group"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779be9995f64ece49720e9193442189d149aec0250f423ffbb528cd487dd7ee2"
+dependencies = [
+ "snarkvm-console-network-environment 1.2.1",
+ "snarkvm-console-types-boolean 1.2.1",
+ "snarkvm-console-types-field 1.2.1",
+ "snarkvm-console-types-scalar 1.2.1",
+]
+
+[[package]]
+name = "snarkvm-console-types-integers"
+version = "1.1.0"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#49f3f6f5f1cc63980c6dede6fa9e267de5300619"
+dependencies = [
+ "snarkvm-console-network-environment 1.1.0",
+ "snarkvm-console-types-boolean 1.1.0",
+ "snarkvm-console-types-field 1.1.0",
+ "snarkvm-console-types-scalar 1.1.0",
+]
+
+[[package]]
+name = "snarkvm-console-types-integers"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7175cfbdc47d9fd1f6def42875a6d4e79e12ddb7e88d440c8354bec604b0277a"
+dependencies = [
+ "snarkvm-console-network-environment 1.2.1",
+ "snarkvm-console-types-boolean 1.2.1",
+ "snarkvm-console-types-field 1.2.1",
+ "snarkvm-console-types-scalar 1.2.1",
+]
+
+[[package]]
+name = "snarkvm-console-types-scalar"
+version = "1.1.0"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#49f3f6f5f1cc63980c6dede6fa9e267de5300619"
+dependencies = [
+ "snarkvm-console-network-environment 1.1.0",
+ "snarkvm-console-types-boolean 1.1.0",
+ "snarkvm-console-types-field 1.1.0",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-console-types-scalar"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09169a4d6a71adbc7bb3619ab521f84578d1146d3c4d9129e81597328dba97ce"
+dependencies = [
+ "snarkvm-console-network-environment 1.2.1",
+ "snarkvm-console-types-boolean 1.2.1",
+ "snarkvm-console-types-field 1.2.1",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-console-types-string"
+version = "1.1.0"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#49f3f6f5f1cc63980c6dede6fa9e267de5300619"
+dependencies = [
+ "snarkvm-console-network-environment 1.1.0",
+ "snarkvm-console-types-boolean 1.1.0",
+ "snarkvm-console-types-field 1.1.0",
+ "snarkvm-console-types-integers 1.1.0",
+]
+
+[[package]]
+name = "snarkvm-console-types-string"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22c054c5a5bef4c45827011314db35ab83363003b9409461e5cf0bcc0114d641"
+dependencies = [
+ "snarkvm-console-network-environment 1.2.1",
+ "snarkvm-console-types-boolean 1.2.1",
+ "snarkvm-console-types-field 1.2.1",
+ "snarkvm-console-types-integers 1.2.1",
+]
+
+[[package]]
+name = "snarkvm-cosmwasm"
+version = "1.1.0"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#49f3f6f5f1cc63980c6dede6fa9e267de5300619"
+dependencies = [
+ "getrandom",
+ "snarkvm-console-account 1.1.0",
+ "snarkvm-console-network 1.1.0",
+ "snarkvm-console-program 1.1.0",
+ "snarkvm-console-types 1.1.0",
+]
+
+[[package]]
+name = "snarkvm-curves"
+version = "1.1.0"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#49f3f6f5f1cc63980c6dede6fa9e267de5300619"
+dependencies = [
+ "rand",
+ "rayon",
+ "rustc_version 0.4.1",
+ "serde",
+ "snarkvm-fields 1.1.0",
+ "snarkvm-utilities 1.1.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "snarkvm-curves"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dc82bf651c0f99f67db6b87679648da36d836c0f626871a7862594520149cfc"
+dependencies = [
+ "rand",
+ "rayon",
+ "rustc_version 0.4.1",
+ "serde",
+ "snarkvm-fields 1.2.1",
+ "snarkvm-utilities 1.2.1",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "snarkvm-fields"
+version = "1.1.0"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#49f3f6f5f1cc63980c6dede6fa9e267de5300619"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "itertools 0.11.0",
+ "num-traits",
+ "rand",
+ "rayon",
+ "serde",
+ "snarkvm-utilities 1.1.0",
+ "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-fields"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff74eda397cce45990855939f53a0d479f2388627ac9e35f477423651b5f7b4"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "itertools 0.11.0",
+ "num-traits",
+ "rand",
+ "rayon",
+ "serde",
+ "snarkvm-utilities 1.2.1",
+ "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-ledger"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd67576d3b94f71e3a7fa9f48a7ddad342cfb7e32359bd02fa0e96a82233c878"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "indexmap 2.7.0",
+ "parking_lot",
+ "rand",
+ "rayon",
+ "snarkvm-console",
+ "snarkvm-ledger-authority",
+ "snarkvm-ledger-block",
+ "snarkvm-ledger-committee",
+ "snarkvm-ledger-narwhal",
+ "snarkvm-ledger-puzzle",
+ "snarkvm-ledger-query",
+ "snarkvm-ledger-store",
+ "snarkvm-synthesizer",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "snarkvm-ledger-authority"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd5b84e48eaaa844a4c9b5b407d33d07d889224e047eaef1c205332b141a19b"
+dependencies = [
+ "anyhow",
+ "rand",
+ "serde_json",
+ "snarkvm-console",
+ "snarkvm-ledger-narwhal-subdag",
+]
+
+[[package]]
+name = "snarkvm-ledger-block"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2507263dd99db45f5a243f3d39d8c653593f91da58d123fb824b858a4346459"
+dependencies = [
+ "indexmap 2.7.0",
+ "rayon",
+ "serde_json",
+ "snarkvm-console",
+ "snarkvm-ledger-authority",
+ "snarkvm-ledger-committee",
+ "snarkvm-ledger-narwhal-batch-header",
+ "snarkvm-ledger-narwhal-data",
+ "snarkvm-ledger-narwhal-subdag",
+ "snarkvm-ledger-narwhal-transmission-id",
+ "snarkvm-ledger-puzzle",
+ "snarkvm-synthesizer-program",
+ "snarkvm-synthesizer-snark",
+]
+
+[[package]]
+name = "snarkvm-ledger-committee"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1390935ddb2a6d6434b6b040950497d74844177b3311152710f08687cb5c049f"
+dependencies = [
+ "indexmap 2.7.0",
+ "rayon",
+ "serde_json",
+ "snarkvm-console",
+ "snarkvm-ledger-narwhal-batch-header",
+]
+
+[[package]]
+name = "snarkvm-ledger-narwhal"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640ce9cbb7ecd94f67eb44d21a196fe084032bb854c97b915691a07912d00bec"
+dependencies = [
+ "snarkvm-ledger-narwhal-batch-certificate",
+ "snarkvm-ledger-narwhal-batch-header",
+ "snarkvm-ledger-narwhal-data",
+ "snarkvm-ledger-narwhal-subdag",
+ "snarkvm-ledger-narwhal-transmission",
+ "snarkvm-ledger-narwhal-transmission-id",
+]
+
+[[package]]
+name = "snarkvm-ledger-narwhal-batch-certificate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3afea0832e49442ad5ffbde9671b27f77af4d6ca2811c75d9b1ce5c6a7e67e37"
+dependencies = [
+ "indexmap 2.7.0",
+ "rayon",
+ "serde_json",
+ "snarkvm-console",
+ "snarkvm-ledger-narwhal-batch-header",
+ "snarkvm-ledger-narwhal-transmission-id",
+]
+
+[[package]]
+name = "snarkvm-ledger-narwhal-batch-header"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38fc9d3cb5fda7a54aa9e5d8bcd0f67229118893f2526afa47339653898337fc"
+dependencies = [
+ "indexmap 2.7.0",
+ "rayon",
+ "serde_json",
+ "snarkvm-console",
+ "snarkvm-ledger-narwhal-transmission-id",
+]
+
+[[package]]
+name = "snarkvm-ledger-narwhal-data"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a130a65d82b431c123006d049833e234ed4ac5942a165a5dfbf10a445ce6cb67"
+dependencies = [
+ "bytes",
+ "serde_json",
+ "snarkvm-console",
+ "tokio",
+]
+
+[[package]]
+name = "snarkvm-ledger-narwhal-subdag"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb4ab129416b02ea58955a24870a9a7ab5c0c2de1f0dd41087532ca784802186"
+dependencies = [
+ "indexmap 2.7.0",
+ "rayon",
+ "serde_json",
+ "snarkvm-console",
+ "snarkvm-ledger-committee",
+ "snarkvm-ledger-narwhal-batch-certificate",
+ "snarkvm-ledger-narwhal-batch-header",
+ "snarkvm-ledger-narwhal-transmission-id",
+]
+
+[[package]]
+name = "snarkvm-ledger-narwhal-transmission"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2c8aa71c8154056d19cce1c8d52c3778cf7f0a887a277d52e8a3deebe5cd55"
+dependencies = [
+ "bytes",
+ "serde_json",
+ "snarkvm-console",
+ "snarkvm-ledger-block",
+ "snarkvm-ledger-narwhal-data",
+ "snarkvm-ledger-puzzle",
+]
+
+[[package]]
+name = "snarkvm-ledger-narwhal-transmission-id"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d95a764e09f995ed67d1cc43a60c6c7ac81dadc0cee044ef6664b1de617015d"
+dependencies = [
+ "snarkvm-console",
+ "snarkvm-ledger-puzzle",
+]
+
+[[package]]
+name = "snarkvm-ledger-puzzle"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1032a3376a4f95693779be7955a3636f3d8f4c790ae1e7aa4d9e2718e0904df6"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "bincode",
+ "indexmap 2.7.0",
+ "lru 0.12.5",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "rand_chacha",
+ "rayon",
+ "serde_json",
+ "snarkvm-algorithms 1.2.1",
+ "snarkvm-console",
+]
+
+[[package]]
+name = "snarkvm-ledger-puzzle-epoch"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea07d20cc6f157f069b70d23cd3c1758d072d064e5060d1ac4364cd61d61c2a"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "colored",
+ "indexmap 2.7.0",
+ "lru 0.12.5",
+ "parking_lot",
+ "rand",
+ "rand_chacha",
+ "rayon",
+ "snarkvm-circuit",
+ "snarkvm-console",
+ "snarkvm-ledger-puzzle",
+ "snarkvm-synthesizer-process",
+ "snarkvm-synthesizer-program",
+]
+
+[[package]]
+name = "snarkvm-ledger-query"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f5e1c6b1d6f6ae7ee4252b847cdb00d09d2ab1f21aa4a74da7ad0aadb528d9"
+dependencies = [
+ "async-trait",
+ "reqwest 0.11.27",
+ "snarkvm-console",
+ "snarkvm-ledger-store",
+ "snarkvm-synthesizer-program",
+ "ureq",
+]
+
+[[package]]
+name = "snarkvm-ledger-store"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0173d03cbdaaffb2c3f2e419ecdfb8c07817cc4b53547e101817fb0459a32033"
+dependencies = [
+ "aleo-std-storage",
+ "anyhow",
+ "bincode",
+ "indexmap 2.7.0",
+ "once_cell",
+ "parking_lot",
+ "rayon",
+ "rocksdb",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "snarkvm-console",
+ "snarkvm-ledger-authority",
+ "snarkvm-ledger-block",
+ "snarkvm-ledger-committee",
+ "snarkvm-ledger-narwhal-batch-certificate",
+ "snarkvm-ledger-puzzle",
+ "snarkvm-synthesizer-program",
+ "snarkvm-synthesizer-snark",
+ "tracing",
+]
+
+[[package]]
+name = "snarkvm-parameters"
+version = "1.1.0"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#49f3f6f5f1cc63980c6dede6fa9e267de5300619"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "bincode",
+ "cfg-if",
+ "colored",
+ "curl",
+ "getrandom",
+ "hex",
+ "indexmap 2.7.0",
+ "itertools 0.11.0",
+ "lazy_static",
+ "parking_lot",
+ "paste",
+ "rand",
+ "serde_json",
+ "sha2 0.10.8",
+ "snarkvm-curves 1.1.0",
+ "snarkvm-utilities 1.1.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "snarkvm-parameters"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46c34ce053ac41ff0a6af45b3e641a275d703c2acacc76cdc73d1ce3c33e0ba"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "bincode",
+ "cfg-if",
+ "colored",
+ "curl",
+ "hex",
+ "indexmap 2.7.0",
+ "itertools 0.11.0",
+ "lazy_static",
+ "parking_lot",
+ "paste",
+ "rand",
+ "serde_json",
+ "sha2 0.10.8",
+ "snarkvm-curves 1.2.1",
+ "snarkvm-utilities 1.2.1",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "snarkvm-synthesizer"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c78b73fb2849c5fbd34c32ee332cbc7fc39ce6bcc504a6c0d073f9cced34611"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "indexmap 2.7.0",
+ "itertools 0.11.0",
+ "lru 0.12.5",
+ "parking_lot",
+ "rand",
+ "rayon",
+ "serde_json",
+ "snarkvm-algorithms 1.2.1",
+ "snarkvm-circuit",
+ "snarkvm-console",
+ "snarkvm-ledger-block",
+ "snarkvm-ledger-committee",
+ "snarkvm-ledger-narwhal-data",
+ "snarkvm-ledger-puzzle",
+ "snarkvm-ledger-puzzle-epoch",
+ "snarkvm-ledger-query",
+ "snarkvm-ledger-store",
+ "snarkvm-synthesizer-process",
+ "snarkvm-synthesizer-program",
+ "snarkvm-synthesizer-snark",
+ "snarkvm-utilities 1.2.1",
+ "tracing",
+]
+
+[[package]]
+name = "snarkvm-synthesizer-process"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "968e72f0868d3f00a91c64c5ab53677ba11382c7d8e80313275c04a8e17ba27b"
+dependencies = [
+ "aleo-std",
+ "colored",
+ "indexmap 2.7.0",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "rand_chacha",
+ "rayon",
+ "serde_json",
+ "snarkvm-circuit",
+ "snarkvm-console",
+ "snarkvm-ledger-block",
+ "snarkvm-ledger-query",
+ "snarkvm-ledger-store",
+ "snarkvm-synthesizer-program",
+ "snarkvm-synthesizer-snark",
+ "snarkvm-utilities 1.2.1",
+]
+
+[[package]]
+name = "snarkvm-synthesizer-program"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e02486e1a43593bc70cdb3a195d7df0876680fe565587c143366cef3bb10ec"
+dependencies = [
+ "indexmap 2.7.0",
+ "paste",
+ "rand",
+ "rand_chacha",
+ "serde_json",
+ "snarkvm-circuit",
+ "snarkvm-console",
+]
+
+[[package]]
+name = "snarkvm-synthesizer-snark"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a199be7e1d4b5ab2a1085b538f0922e5804239a04e265a11786e6cd563344980"
+dependencies = [
+ "bincode",
+ "once_cell",
+ "serde_json",
+ "snarkvm-algorithms 1.2.1",
+ "snarkvm-circuit",
+ "snarkvm-console",
+]
+
+[[package]]
+name = "snarkvm-utilities"
+version = "1.1.0"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#49f3f6f5f1cc63980c6dede6fa9e267de5300619"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "bincode",
+ "cosmwasm-std",
+ "num-bigint 0.4.6",
+ "num_cpus",
+ "rand",
+ "rand_xorshift",
+ "rayon",
+ "serde",
+ "serde_json",
+ "smol_str",
+ "snarkvm-utilities-derives 1.1.0",
+ "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-utilities"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299dd0f31f80294af6d461f753788a139217ac691e37cda42d7fd67fbfcdc43d"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "bincode",
+ "num-bigint 0.4.6",
+ "num_cpus",
+ "rand",
+ "rand_xorshift",
+ "rayon",
+ "serde",
+ "serde_json",
+ "smol_str",
+ "snarkvm-utilities-derives 1.2.1",
+ "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-utilities-derives"
+version = "1.1.0"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#49f3f6f5f1cc63980c6dede6fa9e267de5300619"
+dependencies = [
+ "proc-macro2 1.0.92",
+ "quote 1.0.38",
+ "syn 2.0.92",
+]
+
+[[package]]
+name = "snarkvm-utilities-derives"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea94280e7bbaa7da748a95c9b83f301fd36a90d426c7c7f40b9395563040208"
+dependencies = [
+ "proc-macro2 1.0.92",
+ "quote 1.0.38",
+ "syn 2.0.92",
+]
 
 [[package]]
 name = "socket2"
@@ -8172,6 +9915,16 @@ dependencies = [
  "log",
  "rand",
  "sha-1",
+]
+
+[[package]]
+name = "solabi"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a05e216e6d7e93fcd8bda50df6c57960998b22bd926638fd9aa14b786bc53bf2"
+dependencies = [
+ "ethprim",
+ "serde",
 ]
 
 [[package]]
@@ -8533,7 +10286,7 @@ dependencies = [
  "async-trait",
  "bcs",
  "eyre",
- "lru",
+ "lru 0.10.1",
  "move-binary-format",
  "move-command-line-common",
  "move-core-types",
@@ -8667,7 +10420,7 @@ dependencies = [
  "indexmap 2.7.0",
  "itertools 0.13.0",
  "jsonrpsee",
- "lru",
+ "lru 0.10.1",
  "move-binary-format",
  "move-bytecode-utils",
  "move-command-line-common",
@@ -8721,6 +10474,17 @@ dependencies = [
  "rand",
  "serde",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+dependencies = [
+ "quote 0.3.15",
+ "synom",
+ "unicode-xid 0.0.4",
 ]
 
 [[package]]
@@ -8781,6 +10545,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 dependencies = [
  "futures-core",
+]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+dependencies = [
+ "unicode-xid 0.0.4",
 ]
 
 [[package]]
@@ -8856,7 +10629,7 @@ checksum = "0ce69a5028cd9576063ec1f48edb2c75339fd835e6094ef3e05b3a079bf594a6"
 dependencies = [
  "papergrid",
  "tabled_derive",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -9216,6 +10989,29 @@ dependencies = [
  "rand_chacha",
  "serde",
  "sha2 0.10.8",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "tofn"
+version = "1.1.0"
+source = "git+https://github.com/eigerco/tofn.git?branch=aleo-schnorr#cfa3d502d0290f3297eb2b20126df1551a77af91"
+dependencies = [
+ "bincode",
+ "cosmwasm-std",
+ "crypto-bigint",
+ "ecdsa",
+ "ed25519 2.2.3",
+ "ed25519-dalek",
+ "hmac",
+ "k256",
+ "rand",
+ "rand_chacha",
+ "serde",
+ "sha2 0.10.8",
+ "snarkos-account",
+ "snarkvm",
  "tracing",
  "zeroize",
 ]
@@ -9822,6 +11618,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unicode-xid"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+
+[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9869,7 +11677,25 @@ checksum = "9fe29601d1624f104fa9a35ea71a5f523dd8bd1cfc8c31f8124ad2b829f013c0"
 dependencies = [
  "serde",
  "unicode-ident",
- "unicode-width",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls 0.23.20",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.7",
 ]
 
 [[package]]
@@ -9883,6 +11709,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,13 +1300,13 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "prettyplease 0.2.25",
+ "prettyplease 0.2.29",
  "proc-macro2 1.0.92",
  "quote 1.0.38",
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2908,7 +2908,7 @@ checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -9877,7 +9877,7 @@ source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#49f3f6f5f1cc639
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -9888,7 +9888,7 @@ checksum = "eea94280e7bbaa7da748a95c9b83f301fd36a90d426c7c7f40b9395563040208"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.38",
- "syn 2.0.92",
+ "syn 2.0.96",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ axelar-wasm-std-derive = { version = "^1.0.0", path = "packages/axelar-wasm-std-
 axelarnet-gateway = { version = "^1.0.0", path = "contracts/axelarnet-gateway" }
 bcs = "0.1.5"
 bech32 = "0.11.0"
-bitvec = "1.0.1"
 client = { version = "^1.0.0", path = "packages/client" }
 coordinator = { version = "^1.1.0", path = "contracts/coordinator" }
 cosmwasm-crypto = "2.1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [workspace.dependencies]
+aleo-types = { path = "packages/aleo-types" }
+aleo-gateway = { path = "packages/aleo-gateway" }
 alloy-primitives = { version = "0.7.6", default-features = false, features = [
   "std",
 ] }
@@ -34,6 +36,7 @@ axelar-wasm-std-derive = { version = "^1.0.0", path = "packages/axelar-wasm-std-
 axelarnet-gateway = { version = "^1.0.0", path = "contracts/axelarnet-gateway" }
 bcs = "0.1.5"
 bech32 = "0.11.0"
+bitvec = "1.0.1"
 client = { version = "^1.0.0", path = "packages/client" }
 coordinator = { version = "^1.1.0", path = "contracts/coordinator" }
 cosmwasm-crypto = "2.1.4"
@@ -67,6 +70,8 @@ msgs-derive = { version = "^1.0.0", path = "packages/msgs-derive" }
 multisig = { version = "^1.1.1", path = "contracts/multisig" }
 multisig-prover = { version = "^1.1.1", path = "contracts/multisig-prover" }
 num-traits = { version = "0.2.14", default-features = false }
+pest = { version = "2.7.14" }
+pest_derive = { version = "2.7.14" }
 quote = "1.0.38"
 rand = "0.8.5"
 report = { version = "^1.0.0", path = "packages/report" }
@@ -99,6 +104,7 @@ tokio-util = "0.7.11"
 voting-verifier = { version = "^1.1.0", path = "contracts/voting-verifier" }
 axelar-core-std = { version = "^1.0.0", path = "packages/axelar-core-std" }
 proc-macro2 = "1.0.92"
+snarkvm-cosmwasm = { git = "https://github.com/eigerco/snarkVM", branch = "cosmwasm" }
 
 [workspace.lints.clippy]
 arithmetic_side_effects = "deny"

--- a/ampd/Cargo.toml
+++ b/ampd/Cargo.toml
@@ -55,7 +55,7 @@ serde_json = { workspace = true }
 serde_with = "3.2.0"
 service-registry-api = { workspace = true }
 sha3 = { workspace = true }
-snarkvm = "1.1.0"
+# snarkvm = "1.1.0"
 solabi = "0.2.0"
 stellar = { workspace = true }
 stellar-rpc-client = "21.4.0"
@@ -81,6 +81,8 @@ valuable-serde = { version = "0.1.0", features = ["std"] }
 voting-verifier = { workspace = true }
 aleo-gateway = { workspace = true }
 snarkvm-cosmwasm = { workspace = true }
+# aleo-parser = { path = "../../axelar-aleo/crates/aleo-parser" }
+aleo-parser = { git = "ssh://git@github.com/eigerco/axelar-aleo.git", branch = "aleo-helper-libs" }
 
 [dev-dependencies]
 assert_ok = { workspace = true }

--- a/ampd/Cargo.toml
+++ b/ampd/Cargo.toml
@@ -6,6 +6,7 @@ rust-version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+aleo-types = { workspace = true }
 async-trait = "0.1.59"
 axelar-wasm-std = { workspace = true }
 axum = "0.7.5"
@@ -38,8 +39,11 @@ mockall = "0.11.3"
 move-core-types = { git = "https://github.com/mystenlabs/sui", tag = "testnet-v1.39.1" }
 multisig = { workspace = true, features = ["library"] }
 multiversx-sdk = "0.6.1"
+nom = "7.1.3"
 num-traits = { workspace = true }
 openssl = { version = "0.10.35", features = ["vendored"] }  # Needed to make arm compilation work by forcing vendoring
+pest = { workspace = true }
+pest_derive = { workspace = true }
 prost = "0.11.9"
 prost-types = "0.11.9"
 report = { workspace = true }
@@ -51,6 +55,8 @@ serde_json = { workspace = true }
 serde_with = "3.2.0"
 service-registry-api = { workspace = true }
 sha3 = { workspace = true }
+snarkvm = "1.1.0"
+solabi = "0.2.0"
 stellar = { workspace = true }
 stellar-rpc-client = "21.4.0"
 stellar-xdr = { workspace = true, features = ["serde_json"] }
@@ -73,6 +79,8 @@ url = "2.3.1"
 valuable = { version = "0.1.0", features = ["derive"] }
 valuable-serde = { version = "0.1.0", features = ["std"] }
 voting-verifier = { workspace = true }
+aleo-gateway = { workspace = true }
+snarkvm-cosmwasm = { workspace = true }
 
 [dev-dependencies]
 assert_ok = { workspace = true }

--- a/ampd/proto/tofnd/common.proto
+++ b/ampd/proto/tofnd/common.proto
@@ -7,6 +7,7 @@ package tofnd;
 enum Algorithm {
   ALGORITHM_ECDSA = 0;
   ALGORITHM_ED25519 = 1;
+  ALGORITHM_ALEO_SCHNORR = 2;
 }
 
 // Key presence check types

--- a/ampd/src/aleo-json-like-format.pest
+++ b/ampd/src/aleo-json-like-format.pest
@@ -1,0 +1,43 @@
+aleo = _{ SOI ~ object ~ EOI }
+
+object = {
+    "{" ~ "}" |
+    "{" ~ pair ~ ("," ~ pair)* ~ ","? ~ "}"
+}
+
+pair = { key ~ ":" ~ value }
+
+key = @{
+    ASCII_ALPHA+ ~ ("_" ~ ASCII_ALPHA+)*
+}
+
+value = _{
+    object
+    | array
+    | number
+    | boolean
+    | null
+    | aleo_address
+}
+
+aleo_address = @{
+    "aleo1" ~ (ASCII_ALPHANUMERIC){58}
+}
+
+array = {
+    "[" ~ "]" |
+    "[" ~ value ~ ("," ~ value)* ~ ","? ~ "]"
+}
+
+number = @{
+    "-"?
+    ~ ("0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*)
+    ~ ("." ~ ASCII_DIGIT*)?
+    ~ (^"e" ~ ("+" | "-")? ~ ASCII_DIGIT+)?
+    ~ "u128"
+}
+
+boolean = { "true" | "false" }
+null = { "null" }
+
+WHITESPACE = _{ " " | "\t" | "\r" | "\n" }

--- a/ampd/src/aleo/http_client.rs
+++ b/ampd/src/aleo/http_client.rs
@@ -1,0 +1,479 @@
+use std::str::FromStr;
+
+use aleo_types::address::Address;
+use aleo_types::transaction::Transaction;
+use aleo_types::transition::Transition;
+use async_trait::async_trait;
+use error_stack::{ensure, report, Report, Result, ResultExt};
+use mockall::automock;
+use router_api::ChainName;
+use sha3::{Digest, Keccak256};
+use snarkvm::ledger::{Output, Transaction as SnarkvmTransaction};
+use snarkvm::prelude::{AleoID, Field, TestnetV0};
+use thiserror::Error;
+use tracing::{debug, info, warn};
+
+use super::json_like;
+use super::parser::CallContract;
+use crate::types::Hash;
+
+type CurrentNetwork = TestnetV0;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("failed to create client")]
+    Client,
+    #[error("Request error")]
+    Request,
+    #[error("Transition not found")]
+    TransitionNotFound,
+    #[error("Not an execution transition")]
+    TransactionNotexecution,
+    #[error("Failed to find callContract")]
+    CallnotFound,
+    #[error("Failed to find user call")]
+    UserCallnotFound,
+    #[error("The provided chain name is invalid")]
+    InvalidChainName,
+    #[error("Invalid source address")]
+    InvalidSourceAddress,
+    #[error("Failed to create AleoID: {0}")]
+    FailedToCreateAleoID(String),
+}
+
+#[derive(Debug)]
+pub enum Receipt {
+    Found(TransitionReceipt),
+    NotFound(Transition, Report<Error>),
+}
+
+#[derive(Debug)]
+pub struct TransitionReceipt {
+    pub transition: Transition,
+    pub destination_address: String,
+    pub destination_chain: ChainName,
+    pub source_address: Address,
+    pub payload: Vec<u8>,
+}
+
+impl PartialEq<crate::handlers::aleo_verify_msg::Message> for TransitionReceipt {
+    fn eq(&self, message: &crate::handlers::aleo_verify_msg::Message) -> bool {
+        info!(
+            "transition_id: chain.{} == msg.{} ({})",
+            self.transition,
+            message.tx_id,
+            self.transition == message.tx_id
+        );
+        info!(
+            "destination_address: chain.{} == msg.{} ({})",
+            self.destination_address,
+            message.destination_address,
+            self.destination_address == message.destination_address
+        );
+        info!(
+            "destination_chain: chain.{} == msg.{} ({})",
+            self.destination_chain,
+            message.destination_chain,
+            self.destination_chain == message.destination_chain
+        );
+        info!(
+            "source_address: chain.{:?} == msg.{:?} ({})",
+            self.source_address,
+            message.source_address,
+            self.source_address == message.source_address
+        );
+
+        let payload = std::str::from_utf8(&self.payload).unwrap();
+        let payload_hash = if self.destination_chain.as_ref().starts_with("eth") {
+            let payload = json_like::into_json(payload).unwrap();
+            let payload: Vec<u8> = serde_json::from_str(&payload).unwrap();
+            let payload = std::str::from_utf8(&payload).unwrap();
+            let payload = solabi::encode(&payload);
+            let payload_hash = keccak256(&payload).to_vec();
+            Hash::from_slice(&payload_hash)
+        }
+        else {
+            // let payload_hash = keccak256(&payload).to_vec();
+            let payload_hash = aleo_gateway::aleo_hash::<&str, snarkvm_cosmwasm::network::TestnetV0>(payload).unwrap();
+            let payload_hash = payload_hash.strip_suffix("group").unwrap();
+            let hash = cosmwasm_std::Uint256::from_str(&payload_hash).unwrap();
+            let hash = hash.to_le_bytes();
+            Hash::from_slice(&hash)
+        };
+
+        info!(
+            "payload_hash: chain.{:?} == msg.{:?} ({})",
+            payload_hash,
+            message.payload_hash,
+            payload_hash == message.payload_hash
+        );
+
+        self.transition == message.tx_id
+            && self.destination_address == message.destination_address
+            && self.destination_chain == message.destination_chain
+            && self.source_address == message.source_address
+            && payload_hash == message.payload_hash
+    }
+}
+
+#[automock]
+#[async_trait]
+pub trait ClientTrait: Send {
+    async fn get_transaction(
+        &self,
+        transaction_id: &Transaction,
+    ) -> Result<SnarkvmTransaction<CurrentNetwork>, Error>;
+
+    async fn find_transaction(&self, transition_id: &Transition) -> Result<String, Error>; // TODO: remove magic number
+}
+
+#[derive(Clone)]
+pub struct Client {
+    client: reqwest::Client,
+    base_url: String,
+    network: String,
+}
+
+#[derive(Default, Debug)]
+struct ParsedOutput {
+    payload: Vec<u8>,
+    call_contract: CallContract,
+}
+
+impl Client {
+    pub fn new(client: reqwest::Client, base_url: String, network: String) -> Result<Self, Error> {
+        ensure!(
+            base_url.starts_with("http://") || base_url.starts_with("https://"),
+            report!(Error::Client).attach_printable("specified url {base_url} invalid, the base url must start with or https:// (or http:// if doing local development)")
+        );
+
+        Ok(Self {
+            client,
+            base_url,
+            network,
+        })
+    }
+}
+
+#[async_trait]
+impl ClientTrait for Client {
+    #[tracing::instrument(skip(self))]
+    async fn get_transaction(
+        &self,
+        transaction_id: &Transaction,
+    ) -> Result<SnarkvmTransaction<CurrentNetwork>, Error> {
+        const ENDPOINT: &str = "transaction";
+        let url = format!(
+            "{}/{}/{ENDPOINT}/{}",
+            self.base_url, self.network, &transaction_id
+        );
+
+        tracing::debug!(%url);
+        let response = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .change_context(Error::Request)?;
+
+        let transaction: SnarkvmTransaction<CurrentNetwork> =
+            serde_json::from_str(&response.text().await.change_context(Error::Request)?)
+                .change_context(Error::Request)?; // TODO: This is a CPU intensive operation. We need to handle it differently
+
+        Ok(transaction)
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn find_transaction(&self, transition_id: &Transition) -> Result<String, Error> {
+        const ENDPOINT: &str = "find/transactionID";
+        let url = format!(
+            "{}/{}/{ENDPOINT}/{}",
+            self.base_url, self.network, &transition_id
+        );
+        tracing::debug!(%url);
+
+        let response = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .change_context(Error::Request)?;
+
+        response.text().await.change_context(Error::Request)
+    }
+}
+
+pub struct ClientWrapper<'a, C: ClientTrait> {
+    client: &'a C,
+}
+
+impl<'a, C> ClientWrapper<'a, C>
+where
+    C: ClientTrait + Send + Sync + 'static,
+{
+    pub fn new(client: &'a C) -> Self {
+        Self { client }
+    }
+
+    fn find_call_contract(&self, outputs: &[Output<CurrentNetwork>]) -> Option<CallContract> {
+        // println!("outputs ------>{outputs:#?}");
+        if outputs.len() != 1 {
+            return None;
+        }
+
+        outputs
+            .first()
+            .and_then(|o| match o {
+                Output::<CurrentNetwork>::Public(_field, Some(plaintext)) => {
+                    Some(plaintext.to_string())
+                }
+                _ => None,
+            })
+            .as_ref()
+            .and_then(|value| crate::aleo::parser::parse_call_contract(value))
+    }
+
+    fn parse_user_output(&self, outputs: &[Output<CurrentNetwork>]) -> Result<ParsedOutput, Error> {
+        if outputs.len() != 2 {
+            return Err(Report::new(Error::UserCallnotFound));
+        }
+
+        // ParsedOutput
+        let mut parsed_output = ParsedOutput::default();
+
+        // TODO: there mast be a better way
+        for o in outputs {
+            if let Output::<CurrentNetwork>::Public(_field, Some(plaintext)) = o {
+                let parsed =
+                    crate::aleo::parser::parse_call_contract(plaintext.to_string().as_str());
+                if let Some(call_contract) = parsed {
+                    parsed_output.call_contract = call_contract;
+                } else {
+                    parsed_output.payload = plaintext.to_string().as_bytes().to_vec();
+                }
+            }
+        }
+
+        Ok(parsed_output)
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub async fn transition_receipt(
+        &self,
+        transition_id: &Transition,
+        gateway_contract: &str,
+    ) -> Result<Receipt, Error> {
+        const TRANSITION_PREFIX: &[u8] = "au".as_bytes();
+        const TRANSITION_BYTES_PREFIX: u16 =
+            u16::from_le_bytes([TRANSITION_PREFIX[0], TRANSITION_PREFIX[1]]);
+
+        let transaction = self.client.find_transaction(transition_id).await?;
+        let transaction = transaction.trim_matches('"');
+
+        // Find transaction
+        let transaction_id =
+            Transaction::from_str(transaction).change_context(Error::TransitionNotFound)?;
+
+        let transaction = self.client.get_transaction(&transaction_id).await?;
+
+        if transaction.execution().is_none() {
+            warn!("Transaction '{:?}' is not an execution transaction. The following transitions can not be vailidated: '{:?}'",
+                transaction_id,
+                transition_id
+            );
+            return Err(Report::new(Error::TransactionNotexecution));
+        }
+
+        // Get the gateway transition
+        let gateway_transition = transaction
+            .find_transition(
+                &AleoID::<Field<CurrentNetwork>, TRANSITION_BYTES_PREFIX>::from_str(
+                    transition_id.to_string().as_str(),
+                )
+                .map_err(|e| Error::FailedToCreateAleoID(e.to_string()))?,
+            )
+            .ok_or(Error::TransitionNotFound)?;
+
+        // Get the outputs of the transition
+        // The transition should have only the gateway call
+        let outputs = gateway_transition.outputs();
+        let call_contract_call = self.find_call_contract(outputs);
+        // println!("----> call_contract_call: {call_contract_call:#?}");
+        let call_contract = call_contract_call.ok_or(Error::CallnotFound)?;
+
+        // println!("----> call_contract: {call_contract:#?}");
+        let scm = gateway_transition.scm();
+        // println!("----> scm: {scm:#?}");
+
+        let gateway_calls_count = transaction
+            .transitions()
+            .filter(|t| {
+                // println!("t.scm(): {:#?}", t.scm());
+                // println!("t.program_id().to_string().as_str(): {:#?}", t.program_id().to_string().as_str());
+                // println!("gateway_contract: {:#?}", gateway_contract);
+                // println!("res: {:?}", t.scm() == scm && t.program_id().to_string().as_str() == gateway_contract);
+
+                t.scm() == scm && t.program_id().to_string().as_str() == gateway_contract
+            })
+            .count();
+
+        // println!("gateway_calls_count: {gateway_calls_count:#?}");
+        ensure!(gateway_calls_count == 1, Error::CallnotFound);
+
+        let same_scm: Vec<_> = transaction
+            .transitions()
+            .filter(|t| t.scm() == scm && t.id() != gateway_transition.id())
+            .collect();
+
+        ensure!(gateway_calls_count == 1, Error::UserCallnotFound);
+
+        let parsed_output = self.parse_user_output(same_scm[0].outputs())?;
+
+        ensure!(
+            parsed_output.call_contract == call_contract,
+            Error::UserCallnotFound
+        );
+
+        Ok(Receipt::Found(TransitionReceipt {
+            transition: transition_id.clone(),
+            destination_address: call_contract.destination_address().map_err(|e| {
+                Report::new(Error::FailedToCreateAleoID(e.to_string()))
+            })?,
+            destination_chain: ChainName::try_from(call_contract.destination_chain())
+                .change_context(Error::InvalidChainName)?,
+            source_address: Address::from_str(call_contract.sender.to_string().as_ref())
+                .change_context(Error::InvalidSourceAddress)?,
+            payload: parsed_output.payload,
+        }))
+    }
+}
+
+fn keccak256(payload: impl AsRef<[u8]>) -> [u8; 32] {
+    let mut hasher = Keccak256::new();
+    hasher.update(payload);
+    hasher.finalize().into()
+}
+
+#[cfg(test)]
+pub mod tests {
+    use std::collections::HashMap;
+    use std::str::FromStr;
+
+    use super::*;
+
+    pub fn mock_client() -> MockClientTrait {
+        let mut mock_client = MockClientTrait::new();
+
+        let transaction_id = "at18c83pwjlvvjpdk95pudngzxqydvq92np206njcyppgndjalujsrshjn48j";
+        let mut expected_transitions: HashMap<Transaction, SnarkvmTransaction<CurrentNetwork>> =
+            HashMap::new();
+        let transaction_one = include_str!(
+            "../tests/at18c83pwjlvvjpdk95pudngzxqydvq92np206njcyppgndjalujsrshjn48j.json"
+        );
+        let snark_tansaction =
+            SnarkvmTransaction::<CurrentNetwork>::from_str(transaction_one).unwrap();
+        let transaction = Transaction::from_str(transaction_id).unwrap();
+        expected_transitions.insert(transaction, snark_tansaction);
+
+        mock_client
+            .expect_get_transaction()
+            .returning(move |transaction| {
+                Ok(expected_transitions.get(transaction).unwrap().clone())
+            });
+
+        mock_client.expect_find_transaction().returning(move |_| {
+            let transaction_id = "at18c83pwjlvvjpdk95pudngzxqydvq92np206njcyppgndjalujsrshjn48j";
+            Ok(transaction_id.to_string())
+        });
+
+        mock_client
+    }
+
+    pub fn mock_client_2() -> MockClientTrait {
+        let mut mock_client = MockClientTrait::new();
+
+        let transaction_id = "at1dgmvx30f79wt6w8fcjurwtsc5zak4efg4ayyme79862xylve7gxsq3nfh6";
+        let mut expected_transitions: HashMap<Transaction, SnarkvmTransaction<CurrentNetwork>> =
+            HashMap::new();
+        let transaction_one = include_str!(
+            "../tests/at1dgmvx30f79wt6w8fcjurwtsc5zak4efg4ayyme79862xylve7gxsq3nfh6.json"
+        );
+        let snark_tansaction =
+            SnarkvmTransaction::<CurrentNetwork>::from_str(transaction_one).unwrap();
+        let transaction = Transaction::from_str(transaction_id).unwrap();
+        expected_transitions.insert(transaction, snark_tansaction);
+
+        mock_client
+            .expect_get_transaction()
+            .returning(move |transaction| {
+                // println!("{transaction:#?}");
+                Ok(expected_transitions.get(transaction).unwrap().clone())
+            });
+
+        mock_client.expect_find_transaction().returning(move |_| {
+            let transaction_id = "at1dgmvx30f79wt6w8fcjurwtsc5zak4efg4ayyme79862xylve7gxsq3nfh6";
+            Ok(transaction_id.to_string())
+        });
+
+        mock_client
+    }
+
+    pub fn mock_client_3() -> MockClientTrait {
+        let mut mock_client = MockClientTrait::new();
+
+        let transaction_id = "at14gry4nauteg5sp00p6d2pj93dhpsm5857ml8y3xg57nkpszhav9qk0tgvd";
+        let mut expected_transitions: HashMap<Transaction, SnarkvmTransaction<CurrentNetwork>> =
+            HashMap::new();
+        let transaction_one = include_str!(
+            "../tests/at14gry4nauteg5sp00p6d2pj93dhpsm5857ml8y3xg57nkpszhav9qk0tgvd.json"
+        );
+        let snark_tansaction =
+            SnarkvmTransaction::<CurrentNetwork>::from_str(transaction_one).unwrap();
+        let transaction = Transaction::from_str(transaction_id).unwrap();
+        expected_transitions.insert(transaction, snark_tansaction);
+
+        mock_client
+            .expect_get_transaction()
+            .returning(move |transaction| {
+                Ok(expected_transitions.get(transaction).unwrap().clone())
+            });
+
+        mock_client.expect_find_transaction().returning(move |_| {
+            let transaction_id = "at14gry4nauteg5sp00p6d2pj93dhpsm5857ml8y3xg57nkpszhav9qk0tgvd";
+            Ok(transaction_id.to_string())
+        });
+
+        mock_client
+    }
+
+    #[tokio::test]
+    async fn foo_test() {
+        let client = mock_client_2();
+        let transision_id = "au1zn24gzpgkr936qv49g466vfccg8aykcv05rk39s239hjxwrtsu8sltpsd8";
+        // let transision_id = "au1knlxwe55dx6cnm2j5sgtsl2z2z590jprme2t4cc49h85uv0emgrsuzvutv";
+        let transition = Transition::from_str(transision_id).unwrap();
+        let client = ClientWrapper::new(&client);
+        let gateway_contract = "gateway_base.aleo";
+
+        let res = client
+            .transition_receipt(&transition, gateway_contract)
+            .await;
+        println!("{res:#?}");
+        assert!(res.is_ok());
+    }
+
+    #[tokio::test]
+    async fn flow_test() {
+        let client = mock_client_3();
+        let transision_id = "au17kdp7a7p6xuq6h0z3qrdydn4f6fjaufvzvlgkdd6vzpr87lgcgrq8qx6st";
+        let transition = Transition::from_str(transision_id).unwrap();
+        let client = ClientWrapper::new(&client);
+        let gateway_contract = "ac64caccf8221554ec3f89bf.aleo";
+
+        let res = client
+            .transition_receipt(&transition, gateway_contract)
+            .await;
+        // println!("{res:#?}");
+        assert!(res.is_ok());
+    }
+}

--- a/ampd/src/aleo/http_client.rs
+++ b/ampd/src/aleo/http_client.rs
@@ -11,7 +11,7 @@ use sha3::{Digest, Keccak256};
 use snarkvm::ledger::{Output, Transaction as SnarkvmTransaction};
 use snarkvm::prelude::{AleoID, Field, TestnetV0};
 use thiserror::Error;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 use super::json_like;
 use super::parser::CallContract;
@@ -93,7 +93,6 @@ impl PartialEq<crate::handlers::aleo_verify_msg::Message> for TransitionReceipt 
             Hash::from_slice(&payload_hash)
         }
         else {
-            // let payload_hash = keccak256(&payload).to_vec();
             let payload_hash = aleo_gateway::aleo_hash::<&str, snarkvm_cosmwasm::network::TestnetV0>(payload).unwrap();
             let payload_hash = payload_hash.strip_suffix("group").unwrap();
             let hash = cosmwasm_std::Uint256::from_str(&payload_hash).unwrap();
@@ -298,26 +297,17 @@ where
         // The transition should have only the gateway call
         let outputs = gateway_transition.outputs();
         let call_contract_call = self.find_call_contract(outputs);
-        // println!("----> call_contract_call: {call_contract_call:#?}");
         let call_contract = call_contract_call.ok_or(Error::CallnotFound)?;
 
-        // println!("----> call_contract: {call_contract:#?}");
         let scm = gateway_transition.scm();
-        // println!("----> scm: {scm:#?}");
 
         let gateway_calls_count = transaction
             .transitions()
             .filter(|t| {
-                // println!("t.scm(): {:#?}", t.scm());
-                // println!("t.program_id().to_string().as_str(): {:#?}", t.program_id().to_string().as_str());
-                // println!("gateway_contract: {:#?}", gateway_contract);
-                // println!("res: {:?}", t.scm() == scm && t.program_id().to_string().as_str() == gateway_contract);
-
                 t.scm() == scm && t.program_id().to_string().as_str() == gateway_contract
             })
             .count();
 
-        // println!("gateway_calls_count: {gateway_calls_count:#?}");
         ensure!(gateway_calls_count == 1, Error::CallnotFound);
 
         let same_scm: Vec<_> = transaction
@@ -450,7 +440,6 @@ pub mod tests {
     async fn foo_test() {
         let client = mock_client_2();
         let transision_id = "au1zn24gzpgkr936qv49g466vfccg8aykcv05rk39s239hjxwrtsu8sltpsd8";
-        // let transision_id = "au1knlxwe55dx6cnm2j5sgtsl2z2z590jprme2t4cc49h85uv0emgrsuzvutv";
         let transition = Transition::from_str(transision_id).unwrap();
         let client = ClientWrapper::new(&client);
         let gateway_contract = "gateway_base.aleo";
@@ -473,7 +462,6 @@ pub mod tests {
         let res = client
             .transition_receipt(&transition, gateway_contract)
             .await;
-        // println!("{res:#?}");
         assert!(res.is_ok());
     }
 }

--- a/ampd/src/aleo/json_like.rs
+++ b/ampd/src/aleo/json_like.rs
@@ -1,0 +1,484 @@
+use nom::{
+    branch::alt,
+    bytes::complete::{tag, take_while_m_n},
+    character::complete::{alpha1, alphanumeric1, char, digit1, multispace0},
+    combinator::{all_consuming, map_parser, map_res, recognize},
+    multi::{many0, separated_list1},
+    sequence::{delimited, pair, preceded, separated_pair, terminated},
+    IResult,
+};
+
+pub fn into_json(i: &str) -> Result<String, String> {
+    let (_, result) = all_consuming(alt((record, expression)))(i)
+        // there's no recovering from a failed parse, so just returning a string description is
+        // fine
+        .map_err(|err| format!("{:?}", err))?;
+    Ok(result)
+}
+
+fn record(i: &str) -> IResult<&str, String> {
+    map_res(
+        delimited(
+            char('{'),
+            separated_list1(char(','), field),
+            preceded(multispace0, char('}')),
+        ),
+        |values| -> Result<String, ()> { Ok(format!("{{{}}}", values.join(","))) },
+    )(i)
+}
+
+fn field(i: &str) -> IResult<&str, String> {
+    map_res(
+        separated_pair(
+            preceded(multispace0, identifier),
+            tag(":"),
+            preceded(multispace0, expression),
+        ),
+        |(name, value)| -> Result<String, ()> { Ok(format!("\"{name}\":{value}")) },
+    )(i)
+}
+
+// From Leo's grammar:
+//
+// uppercase-letter = %x41-5A ; A-Z
+// lowercase-letter = %x61-7A ; a-z
+// letter = uppercase-letter / lowercase-letter
+// identifier = letter *( letter / decimal-digit / "_" )
+fn identifier(i: &str) -> IResult<&str, &str> {
+    recognize(pair(alpha1, many0(alt((alphanumeric1, tag("_"))))))(i)
+}
+
+// An "expression" in Leo's grammar is too broad, it covers a good chunk of the
+// language syntax, while the interest here is to only parse arrays of literals
+// or of structs/records
+//
+// From Leo's grammar:
+//
+// array-expression = "[" expression 1*( "," expression ) [ "," ] "]"
+fn array_expression(i: &str) -> IResult<&str, String> {
+    map_res(
+        delimited(
+            tag("["),
+            separated_list1(char(','), delimited(multispace0, expression, multispace0)),
+            terminated(tag("]"), multispace0),
+        ),
+        |values| -> Result<String, ()> { Ok(format!("[{}]", values.join(","))) },
+    )(i)
+}
+
+fn expression(i: &str) -> IResult<&str, String> {
+    alt((atomic_literal, array_expression, record))(i)
+}
+
+// From Leo's grammar:
+//
+// atomic-literal = numeric-literal
+//                / boolean-literal
+//                / explicit-address-literal
+//                / string-literal (not supported in the official Leo yet)
+fn atomic_literal(i: &str) -> IResult<&str, String> {
+    alt((numeric_literal, boolean_literal, explicit_address_literal))(i)
+}
+
+// From Leo's grammar:
+//
+// decimal-digit = %x30-39 ; 0-9
+// decimal-numeral = 1*( decimal-digit *"_" ) (_ separator not supported)
+// numeral = binary-numeral (not yet supported)
+//         / octal-numeral (not yet supported)
+//         / decimal-numeral
+//         / hexadecimal-numeral (not yet supported)
+// unsigned-literal = numeral ( %s"u8" / %s"u16" / %s"u32" / %s"u64" / %s"u128" )
+// signed-literal = numeral ( %s"i8" / %s"i16" / %s"i32" / %s"i64" / %s"i128" )
+// integer-literal = unsigned-literal / signed-literal
+// field-literal = decimal-numeral %s"field"
+// product-group-literal = decimal-numeral %s"group"
+// scalar-literal = decimal-numeral %s"scalar"
+// numeric-literal = integer-literal / field-literal / product-group-literal / scalar-literal
+fn numeric_literal(i: &str) -> IResult<&str, String> {
+    map_parser(
+        terminated(
+            digit1,
+            alt((
+                tag("u8"),
+                tag("u16"),
+                tag("u32"),
+                tag("u64"),
+                tag("u128"),
+                tag("i8"),
+                tag("i16"),
+                tag("i32"),
+                tag("i64"),
+                tag("i128"),
+                tag("field"),
+                tag("group"),
+                tag("scalar"),
+            )),
+        ),
+        into,
+    )(i)
+}
+
+// From Leo's grammar:
+//
+// boolean-literal = %s"true" / %s"false"
+fn boolean_literal(i: &str) -> IResult<&str, String> {
+    map_parser(alt((tag("true"), tag("false"))), quote)(i)
+}
+
+// From Leo's grammar:
+//
+// explicit-address-literal = %s"aleo1" 58( lowercase-letter / decimal-digit )
+fn explicit_address_literal(i: &str) -> IResult<&str, String> {
+    map_parser(
+        recognize(pair(
+            tag("aleo1"),
+            take_while_m_n(58, 58, is_ascii_lowercase_or_ascii_digit),
+        )),
+        quote,
+    )(i)
+}
+
+fn is_ascii_lowercase_or_ascii_digit(i: char) -> bool {
+    i.is_ascii_lowercase() || i.is_ascii_digit()
+}
+
+fn into(i: &str) -> IResult<&str, String> {
+    Ok((i, i.into()))
+}
+
+fn quote(i: &str) -> IResult<&str, String> {
+    Ok((i, format!("\"{i}\"")))
+}
+
+// todo: if this ends up becoming a key piece of infrastructure: create arbtests
+#[cfg(test)]
+mod test {
+    use serde::Deserialize;
+
+    use super::{
+        array_expression, boolean_literal, explicit_address_literal, identifier, into_json,
+        is_ascii_lowercase_or_ascii_digit, numeric_literal, record,
+    };
+
+    #[test]
+    fn test_parse_into_json() {
+        #[derive(Deserialize, PartialEq, Debug)]
+        struct Outer {
+            array_of_records: Vec<Inner1>,
+            record_of_records: Inner2,
+        }
+
+        #[derive(Deserialize, PartialEq, Debug)]
+        struct Inner1 {
+            foo: usize,
+            bar: usize,
+        }
+
+        #[derive(Deserialize, PartialEq, Debug)]
+        struct Inner2 {
+            foo: Inner3,
+            bar: Inner4,
+        }
+
+        #[derive(Deserialize, PartialEq, Debug)]
+        struct Inner3 {
+            baz: usize,
+        }
+
+        #[derive(Deserialize, PartialEq, Debug)]
+        struct Inner4 {
+            baz: String,
+        }
+
+        let i = "{\n  array_of_records: [\n    {foo: 1u8, bar: 2field},\n    {foo: 1u16, bar: 2group},\n    {foo: 1u32, bar: 2scalar}\n  ],\n    record_of_records: { foo: { baz: 1u32 }, bar: { baz: aleo1lv7mvjhq9zkfc9fn0vt4nv2eh3k90t33gpt6r73n4yf8rae3gc8s526ddx } }\n}";
+
+        let actual: Outer = serde_json::from_str(&into_json(i).unwrap()).unwrap();
+        let expected = Outer {
+            array_of_records: vec![
+                Inner1 { foo: 1, bar: 2 },
+                Inner1 { foo: 1, bar: 2 },
+                Inner1 { foo: 1, bar: 2 },
+            ],
+            record_of_records: Inner2 {
+                foo: Inner3 { baz: 1 },
+                bar: Inner4 {
+                    baz: "aleo1lv7mvjhq9zkfc9fn0vt4nv2eh3k90t33gpt6r73n4yf8rae3gc8s526ddx".into(),
+                },
+            },
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_complete_parse_of_nested_structures() {
+        let case = "{\n  array_of_records: [\n    {foo: 1u8, bar: 2field},\n    {foo: 1u16, bar: 2group},\n    {foo: 1u32, bar: 2scalar}\n  ],\n    record_of_records: { foo: { baz: 1u32 }, bar: { baz: aleo1lv7mvjhq9zkfc9fn0vt4nv2eh3k90t33gpt6r73n4yf8rae3gc8s526ddx } }\n}";
+        let (rest, consumed) = record(case).unwrap();
+        assert_eq!(rest, "");
+        let expected = "{\"array_of_records\":[{\"foo\":1,\"bar\":2},{\"foo\":1,\"bar\":2},{\"foo\":1,\"bar\":2}],\"record_of_records\":{\"foo\":{\"baz\":1},\"bar\":{\"baz\":\"aleo1lv7mvjhq9zkfc9fn0vt4nv2eh3k90t33gpt6r73n4yf8rae3gc8s526ddx\"}}}";
+        assert_eq!(consumed, expected);
+    }
+
+    #[test]
+    fn test_complete_parse_of_flat_structure() {
+        let case = "{\n  caller: aleo1lv7mvjhq9zkfc9fn0vt4nv2eh3k90t33gpt6r73n4yf8rae3gc8s526ddx,\n    signer: aleo1rtxa7fxfsznuulgcfc77prmwvw7g4y2y7r7xl4xltcygjpn34yzsh2dmln,\n    destination_address: [\n    101u8,\n    116u8,\n    104u8,\n    101u8,\n    114u8,\n    101u8,\n    117u8,\n    109u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8\n  ],\n    destination_chain: [\n    101u8,\n    116u8,\n    104u8,\n    101u8,\n    114u8,\n    101u8,\n    117u8,\n    109u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8\n  ]\n}";
+        let (rest, consumed) = record(case).unwrap();
+        assert_eq!(rest, "");
+        let expected  = "{\"caller\":\"aleo1lv7mvjhq9zkfc9fn0vt4nv2eh3k90t33gpt6r73n4yf8rae3gc8s526ddx\",\"signer\":\"aleo1rtxa7fxfsznuulgcfc77prmwvw7g4y2y7r7xl4xltcygjpn34yzsh2dmln\",\"destination_address\":[101,116,104,101,114,101,117,109,0,0,0,0,0,0,0,0,0,0,0,0],\"destination_chain\":[101,116,104,101,114,101,117,109,0,0,0,0,0,0,0,0,0,0,0,0]}";
+        assert_eq!(consumed, expected);
+    }
+
+    #[test]
+    fn test_valid_identifiers() {
+        let cases = ["caller", "caller_", "c_aller", "c1aller", "Caller"];
+        for case in cases {
+            let (rest, consumed) = identifier(case).unwrap();
+            assert_eq!(rest, "");
+            assert_eq!(consumed, case);
+        }
+    }
+
+    #[test]
+    fn test_invalid_identifiers() {
+        let case = "_caller";
+        let actual_err = numeric_literal(case).unwrap_err();
+        let expected_err = nom::Err::Error(nom::error::Error {
+            input: case,
+            code: nom::error::ErrorKind::Digit,
+        });
+        assert_eq!(actual_err, expected_err);
+
+        let case = "1caller";
+        let actual_err = numeric_literal(case).unwrap_err();
+        let expected_err = nom::Err::Error(nom::error::Error {
+            input: "caller",
+            code: nom::error::ErrorKind::Tag,
+        });
+        assert_eq!(actual_err, expected_err);
+    }
+
+    #[test]
+    fn test_valid_boolean_literal_expression() {
+        let case = "[\n    true,\n    false,\n    true,    false\n  ]";
+        let (rest, consumed) = array_expression(case).unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(consumed, "[\"true\",\"false\",\"true\",\"false\"]");
+    }
+
+    #[test]
+    fn test_valid_address_literal_expression() {
+        let case = "[\n    aleo1n6c5ugxk6tp09vkrjegcpcprssdfcf7283agcdtt8gu9qex2c5xs9c28ay,\n    aleo1dsrv0z6wu9mgzl5l7wh62rwmrd4yt3zva7n4ayhvg02luvtqkqgq5tw209,\n    aleo12tf856xd9we5ay090zkep0s3q5e8srzwqr37ds0ppvv5kkzad5fqvwndmx,    aleo1anfvarnm27e2s5j6mzx3kzakx5eryc69re96x6grzkm9nkapkgpq4vyy5t\n  ]";
+        let (rest, consumed) = array_expression(case).unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(consumed, "[\"aleo1n6c5ugxk6tp09vkrjegcpcprssdfcf7283agcdtt8gu9qex2c5xs9c28ay\",\"aleo1dsrv0z6wu9mgzl5l7wh62rwmrd4yt3zva7n4ayhvg02luvtqkqgq5tw209\",\"aleo12tf856xd9we5ay090zkep0s3q5e8srzwqr37ds0ppvv5kkzad5fqvwndmx\",\"aleo1anfvarnm27e2s5j6mzx3kzakx5eryc69re96x6grzkm9nkapkgpq4vyy5t\"]");
+    }
+
+    #[test]
+    fn test_valid_array_numeric_literal_expressions() {
+        let cases = [
+            "[\n    102u8,\n    116u8,\n    109u8,    0u8\n  ]",
+            "[\n    102u16,\n    116u16,\n    109u16,    0u16\n  ]",
+            "[\n    102u32,\n    116u32,\n    109u32,    0u32\n  ]",
+            "[\n    102u64,\n    116u64,\n    109u64,    0u64\n  ]",
+            "[\n    102u128,\n    116u128,\n    109u128,    0u128\n  ]",
+            "[\n    102i8,\n    116i8,\n    109i8,    0i8\n  ]",
+            "[\n    102i16,\n    116i16,\n    109i16,    0i16\n  ]",
+            "[\n    102i32,\n    116i32,\n    109i32,    0i32\n  ]",
+            "[\n    102i64,\n    116i64,\n    109i64,    0i64\n  ]",
+            "[\n    102i128,\n    116i128,\n    109i128,    0i128\n  ]",
+            "[\n    102field,\n    116field,\n    109field,    0field\n  ]",
+            "[\n    102scalar,\n    116scalar,\n    109scalar,    0scalar\n  ]",
+            "[\n    102group,\n    116group,\n    109group,    0group\n  ]",
+            // every element of a leo array is of the same type
+            // so although these can never be hit, the parser supports it
+            "[\n    102u8,\n    116u16,\n    109u32,    0u64\n  ]",
+            "[\n    102u128,\n    116field,\n    109scalar,    0group\n  ]",
+            "[\n    102i8,\n    116i16,\n    109i32,    0i64\n  ]",
+            "[\n    102i128,\n    116field,\n    109scalar,    0group\n  ]",
+        ];
+        for case in cases {
+            let (rest, consumed) = array_expression(case).unwrap();
+            assert_eq!(rest, "");
+            assert_eq!(consumed, "[102,116,109,0]");
+        }
+    }
+
+    #[test]
+    fn test_failing_array_expression() {
+        let case = "[\n  72u8,\n  101u8,\n  108u8,\n  108u8,\n  111u8,\n  44u8,\n  32u8,\n  87u8,\n  111u8,\n  114u8,\n  108u8,\n  100u8,\n  33u8\n]";
+        let result = into_json(case).unwrap();
+        assert_eq!(result, "[72,101,108,108,111,44,32,87,111,114,108,100,33]");
+    }
+
+    #[test]
+    fn test_invalid_array_expressions() {
+        let case = "[\n    102u256,\n    116u8,\n    109u8,    0u8\n  ]";
+        let actual_err = array_expression(case).unwrap_err();
+        let expected_err = nom::Err::Error(nom::error::Error {
+            input: "102u256,\n    116u8,\n    109u8,    0u8\n  ]",
+            code: nom::error::ErrorKind::Char,
+        });
+        assert_eq!(actual_err, expected_err);
+
+        let cases = ["[\n    \n  ]", "[]"];
+        for case in cases {
+            let actual_err = array_expression(case).unwrap_err();
+            let expected_err = nom::Err::Error(nom::error::Error {
+                input: "]",
+                code: nom::error::ErrorKind::Char,
+            });
+            assert_eq!(actual_err, expected_err);
+        }
+    }
+
+    #[test]
+    fn test_valid_numeric_literals() {
+        let cases = [
+            "1u8", "2u16", "3u32", "4u64", "4u128", "5i8", "6i16", "7i32", "8i64", "9i128",
+            "1field", "2group", "3scalar",
+        ];
+
+        for case in cases {
+            let (rest, consumed) = numeric_literal(case).unwrap();
+            assert_eq!(rest, "");
+            assert_eq!(consumed, &case[0..1]);
+        }
+    }
+
+    #[test]
+    fn test_invalid_numeric_literals() {
+        let case = "1u7";
+        let actual_err = numeric_literal(case).unwrap_err();
+        let expected_err = nom::Err::Error(nom::error::Error {
+            input: "u7",
+            code: nom::error::ErrorKind::Tag,
+        });
+        assert_eq!(actual_err, expected_err);
+
+        let case = "au16";
+        let actual_err = numeric_literal(case).unwrap_err();
+        let expected_err = nom::Err::Error(nom::error::Error {
+            input: case,
+            code: nom::error::ErrorKind::Digit,
+        });
+        assert_eq!(actual_err, expected_err);
+
+        let case = "3j32";
+        let actual_err = numeric_literal(case).unwrap_err();
+        let expected_err = nom::Err::Error(nom::error::Error {
+            input: "j32",
+            code: nom::error::ErrorKind::Tag,
+        });
+        assert_eq!(actual_err, expected_err);
+
+        let case = "10feld";
+        let actual_err = numeric_literal(case).unwrap_err();
+        let expected_err = nom::Err::Error(nom::error::Error {
+            input: "feld",
+            code: nom::error::ErrorKind::Tag,
+        });
+        assert_eq!(actual_err, expected_err);
+
+        let case = "11goup";
+        let actual_err = numeric_literal(case).unwrap_err();
+        let expected_err = nom::Err::Error(nom::error::Error {
+            input: "goup",
+            code: nom::error::ErrorKind::Tag,
+        });
+        assert_eq!(actual_err, expected_err);
+
+        let case = "12scala";
+        let actual_err = numeric_literal(case).unwrap_err();
+        let expected_err = nom::Err::Error(nom::error::Error {
+            input: "scala",
+            code: nom::error::ErrorKind::Tag,
+        });
+        assert_eq!(actual_err, expected_err);
+    }
+
+    #[test]
+    fn test_valid_boolean_literals() {
+        let cases = ["true", "false"];
+
+        for case in cases {
+            let (rest, consumed) = boolean_literal(case).unwrap();
+            assert_eq!(rest, "");
+            assert_eq!(consumed, format!("\"{case}\""));
+        }
+    }
+
+    #[test]
+    fn test_invalid_boolean_literals() {
+        let cases = [
+            "True",
+            "False",
+            "TRUE",
+            "FALSE",
+            "truE",
+            "falsE",
+            "sth_else_entirely",
+        ];
+
+        for case in cases {
+            let actual_err = boolean_literal(case).unwrap_err();
+            let expected_err = nom::Err::Error(nom::error::Error {
+                input: case,
+                code: nom::error::ErrorKind::Tag,
+            });
+            assert_eq!(actual_err, expected_err);
+        }
+    }
+
+    #[test]
+    fn test_valid_explicit_address() {
+        let address = "aleo17m3l8a4hmf3wypzkf5lsausfdwq9etzyujd0vmqh35ledn2sgvqqzqkqal";
+        let (rest, consumed) = explicit_address_literal(address).unwrap();
+
+        assert_eq!(rest, "");
+        assert_eq!(consumed, format!("\"{address}\""));
+    }
+
+    #[test]
+    fn test_invalid_too_short_explicit_address() {
+        let short_address = "aleo17m3l8a4hmf3wypzkf5lsausfdwq9etzyujd0vmqh35ledn2sgvqqzqkqa";
+        let actual_err = explicit_address_literal(short_address).unwrap_err();
+        let expected_err = nom::Err::Error(nom::error::Error {
+            input: &short_address[5..],
+            code: nom::error::ErrorKind::TakeWhileMN,
+        });
+
+        assert_eq!(actual_err, expected_err);
+    }
+
+    #[test]
+    fn test_invalid_too_long_explicit_address() {
+        let long_address = "aleo17m3l8a4hmf3wypzkf5lsausfdwq9etzyujd0vmqh35ledn2sgvqqzqkqall";
+        let expected = format!("\"{}\"", &long_address[..long_address.len() - 1]);
+        let (rest, consumed) = explicit_address_literal(long_address).unwrap();
+        assert_eq!(rest, "l");
+        assert_eq!(consumed, expected);
+    }
+
+    #[test]
+    fn test_invalid_disallowed_chars_explicit_address() {
+        let disallowed_chars_address =
+            "aleo17m3l8a4hmf3wypZKF5LSAUSFDWQ9ETzyujd0vmqh35ledn2sgvqqzqkqa";
+        let actual_err = explicit_address_literal(disallowed_chars_address).unwrap_err();
+        let expected_err = nom::Err::Error(nom::error::Error {
+            input: &disallowed_chars_address[5..],
+            code: nom::error::ErrorKind::TakeWhileMN,
+        });
+
+        assert_eq!(actual_err, expected_err);
+    }
+
+    #[test]
+    fn test_is_ascii_lowercase_or_ascii_digit() {
+        assert!(is_ascii_lowercase_or_ascii_digit('i'));
+        assert!(is_ascii_lowercase_or_ascii_digit('2'));
+        assert!(!is_ascii_lowercase_or_ascii_digit('J'));
+        assert!(!is_ascii_lowercase_or_ascii_digit('.'));
+        assert!(!is_ascii_lowercase_or_ascii_digit('$'));
+        assert!(!is_ascii_lowercase_or_ascii_digit('\t'));
+    }
+}

--- a/ampd/src/aleo/mod.rs
+++ b/ampd/src/aleo/mod.rs
@@ -1,0 +1,4 @@
+pub(crate) mod http_client;
+mod json_like;
+mod parser;
+pub(crate) mod verifier;

--- a/ampd/src/aleo/parser.rs
+++ b/ampd/src/aleo/parser.rs
@@ -1,0 +1,138 @@
+use aleo_gateway::StringEncoder;
+use error_stack::ResultExt;
+use pest::iterators::Pair;
+use pest::Parser;
+use pest_derive::Parser;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Parser)]
+#[grammar = "aleo-json-like-format.pest"]
+struct AleoParser;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Pest: {0}")]
+    Pest(#[from] Box<pest::error::Error<Rule>>),
+    #[error("AleoParser: {0}")]
+    AleoParser(String),
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) enum AleoValue<'a> {
+    Object(Vec<(&'a str, AleoValue<'a>)>),
+    Array(Vec<AleoValue<'a>>),
+    String(&'a str),
+    Number(u128),
+    Boolean(bool),
+    Null,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct CallContract {
+    pub(crate) caller: String,
+    pub(crate) sender: String,
+    pub(crate) destination_chain: Vec<u128>,
+    pub(crate) destination_address: Vec<u128>,
+}
+
+impl CallContract {
+    pub fn destination_chain(&self) -> String {
+        let encoded_string = StringEncoder {
+            buf: self.destination_chain.clone(),
+        };
+        encoded_string.decode()
+    }
+
+    pub fn destination_address(&self) -> Result<String, error_stack::Report<Error>> {
+        let encoded_string = StringEncoder {
+            buf: self.destination_address.clone(),
+        };
+        let ascii_string = encoded_string.decode();
+        Ok(ascii_string)
+    }
+}
+
+fn parse(input: &str) -> Result<Option<Pair<Rule>>, Error> {
+    Ok(AleoParser::parse(Rule::aleo, input)
+        .map_err(Box::new)?
+        .next())
+}
+
+#[allow(dead_code)]
+pub(crate) fn generic_parse(input: &str) -> Result<AleoValue, Error> {
+    let aleo = parse(input)?.ok_or(Error::AleoParser("Empty input".to_string()))?;
+
+    fn parse_value(pair: Pair<Rule>) -> AleoValue {
+        match pair.as_rule() {
+            Rule::object => AleoValue::Object(
+                pair.into_inner()
+                    .flat_map(|pair| {
+                        let mut inner_rules = pair.into_inner();
+                        let name = inner_rules.next().unwrap().as_str();
+                        let value = parse_value(inner_rules.next().unwrap());
+                        Some((name, value))
+                    })
+                    .collect(),
+            ),
+            Rule::array => AleoValue::Array(pair.into_inner().map(parse_value).collect()),
+            Rule::number => AleoValue::Number(
+                pair.as_str()
+                    .replace("u8", "")
+                    .replace("u128", "")
+                    .parse()
+                    .unwrap(),
+            ),
+            Rule::boolean => AleoValue::Boolean(pair.as_str().parse().unwrap()),
+            Rule::null => AleoValue::Null,
+            Rule::aleo_address => AleoValue::String(pair.as_str()),
+            Rule::pair | Rule::value | Rule::key | Rule::aleo | Rule::WHITESPACE | Rule::EOI => {
+                unreachable!()
+            }
+        }
+    }
+
+    Ok(parse_value(aleo))
+}
+
+fn parse_array(pair: Pair<Rule>) -> Vec<u128> {
+    pair.into_inner()
+        .map(|p| p.as_str().replace("u128", "").parse::<u128>().unwrap())
+        .collect()
+}
+
+pub fn parse_call_contract(input: &str) -> Option<CallContract> {
+    // println!("Parsing: {}", input);
+    // println!("parse: {:?}", parse(input));
+    let pair = parse(input).ok().flatten()?;
+    // println!("Pair: {:?}", pair);
+
+    let mut caller = String::new();
+    let mut sender = String::new();
+    let mut destination_chain = Vec::new();
+    let mut destination_address = Vec::new();
+
+    for field in pair.into_inner() {
+        if field.as_rule() == Rule::pair {
+            let mut inner = field.into_inner();
+            let key = inner.next()?.as_str();
+            let value = inner.next()?;
+
+            match key {
+                "caller" => caller = value.as_str().to_string(),
+                "sender" => sender = value.as_str().to_string(),
+                "destination_chain" => destination_chain = parse_array(value),
+                "destination_address" => destination_address = parse_array(value),
+                _ => {}
+            }
+        }
+    }
+
+    Some(CallContract {
+        caller,
+        sender,
+        destination_chain,
+        destination_address,
+    })
+}

--- a/ampd/src/aleo/parser.rs
+++ b/ampd/src/aleo/parser.rs
@@ -1,5 +1,4 @@
 use aleo_gateway::StringEncoder;
-use error_stack::ResultExt;
 use pest::iterators::Pair;
 use pest::Parser;
 use pest_derive::Parser;
@@ -103,10 +102,7 @@ fn parse_array(pair: Pair<Rule>) -> Vec<u128> {
 }
 
 pub fn parse_call_contract(input: &str) -> Option<CallContract> {
-    // println!("Parsing: {}", input);
-    // println!("parse: {:?}", parse(input));
     let pair = parse(input).ok().flatten()?;
-    // println!("Pair: {:?}", pair);
 
     let mut caller = String::new();
     let mut sender = String::new();

--- a/ampd/src/aleo/verifier.rs
+++ b/ampd/src/aleo/verifier.rs
@@ -5,7 +5,6 @@ use super::http_client::Receipt;
 use crate::handlers::aleo_verify_msg::Message;
 
 fn verify(
-    // _gateway_address: &Program, // TODO: use this
     receipt: &Receipt,
     msg: &Message,
 ) -> Vote {

--- a/ampd/src/aleo/verifier.rs
+++ b/ampd/src/aleo/verifier.rs
@@ -1,0 +1,33 @@
+use axelar_wasm_std::voting::Vote;
+use tracing::warn;
+
+use super::http_client::Receipt;
+use crate::handlers::aleo_verify_msg::Message;
+
+fn verify(
+    // _gateway_address: &Program, // TODO: use this
+    receipt: &Receipt,
+    msg: &Message,
+) -> Vote {
+    let res = match receipt {
+        Receipt::Found(transition_receipt) => transition_receipt == msg,
+        Receipt::NotFound(transition, e) => {
+            warn!("AleoMessageId: {:?} is not verified: {:?}", transition, e);
+
+            false
+        }
+    };
+
+    match res {
+        true => Vote::SucceededOnChain,
+        false => Vote::FailedOnChain,
+    }
+}
+
+pub fn verify_message(
+    // _gateway_address: &Program,
+    receipt: &Receipt,
+    msg: &Message,
+) -> Vote {
+    verify(receipt, msg)
+}

--- a/ampd/src/commands/register_public_key.rs
+++ b/ampd/src/commands/register_public_key.rs
@@ -101,9 +101,7 @@ pub async fn run(config: Config, args: Args) -> Result<Option<String>, Error> {
     .into_any()
     .expect("failed to serialize proto message");
 
-    println!("11: {:?}", pub_key);
     let tx_hash = broadcast_tx(config, tx, pub_key).await?.txhash;
-    println!("12");
 
     Ok(Some(format!(
         "successfully broadcast register public key transaction, tx hash: {}",

--- a/ampd/src/commands/register_public_key.rs
+++ b/ampd/src/commands/register_public_key.rs
@@ -21,6 +21,7 @@ use crate::{handlers, Error, PREFIX};
 enum KeyType {
     Ecdsa,
     Ed25519,
+    AleoSchnorr,
 }
 
 impl From<KeyType> for tofnd::Algorithm {
@@ -28,6 +29,7 @@ impl From<KeyType> for tofnd::Algorithm {
         match val {
             KeyType::Ecdsa => tofnd::Algorithm::Ecdsa,
             KeyType::Ed25519 => tofnd::Algorithm::Ed25519,
+            KeyType::AleoSchnorr => tofnd::Algorithm::AleoSchnorr,
         }
     }
 }
@@ -37,6 +39,7 @@ impl From<KeyType> for multisig::key::KeyType {
         match val {
             KeyType::Ecdsa => multisig::key::KeyType::Ecdsa,
             KeyType::Ed25519 => multisig::key::KeyType::Ed25519,
+            KeyType::AleoSchnorr => multisig::key::KeyType::AleoSchnorr,
         }
     }
 }
@@ -98,7 +101,9 @@ pub async fn run(config: Config, args: Args) -> Result<Option<String>, Error> {
     .into_any()
     .expect("failed to serialize proto message");
 
+    println!("11: {:?}", pub_key);
     let tx_hash = broadcast_tx(config, tx, pub_key).await?.txhash;
+    println!("12");
 
     Ok(Some(format!(
         "successfully broadcast register public key transaction, tx hash: {}",

--- a/ampd/src/handlers/aleo_verify_msg.rs
+++ b/ampd/src/handlers/aleo_verify_msg.rs
@@ -1,0 +1,307 @@
+use std::collections::{HashMap, HashSet};
+use std::str::FromStr;
+
+use aleo_types::address::Address as AleoAddress;
+use aleo_types::program::Program;
+use aleo_types::transition::Transition;
+use async_trait::async_trait;
+use axelar_wasm_std::voting::{PollId, Vote};
+use cosmrs::cosmwasm::MsgExecuteContract;
+use cosmrs::tx::Msg;
+use events::Error::EventTypeMismatch;
+use events::Event;
+use events_derive::try_from;
+use futures::stream::{self, StreamExt};
+use prost_types::Any;
+use router_api::ChainName;
+use serde::{Deserialize, Serialize};
+use tokio::sync::watch::Receiver;
+use tracing::{debug, info, info_span};
+use valuable::Valuable;
+use voting_verifier::msg::ExecuteMsg;
+
+use crate::aleo::http_client::{
+    ClientTrait as AleoClientTrait, ClientWrapper as AleoClientWrapper, Receipt,
+};
+use crate::event_processor::EventHandler;
+use crate::handlers::errors::Error;
+use crate::handlers::errors::Error::DeserializeEvent;
+use crate::types::{Hash, TMAddress};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Message {
+    pub tx_id: Transition,
+    pub destination_address: String,
+    pub destination_chain: ChainName,
+    pub source_address: AleoAddress,
+    pub payload_hash: Hash,
+}
+
+#[derive(Deserialize, Debug)]
+#[try_from("wasm-messages_poll_started")]
+struct PollStartedEvent {
+    poll_id: PollId,
+    source_chain: ChainName,
+    source_gateway_address: Program,
+    expires_at: u64,
+    participants: Vec<TMAddress>,
+    messages: Vec<Message>,
+}
+
+#[derive(Clone)]
+pub struct Handler<C: AleoClientTrait> {
+    verifier: TMAddress,
+    voting_verifier_contract: TMAddress,
+    http_client: C,
+    latest_block_height: Receiver<u64>,
+    chain: ChainName,
+    gateway_contract: String,
+}
+
+impl<C> Handler<C>
+where
+    C: AleoClientTrait + Send + Sync,
+{
+    pub fn new(
+        verifier: TMAddress,
+        voting_verifier_contract: TMAddress,
+        aleo_client: C,
+        latest_block_height: Receiver<u64>,
+        gateway_contract: String,
+    ) -> Self {
+        Self {
+            verifier,
+            voting_verifier_contract,
+            http_client: aleo_client,
+            latest_block_height,
+            chain: ChainName::from_str("aleo-2").unwrap(),
+            gateway_contract,
+        }
+    }
+
+    fn vote_msg(&self, poll_id: PollId, votes: Vec<Vote>) -> MsgExecuteContract {
+        MsgExecuteContract {
+            sender: self.verifier.as_ref().clone(),
+            contract: self.voting_verifier_contract.as_ref().clone(),
+            msg: serde_json::to_vec(&ExecuteMsg::Vote { poll_id, votes })
+                .expect("vote msg should serialize"),
+            funds: vec![],
+        }
+    }
+}
+
+#[async_trait]
+impl<C> EventHandler for Handler<C>
+where
+    C: AleoClientTrait + Send + Sync + 'static,
+{
+    type Err = Error;
+
+    #[tracing::instrument(skip(self, event))]
+    async fn handle(&self, event: &Event) -> error_stack::Result<Vec<Any>, Self::Err> {
+        debug!("event: {event:?}");
+        if !event.is_from_contract(self.voting_verifier_contract.as_ref()) {
+            return Ok(vec![]);
+        }
+
+        let PollStartedEvent {
+            poll_id,
+            source_chain,
+            source_gateway_address: _,
+            expires_at,
+            participants,
+            messages,
+        } = match event.try_into() as error_stack::Result<_, _> {
+            Err(report) if matches!(report.current_context(), EventTypeMismatch(_)) => {
+                return Ok(vec![])
+            }
+            event => event.change_context(DeserializeEvent)?,
+        };
+
+        if self.chain != source_chain {
+            return Ok(vec![]);
+        }
+
+        if !participants.contains(&self.verifier) {
+            return Ok(vec![]);
+        }
+
+        if *self.latest_block_height.borrow() >= expires_at {
+            info!(poll_id = poll_id.to_string(), "skipping expired poll");
+            return Ok(vec![]);
+        }
+
+        let transitions: HashSet<Transition> = messages.iter().map(|m| m.tx_id.clone()).collect();
+
+        let http_client = AleoClientWrapper::new(&self.http_client);
+        let transition_receipts: HashMap<_, _> = stream::iter(transitions)
+            .map(|id| async {
+                match http_client
+                    .transition_receipt(&id, self.gateway_contract.as_str())
+                    .await
+                {
+                    Ok(recipt) => (id, recipt),
+                    Err(e) => (id.clone(), Receipt::NotFound(id, e)),
+                }
+            })
+            .buffer_unordered(10)
+            .collect()
+            .await;
+
+        let poll_id_str: String = poll_id.into();
+        let source_chain_str: String = source_chain.into();
+        let votes = info_span!(
+            "verify messages from an Aleo chain",
+            poll_id = poll_id_str,
+            source_chain = source_chain_str,
+            message_ids = messages
+                .iter()
+                .map(|msg| msg.tx_id.as_ref())
+                .collect::<Vec<&str>>()
+                .as_value(),
+        )
+        .in_scope(|| {
+            info!("ready to verify messages in poll");
+
+            let votes: Vec<_> = messages
+                .iter()
+                .map(|msg| {
+                    transition_receipts
+                        .get(&msg.tx_id)
+                        .map_or(Vote::NotFound, |tx_receipt| {
+                            crate::aleo::verifier::verify_message(tx_receipt, msg)
+                        })
+                })
+                .collect();
+            info!(
+                votes = votes.as_value(),
+                "ready to vote for messages in poll"
+            );
+
+            votes
+        });
+
+        println!("{:?}", votes);
+        Ok(vec![self
+            .vote_msg(poll_id, votes)
+            .into_any()
+            .expect("vote msg should serialize")])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use cosmrs::AccountId;
+    // use multisig::msg::ExecuteMsg;
+    use router_api::Address;
+    use voting_verifier::events::{PollMetadata, PollStarted, TxEventConfirmation};
+
+    use super::*;
+    use crate::types::TMAddress;
+
+    fn poll_started_event() -> Event {
+        let expires_at: u64 = 10;
+        let participants: Vec<TMAddress> = vec![AccountId::from_str(
+            "axelar1a9d3a3hcykzfa8rn3y7d47ns55x3wdlykchydd8x3f95dtz9qh0q3vnrg0",
+        )
+        .unwrap()
+        .into()];
+        let messages: Vec<Message> = vec![Message {
+            tx_id: Transition::from_str(
+                "au17kdp7a7p6xuq6h0z3qrdydn4f6fjaufvzvlgkdd6vzpr87lgcgrq8qx6st",
+            )
+            .unwrap(),
+            destination_address: "dapp20250123exec.aleo".to_string(),
+            destination_chain: ChainName::from_str("aleo-2").unwrap(),
+            source_address: AleoAddress::from_str(
+                "aleo1ejcm4cpwcjtenxlg37utj8dn7s88xs5asvl5u25w4udkd7e7dcpqvaeyaz",
+            )
+            .unwrap(),
+            payload_hash: Hash::from_str(
+                "d1af832424763b0b7692605ebfbdd461cc5f4d560228e06b4b6e6191c9e6fb08",
+            )
+            .unwrap(),
+        }];
+
+        let v: Vec<(String, serde_json::Value)> = vec![
+            (
+                "poll_id".to_string(),
+                serde_json::to_value(PollId::from(100)).unwrap(),
+            ),
+            (
+                "_contract_address".to_string(),
+                serde_json::to_value(
+                    "axelar1a9d3a3hcykzfa8rn3y7d47ns55x3wdlykchydd8x3f95dtz9qh0q3vnrg0",
+                )
+                .unwrap(),
+            ),
+            (
+                "source_chain".to_string(),
+                serde_json::to_value("aleo-2").unwrap(),
+            ),
+            (
+                "source_gateway_address".to_string(),
+                serde_json::to_value(Program::from_str("vzevxifdoj.aleo").unwrap()).unwrap(),
+            ),
+            (
+                "expires_at".to_string(),
+                serde_json::to_value(expires_at).unwrap(),
+            ),
+            (
+                "participants".to_string(),
+                serde_json::to_value(participants).unwrap(),
+            ),
+            (
+                "messages".to_string(),
+                serde_json::to_value(messages).unwrap(),
+            ),
+        ];
+
+        let json_map: serde_json::Map<String, serde_json::Value> = v.into_iter().collect();
+
+        Event::Abci {
+            event_type: "wasm-messages_poll_started".to_string(),
+            attributes: json_map,
+        }
+    }
+
+    use cosmrs::proto::cosmwasm::wasm::v1::MsgExecuteContract;
+    use prost::Message as _;
+
+    #[tokio::test]
+    async fn aleo_verify_msg() {
+        let mock_client = crate::aleo::http_client::tests::mock_client_3();
+        let event = poll_started_event();
+
+        let handler = Handler::new(
+            TMAddress::from(
+                AccountId::from_str(
+                    "axelar1a9d3a3hcykzfa8rn3y7d47ns55x3wdlykchydd8x3f95dtz9qh0q3vnrg0",
+                )
+                .unwrap(),
+            ),
+            TMAddress::from(
+                AccountId::from_str(
+                    "axelar1a9d3a3hcykzfa8rn3y7d47ns55x3wdlykchydd8x3f95dtz9qh0q3vnrg0",
+                )
+                .unwrap(),
+            ),
+            mock_client,
+            tokio::sync::watch::channel(0).1,
+            "ac64caccf8221554ec3f89bf.aleo".to_string(),
+        );
+
+        let res = handler.handle(&event).await.unwrap();
+        let res: Vec<MsgExecuteContract> = res
+            .iter()
+            .map(|msg| MsgExecuteContract::decode(msg.value.as_slice()).unwrap())
+            .collect();
+
+        for r in res {
+            let decode: ExecuteMsg = serde_json::from_slice(&r.msg).unwrap();
+            println!("vote: {:?}", decode);
+        }
+    }
+}

--- a/ampd/src/handlers/aleo_verify_msg.rs
+++ b/ampd/src/handlers/aleo_verify_msg.rs
@@ -128,6 +128,7 @@ where
             return Ok(vec![]);
         }
 
+        // Transition IDs on Aleo chain
         let transitions: HashSet<Transition> = messages.iter().map(|m| m.tx_id.clone()).collect();
 
         let http_client = AleoClientWrapper::new(&self.http_client);
@@ -191,9 +192,6 @@ mod tests {
     use std::str::FromStr;
 
     use cosmrs::AccountId;
-    // use multisig::msg::ExecuteMsg;
-    use router_api::Address;
-    use voting_verifier::events::{PollMetadata, PollStarted, TxEventConfirmation};
     use aleo_types::program::Program;
 
     use super::*;

--- a/ampd/src/handlers/aleo_verify_msg.rs
+++ b/ampd/src/handlers/aleo_verify_msg.rs
@@ -2,7 +2,6 @@ use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 
 use aleo_types::address::Address as AleoAddress;
-use aleo_types::program::Program;
 use aleo_types::transition::Transition;
 use async_trait::async_trait;
 use axelar_wasm_std::voting::{PollId, Vote};
@@ -42,7 +41,6 @@ pub struct Message {
 struct PollStartedEvent {
     poll_id: PollId,
     source_chain: ChainName,
-    source_gateway_address: Program,
     expires_at: u64,
     participants: Vec<TMAddress>,
     messages: Vec<Message>,
@@ -107,7 +105,6 @@ where
         let PollStartedEvent {
             poll_id,
             source_chain,
-            source_gateway_address: _,
             expires_at,
             participants,
             messages,

--- a/ampd/src/handlers/aleo_verify_msg.rs
+++ b/ampd/src/handlers/aleo_verify_msg.rs
@@ -194,6 +194,7 @@ mod tests {
     // use multisig::msg::ExecuteMsg;
     use router_api::Address;
     use voting_verifier::events::{PollMetadata, PollStarted, TxEventConfirmation};
+    use aleo_types::program::Program;
 
     use super::*;
     use crate::types::TMAddress;

--- a/ampd/src/handlers/config.rs
+++ b/ampd/src/handlers/config.rs
@@ -22,6 +22,16 @@ with_prefix!(chain "chain_");
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(tag = "type")]
 pub enum Config {
+    AleoMsgVerifier {
+        cosmwasm_contract: TMAddress,
+        #[serde(flatten, with = "chain")]
+        chain: Chain,
+        timeout: Option<Duration>,
+        base_url: String,
+        network: String,
+        gateway_contract: String,
+    },
+    AleoVerifierSetVerifier {},
     EvmMsgVerifier {
         cosmwasm_contract: TMAddress,
         #[serde(flatten, with = "chain")]
@@ -158,6 +168,12 @@ where
         &configs,
         Config::StellarVerifierSetVerifier,
         "Stellar verifier set verifier"
+    )?;
+    ensure_unique_config!(&configs, Config::AleoMsgVerifier, "Aleo message verifier")?;
+    ensure_unique_config!(
+        &configs,
+        Config::AleoVerifierSetVerifier,
+        "Aleo verifier set verifier"
     )?;
 
     Ok(configs)

--- a/ampd/src/handlers/mod.rs
+++ b/ampd/src/handlers/mod.rs
@@ -1,3 +1,4 @@
+pub mod aleo_verify_msg;
 pub mod config;
 mod errors;
 pub mod evm_verify_msg;

--- a/ampd/src/handlers/multisig.rs
+++ b/ampd/src/handlers/multisig.rs
@@ -154,8 +154,6 @@ where
                     .await
                     .change_context(Error::Sign)?;
 
-                info!("signing key: {}", pub_key);
-                println!("--> signing key: {}", pub_key);
                 info!(signature = encode(&signature), "ready to submit signature");
 
                 Ok(vec![self

--- a/ampd/src/handlers/multisig.rs
+++ b/ampd/src/handlers/multisig.rs
@@ -140,6 +140,7 @@ where
                 let key_type = match pub_key {
                     PublicKey::Secp256k1(_) => tofnd::Algorithm::Ecdsa,
                     PublicKey::Ed25519(_) => tofnd::Algorithm::Ed25519,
+                    PublicKey::AleoSchnorr(_) => tofnd::Algorithm::AleoSchnorr,
                 };
 
                 let signature = self
@@ -153,6 +154,8 @@ where
                     .await
                     .change_context(Error::Sign)?;
 
+                info!("signing key: {}", pub_key);
+                println!("--> signing key: {}", pub_key);
                 info!(signature = encode(&signature), "ready to submit signature");
 
                 Ok(vec![self

--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -26,6 +26,7 @@ use types::{CosmosPublicKey, TMAddress};
 
 use crate::config::Config;
 
+mod aleo;
 mod asyncutil;
 mod block_height_monitor;
 mod broadcaster;
@@ -60,6 +61,7 @@ pub async fn run(cfg: Config) -> Result<(), Error> {
 }
 
 async fn prepare_app(cfg: Config) -> Result<App<impl Broadcaster>, Error> {
+    info!(config = ?cfg, "ampd config");
     let Config {
         tm_jsonrpc,
         tm_grpc,
@@ -220,6 +222,36 @@ where
     ) -> Result<App<T>, Error> {
         for config in handler_configs {
             let task = match config {
+                handlers::config::Config::AleoMsgVerifier {
+                    cosmwasm_contract,
+                    chain,
+                    timeout,
+                    base_url,
+                    network,
+                    gateway_contract,
+                } => {
+                    let rest_client = reqwest::ClientBuilder::new()
+                        .connect_timeout(timeout.unwrap_or(DEFAULT_RPC_TIMEOUT))
+                        .timeout(timeout.unwrap_or(DEFAULT_RPC_TIMEOUT))
+                        .build()
+                        .change_context(Error::Connection)?;
+
+                    let client =
+                        aleo::http_client::Client::new(rest_client, base_url, network).unwrap();
+
+                    self.create_handler_task(
+                        format!("{}-msg-verifier", chain.name),
+                        handlers::aleo_verify_msg::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract,
+                            client,
+                            self.block_height_monitor.latest_block_height(),
+                            gateway_contract,
+                        ),
+                        event_processor_config.clone(),
+                    )
+                }
+                handlers::config::Config::AleoVerifierSetVerifier {} => todo!(),
                 handlers::config::Config::EvmMsgVerifier {
                     chain,
                     cosmwasm_contract,

--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -61,7 +61,6 @@ pub async fn run(cfg: Config) -> Result<(), Error> {
 }
 
 async fn prepare_app(cfg: Config) -> Result<App<impl Broadcaster>, Error> {
-    info!(config = ?cfg, "ampd config");
     let Config {
         tm_jsonrpc,
         tm_grpc,

--- a/ampd/src/tests/at14gry4nauteg5sp00p6d2pj93dhpsm5857ml8y3xg57nkpszhav9qk0tgvd.json
+++ b/ampd/src/tests/at14gry4nauteg5sp00p6d2pj93dhpsm5857ml8y3xg57nkpszhav9qk0tgvd.json
@@ -1,0 +1,94 @@
+{
+  "type": "execute",
+  "id": "at14gry4nauteg5sp00p6d2pj93dhpsm5857ml8y3xg57nkpszhav9qk0tgvd",
+  "execution": {
+    "transitions": [
+      {
+        "id": "au17kdp7a7p6xuq6h0z3qrdydn4f6fjaufvzvlgkdd6vzpr87lgcgrq8qx6st",
+        "program": "ac64caccf8221554ec3f89bf.aleo",
+        "function": "callContract",
+        "inputs": [
+          {
+            "type": "private",
+            "id": "4506794751978666942736358016482449104670360224623969523522068849727798584240field",
+            "value": "ciphertext1qgq0mjwxxzh48885h4cuxuw6fshpgakqa9qhnu6a9rdk9p5msgtpszpe33m9j4l2k3qafxrsl28lu805quqk909k4x3k6l5p3hzukr0jq5uwvuyz"
+          },
+          {
+            "type": "private",
+            "id": "6553643553121616581089393710876048450794689508494844503652432369458535457322field",
+            "value": "ciphertext1qvqzsya70u0r2c2em6f5engyqk9p6dkdd0u9mkq8x5n63253cpaekrt2n5x0gcmn0q5jkvssyzv7te889vey9543zsr4gecf6uz4le65peg6auh7st353re8520qwxrh6jgyu2ks6wdsj7ekykkfjrucgfwsw622yuw"
+          }
+        ],
+        "outputs": [
+          {
+            "type": "public",
+            "id": "5198165098266584115042188119258592537018894072610320773254549635412897837755field",
+            "value": "{\n  caller: aleo1u05hx0kc9sgdt6m6nwcefeufnzrymsy32k8hlhy6f6y9hjhdtc9q2qlg0y,\n  sender: aleo1ejcm4cpwcjtenxlg37utj8dn7s88xs5asvl5u25w4udkd7e7dcpqvaeyaz,\n  destination_chain: [\n    129497940983541880690546129557858025472u128,\n    0u128\n  ],\n  destination_address: [\n    133428732892731792184924403750533621091u128,\n    61650339138018452844815768796358770688u128,\n    0u128,\n    0u128\n  ]\n}"
+          }
+        ],
+        "tpk": "1024835507092414504602990539602839664127722571605653964533034405014100451808group",
+        "tcm": "1712492227995560819931917274182886020256414117504929363697235681151685897046field",
+        "scm": "96986057764107205072777350853803571613175575298060644889200520581395201840field"
+      },
+      {
+        "id": "au1kg5es3twgzxhtqmnz03hkzr483v3j8ywza2pn5s7dsz865aatcgsutzx5f",
+        "program": "dapp20250123exec.aleo",
+        "function": "main",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "public",
+            "id": "4741492246060139484226233939103138461689801026840406196551740691917867615688field",
+            "value": "{\n  caller: aleo1u05hx0kc9sgdt6m6nwcefeufnzrymsy32k8hlhy6f6y9hjhdtc9q2qlg0y,\n  sender: aleo1ejcm4cpwcjtenxlg37utj8dn7s88xs5asvl5u25w4udkd7e7dcpqvaeyaz,\n  destination_chain: [\n    129497940983541880690546129557858025472u128,\n    0u128\n  ],\n  destination_address: [\n    133428732892731792184924403750533621091u128,\n    61650339138018452844815768796358770688u128,\n    0u128,\n    0u128\n  ]\n}"
+          },
+          {
+            "type": "public",
+            "id": "2477496325996592645572761852411749891720819437213224502532297589826996840349field",
+            "value": "[\n  72u8,\n  101u8,\n  108u8,\n  108u8,\n  111u8,\n  44u8,\n  32u8,\n  87u8,\n  111u8,\n  114u8,\n  108u8,\n  100u8,\n  33u8\n]"
+          }
+        ],
+        "tpk": "72284650682390598440537984135460096292809195103591315145413030482196927407group",
+        "tcm": "8030110741171727132847899826109190573589985712562088852789714396765883495470field",
+        "scm": "96986057764107205072777350853803571613175575298060644889200520581395201840field"
+      }
+    ],
+    "global_state_root": "sr1mhqpsc2yuc48dpqc8ckmh5cvqtq2w4gcgrpw33jm28cp3sqy4uqqy8z8gj",
+    "proof": "proof1qypqqqqqqqqqqqqpqqqqqqqqqqqqzqqqqqqqqqqq4rpnas64s049ydyx27pxak9dy8q3e8fwx75qt3la4dr5407xggf23jck87ljk4lqv5q022l23jmgq8vd0mfcdh4ccghrkl4d39d69errldn78ca3c6gm3ffsuuk7zc3hs3yrcw7pl5093r3acs87hl4aqqqnkdnr9wdw2l8g8lnnxvd3lwdcck79ws09v3vqdqr6vwfrelsc7x4wkf7atrlf7k7jqlv5yyv3cnuqepaxsqgwyhu4lanl2z5rv3agu45dzkkgcjz87f4xdzq2q72xalx6mku944k38uchqsp8syll4a6srexeyga0qr8pgwnrzvqskktxalvjdemp8t5d94ndfe9tvdt2u7rk3yu2j3y30ym6mqsnvj02ztmps9lfe2hage4k7nf8z5kzzwc6yjaq2px6wz26vrwma09j65ndjxs78kj2gpwm0xl2s36pjxtrmchr0q2s8m2z23aw2x55jru5s90an943at328fls9rwgfx7n80vhkrm3yp344qp79pa04kpj3z6qvp3w6cq8cuyfeftmhry65hn0adpzucgetpty840nrpy4t3y9n93lz0u6lax088mctlq5el4e8nlpg40s75vpqfaglah2adlrh7v6yqmry5csnjrunqzeasuxyceycvchajgupnjc9jkrzv74xgsz3fu40eptf6vgpcjxv0rv5zt47dycf0twxvduw2v6arve8e4n274fkjlpdewyarsva0csu7y543a7p6uevssndujfs9ssadugv5g2cc50mjyl8kzzavhqmm4lskkhr5f9j39rw4hvklrd6yt7wauw28j2grdrvze704zxgqrdkakhjfs0v7gy9uzy2avfw9d65252spguznmftw25zlhag7f5kp5h7u824dx423ve5jkzzg7mtyqa3se6ln0ac7hmjjpztq6kzpq82gs7lafsrwskvvdzcath6znxlzszkedgza3hun9xmucrnl850pup5suvq9r4ks5ldy0qrul2pg2xza4f5uuepatshu39l9p28hwneqzmks0kzm54makhffjtuv988p0luapczemrh4dcztz457txv55q2pykj5sfutnnu4mg2p5r6pdanjjt2q8ezg0askmglzl6hv7cvz37q9h74xdqjjcwg8m0xdycn9l6xcavvrqqsd7v3phqcdl22npf9wqqggn5fgcn50la8rxu4vedwc356tv3ww9fqt9p4hc2jac7n5mnh3qscr6dn2grfmxgss5c3ll3046ystkmcv7jrwqm3quu7rdlv8580yzayjk493xmkv8ewru45yt58a2ue3ch84xttqyf7epc7293qmt5wz5s3n0h0gv9zm4quyu7ap0d3yrk20dkmj888c5m9ph3243xjva3qp9sqs946re02f7gq4e42976kt9xccnykxps93jpk5c53fu7axzquklzxqrrfq6aalr4qduzrzyzf8vrh58vsk4x9kh3lmgyjd7nuegsrperytvmc59uftseup3k6kq6rajxl979vs3qzvjg5ucymue2nuptw0pu52dnk3le3acwsdqvhr3a9xk9m5w56clwzukwgg5hwg0k7pcngmqzfgftc0a39xahpu7sqtz6kr7xvj4jk7e3at6wvk2clzgfzzsxrx0ycd3g6fnlsvqynusggr5jm6485vz0qqxmjzr6cwqedz5sv73kn5etzwr35nx680spjnecz55u7n0xnj8lmv3cn0qwe67c6rqrhh69x7q2yn4tm52sm2wu05p4gkr74789763c3m9x62e5dh8vwyzs52646zwpk94tlss4rffts93v03yevh6vc7698v8varlv0h3acp023kd6a5jfu2fgwllggxg4pdtla9yx3ggyuj7devnz4rkqjrzyzpt7m2jmwyc2exgy0hr3rr807k65lv6kvk2r08r8w0hlzgprklgs6qcqqqqqqqqqqpp3dr9td7xr24qtfcwymynmeds6fu829davyyc99fwha0f8xlc292ugyvczalgr8cchqg264s2v0qqqlqsptyztg5dru7r9fkuxwuqk9q9s2x8qv9cg2j5ut9024v5wjkq70kuaq4q50dghxvxh4gnk090cqqfujwe3rn65j7xrdk7wmvcezddeegxeryhspsnl0hhts79tsvrnqcz6zjt0pce5rrmwku2c5tszpzv3gcnhksfpk0z6zd7u7czpzmllcj0g40wketl9smjenscx05whcqqqcj6mcx"
+  },
+  "fee": {
+    "transition": {
+      "id": "au14zrmfzywg90ewrcztna8nm6978s83m3p3p5t5nntn77d0erlqursg7pqj6",
+      "program": "credits.aleo",
+      "function": "fee_public",
+      "inputs": [
+        {
+          "type": "public",
+          "id": "1698634579091845336004412195232622033211428534674365691019653483741616931081field",
+          "value": "2765u64"
+        },
+        {
+          "type": "public",
+          "id": "4278174104766262044586599232305835535068392222245066380567361696172665861198field",
+          "value": "0u64"
+        },
+        {
+          "type": "public",
+          "id": "8103625698150791772267429083519801573908725496498421405777656194572604237635field",
+          "value": "350431776171510437667514164146360025471399792910911390062796662451148314847field"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "future",
+          "id": "6682985090869323495749049381732313576051623426025561137373642641612087327295field",
+          "value": "{\n  program_id: credits.aleo,\n  function_name: fee_public,\n  arguments: [\n    aleo1ejcm4cpwcjtenxlg37utj8dn7s88xs5asvl5u25w4udkd7e7dcpqvaeyaz,\n    2765u64\n  ]\n}"
+        }
+      ],
+      "tpk": "2961007717274319108057575462847302440469779442732387336806356939595427367970group",
+      "tcm": "2682621962523983210208313203779144056117488475604299195661270048501793156244field",
+      "scm": "7293421052582321410945545328200190374213155021982137955508923154789860988657field"
+    },
+    "global_state_root": "sr1mhqpsc2yuc48dpqc8ckmh5cvqtq2w4gcgrpw33jm28cp3sqy4uqqy8z8gj",
+    "proof": "proof1qyqsqqqqqqqqqqqpqqqqqqqqqqq8mp2p32gn78vkt2q6mt70lh9sdw9kwj7d0awkdmlc6u920avwth56c6kue7cxl43y5tvgnhckvzuqqytvgn4svqh2shsmuf8dkwkghta9haepvqf3qpqx23y3zdk8jd02hu8p8lvj8qqhhp623ns46z3xcq8cdlhpnentutt5evd74x92ecw2ggkxu5yw373er0f8jwv42spwp6rauwc3ppzp2c5nyd9zzpshsgqevfv7cg329wnhtvjndk87aj4dn559ammtpntsyaev83ktnrvt4je9tjdyzp352y6l0w4nz3u5c0gpa0jrm2vllqfed27cqysrgk78ke72g2sfz98lzckjhp54kkzyuuqezq34nx8ve9486d5t756upxasp6fcmvgwde8ntq48j2lygvheusqprq3nf6ykrxh63kzntsltra5vn5nzfka5k5rrh5ez83m4rvt4qrj540dyx93nrtvmqhfh2zlw8c2ez0tz2u44gapgyn0p4ktt89w6r337ek7haqx6wh3q0jg64rcknqpggepcg0prp2re3vdhuyhpxhg8jkk4yh0gj7fjx8j4hx7pznvk3779kvp75h3mxl4fvs46qgwwfuqf0xvpj4daqc2u2ac5tmgtj6d6t6qrktnl5dyzrsqp6hsrs22nxv33emq93uy4pujj0ta7krsxtmqqts4kzv7u7rzq5r40tv97xzk3hurjzve4dmqs9egz4sl26xlnsvyypfr2thf8alxup435e46w6e4ujyygzqncq6udejt9gdvgahx3xppq6vnjsxy2ukyvdpcn27w65r23v9wzm07jjjh00ejncpkrtcdcpz244wzz2k5mdadawuqjucdxywdg5d08vm9qve3dsskme7x9vwfsza2an3mh4ls45gparcw9mde2h6g6g7q0swf5gtpcfhxjj8u3npg2gcn60s54ys4t877fz3t2pr0nqkc2d9yq8h0kcug4zd0h6q0srgzxvnyh6j0m5peakfgadnsct8qffmdajytsze0qure8ly2fveh62qqqxxnrrfle5v04xgt8hunj7t05vr465cpk5k4f57swl3s9fdfkpyzzu7ace7e8y6nd8wpncv7v6q0nzs6jkndrwz9e0jme7uarpzeq7mtyes0kgxqcrpfw8ce8d46gkrldmmjrz8xtnp6jytr92nt6qxgrqvqqqqqqqqqqpapsdxfzcfksxd99etjral44c4g4lrlfpqqnra22qchayhvytp8094r9w4hrvhh82f26f356slj3syqxgvqs0vf9rh586qvhh48gyvzcxfpkacvenmjyrpzkfpf02h2x60fmrgdsgy3w0pjvympxzd09py5qqygqpmh66mp4czhhzqdvmv3efwma5fkg9mey2rp5t2jjfwwaakfpp9kjl9ex86cdh0xsl77lemq2x40az239c80q88kwhqp8c23fq98ec5e0z9q2cfk73lxzpz6cl6t0syqq6p87lx"
+  }
+}

--- a/ampd/src/tests/at18c83pwjlvvjpdk95pudngzxqydvq92np206njcyppgndjalujsrshjn48j.json
+++ b/ampd/src/tests/at18c83pwjlvvjpdk95pudngzxqydvq92np206njcyppgndjalujsrshjn48j.json
@@ -1,0 +1,94 @@
+{
+  "type": "execute",
+  "id": "at18c83pwjlvvjpdk95pudngzxqydvq92np206njcyppgndjalujsrshjn48j",
+  "execution": {
+    "transitions": [
+      {
+        "id": "au1knlxwe55dx6cnm2j5sgtsl2z2z590jprme2t4cc49h85uv0emgrsuzvutv",
+        "program": "vzevxifdoj.aleo",
+        "function": "callContract",
+        "inputs": [
+          {
+            "type": "private",
+            "id": "3082805486204648103027411717085818951337036456565761589330238403410004436961field",
+            "value": "ciphertext1quqynvug2uy0xsy292mqz4muak6340juvx40s2kqwduc7qn9072fxpvraz5qty90k72dj00ecuhh9xsxdd6lxphstasscmffduchesczzx6vkwxes9tu24vgk926u3hux3gdmge7gzrmppj253a3j5zfy2eq2c38y7le80u0a3ve6tw32rp403c79lemzu39nw6yp54duqlnjzsjj7k3qgj7u4v6twmysv8342fc9m5tr0axvn70up8dqhla0wmnt5p8wa0s8gry45vh9pf3xn6t90mwus47mj5002r4z50kqqyp6j266pup85j6n7n9xayhvcjflx0r0xgsftac9kmh74asv6x48yqr9x3sqs0glure"
+          },
+          {
+            "type": "private",
+            "id": "4071849772370364269312712380952927735096606205457162952892391762677543770692field",
+            "value": "ciphertext1q5qxs5nnmdlkgt5dpqhnzllekz3h9fgfl0y9hlg4tgx43akz4zmxwpracuaj9evhwznqlgqua8yfvkewqh387tj8rykfge54uau4zhnvp5tjarnrr6vlt24x44y0tws26el35ykdee8tw3lamvyw4jwky8tsz904qjf0m8ux5zjrvyjedp0pndede00adyndss0qanpxyqmhhqc266laj7rm8y35fj2nkqm94w4y9y6j39pzep3kxds75apfglxq9c9sjf0jdh"
+          }
+        ],
+        "outputs": [
+          {
+            "type": "public",
+            "id": "3618238122949212728531166293731813068726732338798590767051403362579072462298field",
+            "value": "{\n  caller: aleo1fshc7vzla5jwwluvcl9r9vx0lr3h39c395qwz7jpf39ctpauqczq87h028,\n  sender: aleo1kevhe97umnpdf4y08qdz2wg249jzmv486vydtxpfus4l8hwk9c9qfguzgz,\n  destination_chain: [\n    69u8,\n    116u8,\n    104u8,\n    101u8,\n    114u8,\n    101u8,\n    117u8,\n    109u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8\n  ],\n  destination_address: [\n    18u8,\n    52u8,\n    86u8,\n    120u8,\n    144u8,\n    171u8,\n    205u8,\n    239u8,\n    18u8,\n    52u8,\n    86u8,\n    120u8,\n    144u8,\n    171u8,\n    205u8,\n    239u8,\n    18u8,\n    52u8,\n    86u8,\n    120u8\n  ]\n}"
+          }
+        ],
+        "tpk": "8069147505380028115402348333409825068905674036767988703340191771316883847781group",
+        "tcm": "5740401391828123610850017966717986130006111147621425743637474651322466308254field",
+        "scm": "3631498312096013450175345146551067267855535519210240888217443129158061156806field"
+      },
+      {
+        "id": "au1g37nzpnjrj9aeref8ywmne69nqs976q0rt2svp454yh2cnkresrssrgjec",
+        "program": "xtaustbucx.aleo",
+        "function": "main",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "public",
+            "id": "3054866227055186807082597066855916750579581453444049685809136743521866610493field",
+            "value": "{\n  caller: aleo1fshc7vzla5jwwluvcl9r9vx0lr3h39c395qwz7jpf39ctpauqczq87h028,\n  sender: aleo1kevhe97umnpdf4y08qdz2wg249jzmv486vydtxpfus4l8hwk9c9qfguzgz,\n  destination_chain: [\n    69u8,\n    116u8,\n    104u8,\n    101u8,\n    114u8,\n    101u8,\n    117u8,\n    109u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8,\n    0u8\n  ],\n  destination_address: [\n    18u8,\n    52u8,\n    86u8,\n    120u8,\n    144u8,\n    171u8,\n    205u8,\n    239u8,\n    18u8,\n    52u8,\n    86u8,\n    120u8,\n    144u8,\n    171u8,\n    205u8,\n    239u8,\n    18u8,\n    52u8,\n    86u8,\n    120u8\n  ]\n}"
+          },
+          {
+            "type": "public",
+            "id": "459987440572527337282165566026510457185507486301355585158919271537480618925field",
+            "value": "{\n  foo: 4u64,\n  bar: 3u32\n}"
+          }
+        ],
+        "tpk": "1979437462715778844369599717398972162048872085558366367155799630946169368880group",
+        "tcm": "7322048699076326612583226873520845972182111124988618696753561184230823021290field",
+        "scm": "3631498312096013450175345146551067267855535519210240888217443129158061156806field"
+      }
+    ],
+    "global_state_root": "sr1l5q00zjp5lep9hq49tu4gyqjyd65fq8j9kzhplazshqk4kwcxqgsh5fddv",
+    "proof": "proof1qypqqqqqqqqqqqqpqqqqqqqqqqqqzqqqqqqqqqqq7wq5hlzu2a04z5grak8v2msfxz57ldtg222l7vxf54vx9jusmu5ay5v4x5csxtnx7zcspkew5k5gqza4yttx6fd7ta8pk3xc0fjqh7gl6p6kre4qvmyg69cvc9f3l5775fxktehc24qa7ng6qzryejl4sqqjnutcs3tdj6pffhz7nw54ntaev3yjfxajfs3xj4hjmqhvvp03lew2ar6fgyrr9pkkd0ajwt62c55p33xfyhd2tr9qmfzeuxz3hnu67fd9r499dcqkn4kgjtgt2hmefdlv7a89k9ft9qnlw5mvqg0l955qrz4vt8mmt0jeq8k8tqreqcyh4skah5l0fanum4ff8pzygyx90r5g2cws8n2pu6vpmkhfhyglrpecs8nfa69nfuplvf09gp3yaavjx2pwpqnxtydf7h4r4e6m4jfxv9em3s3kmdv8f4plgvv8lkw88qyztqgmphlc8nt6eaqdndcl8n7gajp9hums9afmh3zwrtrrqprvj8mrae5jhn89x5dlgmz8ctnzzp4fpwq44vgxvsm6hn8fdu6vczalgtz3rjc4ru2wmst5ucxupq95rthddd6340s6lkuarsdg544ekz98v7cp4p5svq8n8mn2pz7fta9fnt3crs39qccet5m82r6yqpk0cm9wn7df457zn9xg7wsr3axsf3g6g0pspsckh2vxgh5g6mz3095fycx2u368ehrx6jamljkrcx3ay5vrp2dznl5we9dy2g2peyuag3h2ja5gqxj4zahkkzuplax3fqt0fk73f87rh85ydw2lre5lc2n4t5jmwhfsupky9gye83ctcnmjhzy2x4086q9kfk3ls3a67pz7605x6zt77lnwvk4f2yn2zqk8rq53mzmcd5pnjhz3kmg6vcq29ryxzrg3k3jqygqyh0uxppvqy7xm5e09pypu2pd9ddg97yajcxcxkxwnpe9r7jeqlmxczmpnsq45axcvmthmhjzlfgup5an2jqw8x2tdx0e9ls43k5gfv707z8rtwkmuvu9gtenfslj695zs6u8w3efzq47ntqaegaw5ppkguwzs0j4eglczkrh9up29wmzp2qxs9r4s37flynj9yqcc3m9xma2qv39vk2r305skwd0nk5nsxgc0pz525zv4q320muwpgpv43sdt4zvtqfv9kgvla0wfd3y4sz6t729ppqp5cgydtlxg340wp6hjqqxk8xawy5u8us0627c5hrl3ctwa02q3g6klckxg7mzl5nrvjesrk6at57sxm74gt7wl5k30xn8v3hqxty9u6vckh36342h7mu7jvu24ny29n0a66cm32u6w5ah93vsygf9tur5zynpuhmgsd7nwpgqrg3pfsa6l80ane48vwnl6srjahl78pcrxpq4l4nl7xyatgmpccqu3mkageky79r0fcgm53ek560qpgcjf4hwqnk22pdw8l8r8new67dqzr7lld6acrlvt0wl0ctentl5llcf5nqqxp959h533gwcmmyy5w9nvpl6ku00w6euszngmhajm8mss33fpkgxefu534fr4gtdcmeufqhujsey574xpyzfcvw6wltvhg7m4ra8fyyr8jech3te5e6rsl56qqqaqtp9keqwwnwy0eu89kmd7faswshfjq5gxzerwarpjn7v87tvdztwg098ncrdk6cre7spsmugeagzck4eppkfysmdhk48j8p7muw6ahc7a7ylee6puc0kee0wdtjtrn9flqdsrv8z4zdp8gdq7jtjzucp6j0t9ptg60p60q3zsqlslyxtczua3ycq0g7w5cgr62demecqjkypkffs4ycgrzs2yez9clhak553xaxxacrrwu3lpmkftnswaaxl0ug479a0jemu95q64cr903tgxzfeh35etqmgch5fazdyvmrnn07zep85x8zevxadnc4uhphwm6sd9yfg65ntqkqcqqqqqqqqqqprr26n3st2s0cz3e7g5ncdceczke6763pfl5jt3nny9ws6pn8r4talxkrw3r3kns2v7w2p04y9jdqgqr40hkf9js3stk2uxj0mn2uxrpmyee2pf3e9ptylyphjp63nepz4ez5k94qp83l0kl7hplldpw44cqqwz35q2kep0scuqvxvw4l8uga8hgq2vx2wcscxzt3nwqwuhjnvhzpp5dx7tp6srdn4ey3a9gnnteexlvk4v2hyf9dp2lnkfda8pgwcea22cpm3yy4npndeexy9tjj64mqgqv6ldp2"
+  },
+  "fee": {
+    "transition": {
+      "id": "au1xlk4zcxzwzeql2h3v0smyj7uw94y269y9gxt7mdcy3ukmktm5vxqc6hqsl",
+      "program": "credits.aleo",
+      "function": "fee_public",
+      "inputs": [
+        {
+          "type": "public",
+          "id": "8443172257395802121020101982125342464944575545060758538228582562870101540114field",
+          "value": "3290u64"
+        },
+        {
+          "type": "public",
+          "id": "696281956326514230552317956762564776883743177329149101284300223448199972527field",
+          "value": "0u64"
+        },
+        {
+          "type": "public",
+          "id": "6184434976177600670622795093539943933625364129767711668673665421846602862695field",
+          "value": "7790090030267484746147452313997337803143399449584526149409294706821395786459field"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "future",
+          "id": "6540534451715088289728516712335973386045206055878228383525002684481816786929field",
+          "value": "{\n  program_id: credits.aleo,\n  function_name: fee_public,\n  arguments: [\n    aleo1kevhe97umnpdf4y08qdz2wg249jzmv486vydtxpfus4l8hwk9c9qfguzgz,\n    3290u64\n  ]\n}"
+        }
+      ],
+      "tpk": "2935300086495843577927459079804530921156953876327740773883198734215107546431group",
+      "tcm": "3435693877887598509166539410502828196712652241145110170121142791065227545377field",
+      "scm": "5655381350960315716635173603713648088888605523605794884627373621244422345045field"
+    },
+    "global_state_root": "sr1l5q00zjp5lep9hq49tu4gyqjyd65fq8j9kzhplazshqk4kwcxqgsh5fddv",
+    "proof": "proof1qyqsqqqqqqqqqqqpqqqqqqqqqqq8zxjpcluyunpd6s5vh6seue7xlr5ycrzmumkugzy4yex2zzqsldvh6374fx6enjzu89g9htmx5fyqqywtyjl2uw7vqy8e6mmvmq8k490rxmr9u8kq4d05glxns29xgx5v09tgtrtx7dgta8t67qvu4yn9zqt7fy2qq93c7u6tjmyftsalxc2qmhwk36gl04l0qz6u99hvgcz5534vlj89zypmqnqsddkfmrmmqcqfft2jdn8tne2ngmahxegff45kmr2y6c4gygah7ku0uxar5yvv5wfevdk7gkhgzlnhfc05u4vyd7cqat2k2fapgat99tnd46y5cjpztg39d2hmsrd6sqye3nm4dayy424zas5adnu55vexnnw2e7jqwufcqdl39aalghfh60mfysnshjdvvmyucq4p0aas70mwqd8yqxkq390qepua0tc8gr26dk7pnvv065aqsxlxf86pf0sthhh86mtj9a47t6hae5pkkzve9pv03cgp6ehgpd674v5vut5htv4n3fhluzck7hr3dqfh0scvfucu54p7z97nzzahgvu5mxw8myej84yrfjrptgvzy6uc4qjsxmw9hsv4jlq59edjacgunuq6mgwg26762clv2hzkn5gkvv2suqu65ftazurx70nvvp4vh7umxhsc6yskhqalykayt8yrmp58cz5q3vx3yk7kdc90uee98ltz5wuzv7sw3z2h2nfylu705uu9czd67vplfrcqwvaqt6ff9szy3mw4070rlhk37ppua4f8nt8eha67y7c0vpk0gjzd2je245dk08mnhw989llpgpgmsuwrl4ursjkc7dfnn2lzzrqlvuwgmeczmvm06yhe72veslv8uwr5gv9ur0tp3kxqc7wedd0qgaf08fvqpz5yf6gp3y47fghshkl470lflg5uhc0gxqtvthdjjscdd4p0w40s95ukh36rttaqa9jvvcz64dtx9p2se0dta4vc6jjcxg99ddp24z4wpnlg4ve0cz8lp7h8mk07e8f9zxfc5alatl4j2hphqpdhqfd9eq0p5d20e7c0h3l3xm936lwqh37v0jelx6e7j28c98vrzzyw72m3nsv7l7x0cma0ckgepq9dx65zxqa9esensc9tt2dvkn4q7uc5gd5pu85x0znc42dyjcuqn3ww4q532jq5pd7m0dwasjkgd8q3qvqqqqqqqqqqpajrkmcvnr6huwpvfxdh6ty735c85lej5n45vcjpl6clj2m2y3k6zvgqaumfv70vh99nkgahhwm3qqq84rdfdgtrztsf05vnhhwkafd0pnvm7cue3p5kjgvkvylzyn7ececr320mg7fda7x6lvjyp3q358yqq8l8kreq0sdvwg80h8wtt2lfvlyljunkuqd0lscg0dsfjg3r6wz3pf2lvzu8dyzpm6u503dm4gkspyal6wfkps28fymaumqr8jqj7te0jcgvmfhcn35arqtgh8q2jdtcqqqqpjg9g6"
+  }
+}

--- a/ampd/src/tests/at1dgmvx30f79wt6w8fcjurwtsc5zak4efg4ayyme79862xylve7gxsq3nfh6.json
+++ b/ampd/src/tests/at1dgmvx30f79wt6w8fcjurwtsc5zak4efg4ayyme79862xylve7gxsq3nfh6.json
@@ -1,0 +1,94 @@
+{
+  "type": "execute",
+  "id": "at1dgmvx30f79wt6w8fcjurwtsc5zak4efg4ayyme79862xylve7gxsq3nfh6",
+  "execution": {
+    "transitions": [
+      {
+        "id": "au1zn24gzpgkr936qv49g466vfccg8aykcv05rk39s239hjxwrtsu8sltpsd8",
+        "program": "gateway_base.aleo",
+        "function": "callContract",
+        "inputs": [
+          {
+            "type": "private",
+            "id": "115511577037938052251670875524881924555816346138898023845846035393619398026field",
+            "value": "ciphertext1qgqy23ky6wvc97fpzzythgt97akvvx62snvfurw8gkkh0lvu486e5rv9f2p5km5qehwsl6eckk7h068rj7xjxau4jjwvuzj4j8eu5cy8zqw6l6dg"
+          },
+          {
+            "type": "private",
+            "id": "1346754753222557999954620366062366355670851543240412334577916992873726746099field",
+            "value": "ciphertext1qvqqq4y3520h8vlqkyulyn7jww0c3yhy3ddmglxxc5j00kv9ejf57pef8g4894vp7ldd7dz2mejycnpfswsay4ty87d8ujdr8hxuru2zqv6q48syd03u6espkqrhzffuu6ll5u4drh07xedk94gd9gqvjvlscwrhyua"
+          }
+        ],
+        "outputs": [
+          {
+            "type": "public",
+            "id": "5716136157043597981935575283493176988384748355542483128578055405375962864291field",
+            "value": "{\n  caller: aleo1d4vxwgfempkqy9qmxlxc6a2qu4vptyaxyllpwlqhwwj22tjn3u9s405jsz,\n  sender: aleo10fmsqwh059uqm74x6t6zgj93wfxtep0avevcxz0n4w9uawymkv9s7whsau,\n  destination_chain: [\n    129497940983541880690546129557858025472u128,\n    0u128\n  ],\n  destination_address: [\n    72059799150973012437864881636927078400u128,\n    0u128,\n    0u128,\n    0u128\n  ]\n}"
+          }
+        ],
+        "tpk": "2378426162045410681183408163975351431583363524060976165966443931060754647450group",
+        "tcm": "8135390902405192335584829677611050324394653269857843248093834497841683065374field",
+        "scm": "665547468110612629110551548422380543105051959813434445899567520868543695956field"
+      },
+      {
+        "id": "au1zlzkquv84a0z3ctsa8n0pjc9u6zsf4fnt5n6rvv2kvhujpv7kugsxgk953",
+        "program": "dapp_20241209_1528.aleo",
+        "function": "main",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "public",
+            "id": "498728416888798206540363447056413969945850586697856359703993606559315403792field",
+            "value": "{\n  caller: aleo1d4vxwgfempkqy9qmxlxc6a2qu4vptyaxyllpwlqhwwj22tjn3u9s405jsz,\n  sender: aleo10fmsqwh059uqm74x6t6zgj93wfxtep0avevcxz0n4w9uawymkv9s7whsau,\n  destination_chain: [\n    129497940983541880690546129557858025472u128,\n    0u128\n  ],\n  destination_address: [\n    72059799150973012437864881636927078400u128,\n    0u128,\n    0u128,\n    0u128\n  ]\n}"
+          },
+          {
+            "type": "public",
+            "id": "6071601079138022288680306482161989576772643907255348496374692450720130543174field",
+            "value": "[\n  72u8,\n  101u8,\n  108u8,\n  108u8,\n  111u8,\n  44u8,\n  32u8,\n  87u8,\n  111u8,\n  114u8,\n  108u8,\n  100u8,\n  33u8\n]"
+          }
+        ],
+        "tpk": "626263084313780992010492931202965188483315154993713664610290497371214125085group",
+        "tcm": "8401035237521335437472833462029846927897614023602621311294113318879586142339field",
+        "scm": "665547468110612629110551548422380543105051959813434445899567520868543695956field"
+      }
+    ],
+    "global_state_root": "sr1dqt68qq7w8a3ljzjqrcxs5s5he220j4wh9yaxt0ckk2vxuvy5vpsp2pp7y",
+    "proof": "proof1qypqqqqqqqqqqqqpqqqqqqqqqqqqzqqqqqqqqqqq6t4gugjl7ntzlfvzx9pety4nzdrsy67kj4vfr7dxx7a0uul8ntvs8p9d6at7zsym3j43wac28a4cznyfp5qqdsg2shkae99yfyc0lnmt6lm48hvsp4p9ljtwup945t96vh6jfq8njcmxl6rh0x8dsqp0sqqcfjfzp40lz5dtzu2e9r5psd5dmzsdy43uzag2na2a79pkha6e46tw5dltwv8387l20w9fatgncqvpe2288ncdwgcj5v8rm2maepanl7gu8h7lgp7fe47f3h2shwgv6uxr2wz3xyvez03q0uv5spj582ucqjewpj0vu0khguxfps4gd2tlrc3lg40ah07un4skcyzsrx2lwhjhzwkeujsr32mwf4h8qh79xqy6sx83rz8esszvydqjsa2k7upzpzxeyf58kqalugttmg0jtcldr3av2huepn0feqpfsuanqys4fj45yqppzn9gnqfkw7x3chwyztaufele0htj3a9fpma53gj8u7mlxw05vsknuedsdv2sc0vafrzrkhm9hqqpayzkskur4zmz743y8hry3xz86je08fnultqtzfjpk6p9lwm8xpnq2g5xmv3esgc9g75du4j8necqhrpkdjws260wpw4acxh5jla66xjfjpmwshvuzs2kfsvhwe8e9xykwszvuv09tuv2hhn3pu4h9dxgrzjca2hn0tu0jlh9smezyz87zveskcwj5g43wcpuj0ympjaj3wc9vx5q48hdherk8dny9nqsp20zsrr26atswm4lhdm52zg22vzdzcp6aak5rc9hmfrmf290pezegs4savshapg2gzfwy00vm9kwzl0f0qd0nxv7d9es8teelygwdxek5xgpdg5f4jvdxtpgsvv8nk3uyee9p5cysjlgc8rc0muk6788qs8gn7qrv7k6xd0l7juk5z8slzfl2v8q285vjnhrqahfwyzy54auu63spksh69j2wat56yqdc6vm2cq6qrup35guz7hfd40xquxkx549k22saflmm3yke3nm6hy9w2w8u0h63qy6crz63mgp0a5npvx2acw2v6q4pra3y5f37w6n8plxlm62p2y2zqxqjwjz7l67qdegspckjarn5uq3n2ey9hk3pkef742pld8p3vzlplsjukm8eulg3zga5agwnyuemqee54e9j0xerxwh25estedrchaqutge3edy6sk95delx2xal5u5vlnajhnga8fpft6c5t8n68g5pfspjkkwydqvp9gvt8fn2chvx6yxddsfe54mlw03ktc32wmyxmcxdgqxl2uxa7hr3xmt3s7mcgmn0y9qrqg3fp5n69wh36g0qxx2zsgj2qg4ur95rvw454ddyax38w3wa7sqtn32rynefnj25dde9z4x9t4gptqjkyfrumdc25r7s7kefk8xdwssm0qfkq9235c4hpq59hemhfxq6vt0xstmlpnchxj5xu43sym3qudmk5m4gp4j3g4zfvvzgryd2js0880l5gexhty6xeeua99xh7zdhdja3qtpq0luzycmc65094c6cuppsutdafflejw6dcqkurkhdmdj2309pyr032axez2ewxameyjf2rk4e0295wnk9p80ytyssk5p7uas3h8lte3wjjsrzja9tehtmgx5p5f2ur5g6u9qk6y6w9rhrtp6k4nv6za4ay2m7mgr4emnerqs3rcsz0qxh7mu5l5m628w39ajelyn0c2hff2ft0welzesqm4dpvptf3st3mw83s585asc45dmnxrwr9lf9srucyx2sdf7l7mzfll02zfassyz79gv22tjlgpnxqhzqmsglwzqp8xhrtkgdq5l4jg8tk3j2m34kyh802m6clsz73k8c07jtqv6j9k5gwhtr9mgnzqj8e4yqhql6pg6p9kmardd2x2m0r22nj9zjuz8sw8kscev8wxu8mzdyazqjg7q5a2szqcqqqqqqqqqqrumj53h5qpp58ewjnhkffwwdc5hyd55ez0xjq2v3r3g9qndqea2qt2wdlrq6ds5hgyst8kkrar3qqqq7qlvmzdssrgm4sryy2jjht2nncvzxkluz3hn4ykgeadqrq4f2sj9r3q68v3kj7p2r9dmrgzud4mgqqt6f9ehy7lvpqz77t2jz5krll7rch7rutysvn2fe5cqv0xd7e3mqgwfk9k25v2a2k8gahrq048x6ckht8qlej3a0fsln5g7rnyz64plaxxxwa362ygs3gteglwqru5yeqgqc08upv"
+  },
+  "fee": {
+    "transition": {
+      "id": "au12qnwa436us2drndlcpw2dhrzpz8w0n3ec0f46j9nl6frc9udeyrqzfjas7",
+      "program": "credits.aleo",
+      "function": "fee_public",
+      "inputs": [
+        {
+          "type": "public",
+          "id": "2249192839320937721780915675597212866591329011324951661088926481673460812698field",
+          "value": "2755u64"
+        },
+        {
+          "type": "public",
+          "id": "5812289290010669632870822280913765541470404640304746101201868919757062687056field",
+          "value": "0u64"
+        },
+        {
+          "type": "public",
+          "id": "4277441994367412287537278736396043657304949319255085893773438517162021199349field",
+          "value": "5073423990856891650103304962833567501821891469355246955227315787295678258657field"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "future",
+          "id": "2013964697863603064720977594027456130857408916561475204371549779035212498043field",
+          "value": "{\n  program_id: credits.aleo,\n  function_name: fee_public,\n  arguments: [\n    aleo10fmsqwh059uqm74x6t6zgj93wfxtep0avevcxz0n4w9uawymkv9s7whsau,\n    2755u64\n  ]\n}"
+        }
+      ],
+      "tpk": "3699836179579219999518493538025721092505233232641500459027138434091001475039group",
+      "tcm": "3719026954429616147586812766658839718202009347638084833806901741931897937897field",
+      "scm": "4600539882085985510041634258460380412840654910107094645657973918290281617639field"
+    },
+    "global_state_root": "sr1w9gaalyhczqda97ddterqkl8yw3qyvpz89ktr8h8jfertfqr7qgq8vdg75",
+    "proof": "proof1qyqsqqqqqqqqqqqpqqqqqqqqqqqdrs3d0s8fnz0n9rd0k0kdx7g6mltq569lngz4mk4x77yhhazftq39dtwdsau3pmlvxfgu2p2a3fsqqyjtvjpuuv3cr9hmyy3cay5tgx72jnhggcs2cszq94mg0pt3wxza84t56x6h0unvj2u2djm8564v6qrasup725q428pxcug9afpmkfy2l87qdfqlqluxvc4eew4d6hpyvsfla3fwtpwdx6h553ktann3rvq4dkxev80qxeqdajkcee47d0vmrn8p7a699vp5cd96d2j93x6y3ckpjervq2akwg7numuc4jtmnu5qcqnw6pdpucgluruea3l9warz9z8la378ja5wmjpm5d4pv2speurr33zcnh4rlltvkk76lqtn3nrqq30fqg8nvvqvg6ft3xy4ehzpkzycc9hhjcjsgyjxwpvquspndl9pfgzhptk3rgpu5lc65k0xw0r0s8js574szd8vyp09nc8cd0yvadk7y0x9jpe2qwa7zf2lmgsnunjvny20k2lk706uxkluslh6xnse2q2txekpw32jjy35238ver86n8rzydn9uu6jpttnll4wm24kwtkvungewmtf86e2e8935h9dduhjjcq0psymsl57ayp5g4hjl0xrhquefrfrpj2fxk7ncgse5ll6tcvx0dy2un9tw99p0c0spe0tz2ty9a5qz623n450fyvynhcrtfrwewzp7dh9y7vgq6fkgmjm3p3dmkfjnvx2nfjw0cc7das5y4rl3zamm5u0z4nupn296k79gz5t06phtun6sz2h68dchqv226ftdzgtp77ggx0dw9frc6ed4t405nuez26aja68pvtgkat265ca87t88ycwrvwm9cta9mrywmk5fv7jlqwh0hmaaktst5e8n5jauys3e6mt5gsxs77nvtewwqyylvtf20nugz4e4wc3t0gd5mn6jq57up44k4gqa6g703a4jgunceap5gnpm4emz0qqnw8xzs8w98wr7cwa4qv6pqhljj9jwnlgan2kvcs3m8wzq9ycq4mly8762yyujlqw0038539taq5uqa0dmulf7xfgyxvv0tn46fnanhjq3nkdpkwr5fkpp9vrcq7mkp5qe6u70mzvqc3xat2ew30mzn7yttdfudqs87tgd3janm2wf002ccptwv0dusspr5vft8s5ns4t63xt8kr3r6grqvqqqqqqqqqqq4szxyt5x06pt705q3y9rn73yt3g59s35vvn924fk4520dpgh4r7anrl649g6gz23qxg5f8xj5q2sqqyjt3fzxrnn3n2ghlfeglkw7ad7f6rukphpwsyqkv53ar8pvgsyusf5y4tnxcmyt6vq605utumkwgpqxfhv5jd74hd2ue3rz83exs07uafgtt0hfnpx8ucsfum5srg3wzsy3sxlj7h87y6spyjavwdmnrku0vmwxvgqzy2twjh7f39sm70djacxqehe34nqrvze6nn9fr03t2cqyqqhmv2yt"
+  }
+}

--- a/ampd/src/tofnd/grpc.rs
+++ b/ampd/src/tofnd/grpc.rs
@@ -74,6 +74,7 @@ impl Multisig for MultisigClient {
                 KeygenResponse::PubKey(pub_key) => match algorithm {
                     Algorithm::Ecdsa => PublicKey::new_secp256k1(&pub_key),
                     Algorithm::Ed25519 => PublicKey::new_ed25519(&pub_key),
+                    Algorithm::AleoSchnorr => PublicKey::new_aleo_schnorr(&pub_key),
                 }
                 .change_context(Error::ParsingFailed)
                 .attach_printable(format!("{{ invalid_value = {:?} }}", pub_key)),
@@ -118,6 +119,7 @@ impl Multisig for MultisigClient {
                     Algorithm::Ed25519 => {
                         ed25519_dalek::Signature::from_slice(&signature).map(|sig| sig.to_vec())
                     }
+                    Algorithm::AleoSchnorr => Ok(signature),
                 }
                 .change_context(Error::ParsingFailed),
 

--- a/ampd/src/tofnd/mod.rs
+++ b/ampd/src/tofnd/mod.rs
@@ -36,6 +36,18 @@ pub type Signature = Vec<u8>;
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct MessageDigest([u8; 32]);
 
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct MessageDigestTofnd(pub Vec<u8>);
+
+impl FromHex for MessageDigestTofnd {
+    type Error = error::Error;
+
+    fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
+        Ok(MessageDigestTofnd(Vec::from_hex(hex)?))
+    }
+}
+
+
 impl FromHex for MessageDigest {
     type Error = error::Error;
 

--- a/ampd/src/types/key.rs
+++ b/ampd/src/types/key.rs
@@ -1,5 +1,6 @@
-use std::fmt;
+use std::{fmt, str::FromStr};
 
+use aleo_types::address::Address;
 use cosmwasm_std::HexBinary;
 use ed25519_dalek::PUBLIC_KEY_LENGTH;
 use error_stack::{self, Report, ResultExt};
@@ -21,6 +22,19 @@ pub enum Error {
 pub enum PublicKey {
     Secp256k1(k256::ecdsa::VerifyingKey),
     Ed25519(ed25519_dalek::VerifyingKey),
+    AleoSchnorr([u8; aleo_types::address::ALEO_ADDRESS_LEN]),
+}
+
+fn convert_to_array(bytes: impl AsRef<[u8]>) -> Result<[u8; 63]> {
+    let slice = bytes.as_ref();
+
+    if slice.len() != 63 {
+        return Err(Error::InvalidRawBytes.into());
+    }
+
+    let mut array = [0u8; 63];
+    array.copy_from_slice(slice);
+    Ok(array)
 }
 
 impl PublicKey {
@@ -29,6 +43,10 @@ impl PublicKey {
             k256::ecdsa::VerifyingKey::from_sec1_bytes(bytes.as_ref())
                 .change_context(Error::InvalidRawBytes)?,
         ))
+    }
+
+    pub fn new_aleo_schnorr(bytes: impl AsRef<[u8]>) -> Result<Self> {
+        Ok(PublicKey::AleoSchnorr(convert_to_array(bytes)?))
     }
 
     pub fn new_ed25519(bytes: impl AsRef<[u8]>) -> Result<Self> {
@@ -45,6 +63,7 @@ impl PublicKey {
         match self {
             PublicKey::Secp256k1(key) => key.to_sec1_bytes().to_vec(),
             PublicKey::Ed25519(key) => key.to_bytes().to_vec(),
+            PublicKey::AleoSchnorr(key) => key.to_vec(),
         }
     }
 }
@@ -62,6 +81,13 @@ impl fmt::Display for PublicKey {
             PublicKey::Ed25519(key) => {
                 write!(f, "ed25519: {}", HexBinary::from(key.to_bytes()).to_hex())
             }
+            PublicKey::AleoSchnorr(key) => {
+                write!(
+                    f,
+                    "aleo_schnorr: {}",
+                    Address::from_str(std::str::from_utf8(key).unwrap()).unwrap()
+                )
+            }
         }
     }
 }
@@ -73,6 +99,7 @@ impl TryFrom<&multisig::key::PublicKey> for PublicKey {
         match key {
             multisig::key::PublicKey::Ecdsa(key) => Self::new_secp256k1(key),
             multisig::key::PublicKey::Ed25519(key) => Self::new_ed25519(key),
+            multisig::key::PublicKey::AleoSchnorr(key) => Self::new_aleo_schnorr(key),
         }
     }
 }
@@ -96,6 +123,7 @@ impl TryFrom<&PublicKey> for CosmosPublicKey {
             )
             .expect("must be valid ed25519 key")
             .into()),
+            PublicKey::AleoSchnorr(_) => Err(Error::UnsupportedConversionForCosmosKey(*key).into()),
         }
     }
 }

--- a/contracts/axelarnet-gateway/src/contract/query.rs
+++ b/contracts/axelarnet-gateway/src/contract/query.rs
@@ -2,7 +2,8 @@ use cosmwasm_std::Storage;
 use itertools::Itertools;
 use router_api::{ChainName, CrossChainId, Message};
 
-use crate::state::{self, ExecutableMessage};
+use crate::msg::ExecutableMessage;
+use crate::state;
 
 pub fn routable_messages(
     storage: &dyn Storage,
@@ -18,10 +19,12 @@ pub fn executable_messages(
     storage: &dyn Storage,
     cc_ids: Vec<CrossChainId>,
 ) -> Result<Vec<ExecutableMessage>, state::Error> {
-    cc_ids
+    let results: Vec<_> = cc_ids
         .into_iter()
         .map(|cc_id| state::load_executable_msg(storage, &cc_id))
-        .try_collect()
+        .try_collect()?;
+
+    Ok(results.into_iter().map(Into::into).collect())
 }
 
 pub fn chain_name(storage: &dyn Storage) -> ChainName {

--- a/contracts/axelarnet-gateway/src/msg.rs
+++ b/contracts/axelarnet-gateway/src/msg.rs
@@ -4,7 +4,24 @@ use cosmwasm_std::HexBinary;
 use msgs_derive::EnsurePermissions;
 use router_api::{Address, ChainName, CrossChainId, Message};
 
-use crate::state::ExecutableMessage;
+use crate::state;
+
+impl From<state::ExecutableMessage> for ExecutableMessage {
+    fn from(value: state::ExecutableMessage) -> Self {
+        match value {
+            state::ExecutableMessage::Approved(msg) => ExecutableMessage::Approved(msg),
+            state::ExecutableMessage::Executed(msg) => ExecutableMessage::Executed(msg),
+        }
+    }
+}
+
+#[cw_serde]
+pub enum ExecutableMessage {
+    /// A message that has been sent by the router, but not executed yet.
+    Approved(Message),
+    /// An approved message that has been executed.
+    Executed(Message),
+}
 
 #[cw_serde]
 pub struct InstantiateMsg {

--- a/contracts/multisig-aleo/Cargo.toml
+++ b/contracts/multisig-aleo/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "multisig-aleo"
+version = "1.1.1"
+rust-version = { workspace = true }
+edition = { workspace = true }
+description = "Multisig-aleo contract"
+
+exclude = [
+    "contract.wasm",
+    "hash.txt"
+]
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[[bin]]
+name = "multisig-aleo-schema"
+path = "src/bin/schema.rs"
+
+[features]
+# use library feature to disable all instantiate/execute/query exports
+library = []
+# use this feature to enable test utils
+test = []
+
+[package.metadata.scripts]
+optimize = """docker run --rm -v "$(pwd)":/code \
+  --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
+  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
+  cosmwasm/optimizer:0.16.0
+"""
+
+[dependencies]
+axelar-wasm-std = { workspace = true, features = ["derive"] }
+cosmwasm-schema = { workspace = true }
+cosmwasm-std = { workspace = true }
+cw-utils = { workspace = true }
+enum-display-derive = "0.1.1"
+error-stack = { workspace = true }
+getrandom = { version = "0.2", default-features = false, features = ["custom"] }
+msgs-derive = { workspace = true }
+report = { workspace = true }
+serde = { version = "1.0.145", default-features = false, features = ["derive"] }
+serde_json = "1.0.89"
+thiserror = { workspace = true }
+snarkvm-cosmwasm = { workspace = true, features = ["account", "types", "program", "network"] }
+
+[dev-dependencies]
+hex = "0.4.3"
+
+[lints]
+workspace = true

--- a/contracts/multisig-aleo/error.txt
+++ b/contracts/multisig-aleo/error.txt
@@ -1,9 +1,0 @@
-call_indirect (type 8)
-    call_indirect (type 11)
-
-  (func $_ZN3std3f6421_$LT$impl$u20$f64$GT$4ceil17hdd97a0309344262bE (type 25) (param f64) (result f64)
-  (func $_ZN12wasm_bindgen7convert5impls70_$LT$impl$u20$wasm_bindgen..convert..traits..WasmAbi$u20$for$u20$T$GT$4join17h0496ce99cb8b8cd3E (type 40) (param f32) (result f32)
-  (func $_ZN12wasm_bindgen7convert8closures11invoke3_mut17h26b21fce42394289E (type 41) (param i32 i32 f32 i32 i32)
-(func $_ZN12wasm_bindgen7convert8closures11invoke3_mut17hb3cf0cd3921a74a2E (type 42) (param i32 i32 f64 i32 i32)
-  (func $_ZN67_$LT$f64$u20$as$u20$core..convert..num..FloatToInt$LT$usize$GT$$GT$16to_int_unchecked17h1cd68005153e7188E (type 47) (param f64) (result i32)
-

--- a/contracts/multisig-aleo/error.txt
+++ b/contracts/multisig-aleo/error.txt
@@ -1,0 +1,9 @@
+call_indirect (type 8)
+    call_indirect (type 11)
+
+  (func $_ZN3std3f6421_$LT$impl$u20$f64$GT$4ceil17hdd97a0309344262bE (type 25) (param f64) (result f64)
+  (func $_ZN12wasm_bindgen7convert5impls70_$LT$impl$u20$wasm_bindgen..convert..traits..WasmAbi$u20$for$u20$T$GT$4join17h0496ce99cb8b8cd3E (type 40) (param f32) (result f32)
+  (func $_ZN12wasm_bindgen7convert8closures11invoke3_mut17h26b21fce42394289E (type 41) (param i32 i32 f32 i32 i32)
+(func $_ZN12wasm_bindgen7convert8closures11invoke3_mut17hb3cf0cd3921a74a2E (type 42) (param i32 i32 f64 i32 i32)
+  (func $_ZN67_$LT$f64$u20$as$u20$core..convert..num..FloatToInt$LT$usize$GT$$GT$16to_int_unchecked17h1cd68005153e7188E (type 47) (param f64) (result i32)
+

--- a/contracts/multisig-aleo/src/bin/schema.rs
+++ b/contracts/multisig-aleo/src/bin/schema.rs
@@ -1,0 +1,9 @@
+use cosmwasm_schema::write_api;
+use multisig_aleo::msg::{InstantiateMsg, QueryMsg};
+
+fn main() {
+    write_api! {
+        instantiate: InstantiateMsg,
+        query: QueryMsg,
+    }
+}

--- a/contracts/multisig-aleo/src/contract.rs
+++ b/contracts/multisig-aleo/src/contract.rs
@@ -1,0 +1,49 @@
+use axelar_wasm_std::FnExt as _;
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+use cosmwasm_std::{to_json_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response};
+
+use crate::msg::{InstantiateMsg, QueryMsg};
+
+pub mod query;
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(
+    _deps: DepsMut,
+    _env: Env,
+    _msg: Empty,
+) -> Result<Response, axelar_wasm_std::error::ContractError> {
+    Ok(Response::default())
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    _deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    _msg: InstantiateMsg,
+) -> Result<Response, axelar_wasm_std::error::ContractError> {
+    Ok(Response::default())
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(
+    _deps: Deps,
+    _env: Env,
+    msg: QueryMsg,
+) -> Result<Binary, axelar_wasm_std::error::ContractError> {
+    match msg {
+        QueryMsg::VerifySignature {
+            signature,
+            message,
+            public_key,
+            signer_address: _,
+            session_id: _,
+        } => to_json_binary(&query::verify_signature::<snarkvm_cosmwasm::network::TestnetV0>(
+            signature,
+            message,
+            public_key,
+        )?)?,
+    }
+    .then(Ok)
+}

--- a/contracts/multisig-aleo/src/contract/query.rs
+++ b/contracts/multisig-aleo/src/contract/query.rs
@@ -1,0 +1,67 @@
+use std::str::FromStr as _;
+
+use cosmwasm_std::{HexBinary, StdResult};
+use snarkvm_cosmwasm::account::ToFields;
+use snarkvm_cosmwasm::program::{Network, Signature, Value};
+use snarkvm_cosmwasm::types::{Address, Field};
+
+pub fn verify_signature<N: Network>(
+    signature: HexBinary,
+    message: HexBinary,
+    public_key: HexBinary,
+) -> StdResult<bool> {
+    let signed = String::from_utf8(signature.into()).map_err(|e| {
+        cosmwasm_std::StdError::generic_err(format!("Failed to parse signature: {}", e))
+    })?;
+
+    let signature = Signature::<N>::from_str(signed.as_str())
+        .map_err(|e| {
+            cosmwasm_std::StdError::generic_err(format!("Failed to parse signature: {}", e))
+        })?;
+
+    let address = String::from_utf8(public_key.into()).map_err(|e| {
+        cosmwasm_std::StdError::generic_err(format!("Failed to parse public key: {}", e))
+    })?;
+
+    let addr = Address::from_str(address.as_str()).map_err(|e| {
+        cosmwasm_std::StdError::generic_err(format!("Failed to parse address: {}", e))
+    })?;
+
+    let message = aleo_encoded(&message)?;
+
+    let res = signature.verify(&addr, message.as_slice());
+
+    Ok(res)
+}
+
+fn aleo_encoded<N: Network>(data: &HexBinary) -> Result<Vec<Field<N>>, cosmwasm_std::StdError> {
+    let num = cosmwasm_std::Uint256::from_le_bytes(data.as_slice().try_into().unwrap());
+    let message = format!("{num}group");
+
+    Value::from_str(message.as_str())
+        .map_err(|e| {
+            cosmwasm_std::StdError::generic_err(format!("Failed to parse signature: {}", e))
+        })?
+        .to_fields()
+        .map_err(|e| {
+            cosmwasm_std::StdError::generic_err(format!("Failed to parse signature: {}", e))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_verify_signature() {
+        let msg = "df4fd7e608879cb128c53f82614cdffcfd163b4d14adbe5c797f3aaaa3e316b8";
+        let signature = "7369676e317179713530387371793264327a706a6a3364676b616d636379377272307a30777175656e3966346e6377367874396c326576717a6b646a6d38716b6d796c7038636a6675716434387937656a657937676b777a6d66787039756868376366636c6c7034666370797078703661706372676e7a61773367666479776c61396d347678797776686e73756577643338616c7377703370786d75387a7436706a35346e673877327478766e7a6a70356333707975396c7435346636686c6778756c6e39386a677a72776e70737161737364743376346e";
+        let address = "aleo145tj9hqrnv3hqylrem6p7zjyxc2kryyp3hdm4ht48ntj3e5ttuxs9xs9ak";
+
+        let msg = HexBinary::from_hex(msg).unwrap();
+        let signature = HexBinary::from_hex(signature).unwrap();
+        let address = HexBinary::from(address.as_bytes());
+
+        assert!(verify_signature(signature, msg, address).is_ok());
+    }
+}

--- a/contracts/multisig-aleo/src/contract/query.rs
+++ b/contracts/multisig-aleo/src/contract/query.rs
@@ -14,10 +14,9 @@ pub fn verify_signature<N: Network>(
         cosmwasm_std::StdError::generic_err(format!("Failed to parse signature: {}", e))
     })?;
 
-    let signature = Signature::<N>::from_str(signed.as_str())
-        .map_err(|e| {
-            cosmwasm_std::StdError::generic_err(format!("Failed to parse signature: {}", e))
-        })?;
+    let signature = Signature::<N>::from_str(signed.as_str()).map_err(|e| {
+        cosmwasm_std::StdError::generic_err(format!("Failed to parse signature: {}", e))
+    })?;
 
     let address = String::from_utf8(public_key.into()).map_err(|e| {
         cosmwasm_std::StdError::generic_err(format!("Failed to parse public key: {}", e))
@@ -62,6 +61,6 @@ mod tests {
         let signature = HexBinary::from_hex(signature).unwrap();
         let address = HexBinary::from(address.as_bytes());
 
-        assert!(verify_signature(signature, msg, address).is_ok());
+        assert!(verify_signature::<snarkvm_cosmwasm::network::TestnetV0>(signature, msg, address).is_ok());
     }
 }

--- a/contracts/multisig-aleo/src/error.rs
+++ b/contracts/multisig-aleo/src/error.rs
@@ -1,0 +1,9 @@
+use axelar_wasm_std::IntoContractError;
+use cosmwasm_std::StdError;
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq, IntoContractError)]
+pub enum ContractError {
+    #[error(transparent)]
+    Std(#[from] StdError),
+}

--- a/contracts/multisig-aleo/src/lib.rs
+++ b/contracts/multisig-aleo/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod contract;
+pub mod error;
+pub mod msg;
+
+
+pub use crate::error::ContractError;

--- a/contracts/multisig-aleo/src/msg.rs
+++ b/contracts/multisig-aleo/src/msg.rs
@@ -1,0 +1,18 @@
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::{HexBinary, Uint64};
+
+#[cw_serde]
+pub struct InstantiateMsg {}
+
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum QueryMsg {
+    #[returns(bool)]
+    VerifySignature {
+        signature: HexBinary,
+        message: HexBinary,
+        public_key: HexBinary,
+        signer_address: String,
+        session_id: Uint64,
+    },
+}

--- a/contracts/multisig-prover/Cargo.toml
+++ b/contracts/multisig-prover/Cargo.toml
@@ -62,6 +62,9 @@ stellar-xdr = { workspace = true }
 sui-gateway = { workspace = true }
 thiserror = { workspace = true }
 voting-verifier = { workspace = true, features = ["library"] }
+aleo-gateway = { workspace = true }
+snarkvm-cosmwasm = { workspace = true }
+bincode = "1.3.3"
 
 [dev-dependencies]
 anyhow = "1.0"
@@ -71,6 +74,8 @@ elliptic-curve = "0.13.5"
 generic-array = "0.14.7"
 goldie = { workspace = true }
 prost = "0.12.4"
+tofn = { version = "1.1", git = "https://github.com/eigerco/tofn.git", branch = "aleo-schnorr", features = [ "aleo-schnorr"] }
+snarkvm = "1.2.1"
 
 [lints]
 workspace = true

--- a/contracts/multisig-prover/src/contract/execute.rs
+++ b/contracts/multisig-prover/src/contract/execute.rs
@@ -80,14 +80,6 @@ pub fn construct_proof(
         ),
     };
 
-    // TODO:
-    // run this in unit-test
-    // send the message to ampd
-    // ampd -> tofnd
-    // get the ampd result
-    // translate to Aleo
-    // give it to aleo
-
     let wasm_msg =
         wasm_execute(config.multisig, &start_sig_msg, vec![]).map_err(ContractError::from)?;
 
@@ -255,68 +247,6 @@ pub fn update_verifier_set(
                     .collect::<HashSet<String>>(),
             ),
         ))
-
-    // let cur_verifier_set = CURRENT_VERIFIER_SET
-    //     .may_load(deps.storage)
-    //     .map_err(ContractError::from)?;
-    //
-    // match cur_verifier_set {
-    //     None => {
-    //         // if no verifier set, just store it and return
-    //         let new_verifier_set = make_verifier_set(&deps, &env, &config)?;
-    //         CURRENT_VERIFIER_SET
-    //             .save(deps.storage, &new_verifier_set)
-    //             .map_err(ContractError::from)?;
-    //
-    //         Ok(Response::new()
-    //             .add_message(multisig.register_verifier_set(new_verifier_set.clone()))
-    //             .add_message(
-    //                 coordinator.set_active_verifiers(
-    //                     new_verifier_set
-    //                         .signers
-    //                         .values()
-    //                         .map(|signer| signer.address.to_string())
-    //                         .collect::<HashSet<String>>(),
-    //                 ),
-    //             ))
-    //     }
-    //     Some(cur_verifier_set) => {
-    //         let new_verifier_set = next_verifier_set(&deps, &env, &config)?
-    //             .ok_or(ContractError::VerifierSetUnchanged)?;
-    //
-    //         save_next_verifier_set(deps.storage, &new_verifier_set)?;
-    //
-    //         let payload = Payload::VerifierSet(new_verifier_set.clone());
-    //         let payload_id = payload.id();
-    //         PAYLOAD
-    //             .save(deps.storage, &payload_id, &payload)
-    //             .map_err(ContractError::from)?;
-    //         REPLY_TRACKER
-    //             .save(deps.storage, &payload_id)
-    //             .map_err(ContractError::from)?;
-    //
-    //         let digest =
-    //             config
-    //                 .encoder
-    //                 .digest(&config.domain_separator, &cur_verifier_set, &payload)?;
-    //
-    //         let verifier_union_set = all_active_verifiers(deps.storage)?;
-    //
-    //         Ok(Response::new()
-    //             .add_submessage(SubMsg::reply_on_success(
-    //                 multisig.start_signing_session(
-    //                     cur_verifier_set.id(),
-    //                     digest.into(),
-    //                     config.chain_name,
-    //                     None, // TODO: sig_verifier
-    //                 ),
-    //                 START_MULTISIG_REPLY_ID,
-    //             ))
-    //             .add_message(coordinator.set_active_verifiers(
-    //                 verifier_union_set.iter().map(|v| v.to_string()).collect(),
-    //             )))
-    //     }
-    // }
 }
 
 pub fn clean_verifier_set(deps: DepsMut) -> error_stack::Result<Response, ContractError> {

--- a/contracts/multisig-prover/src/contract/execute.rs
+++ b/contracts/multisig-prover/src/contract/execute.rs
@@ -1,11 +1,14 @@
 use std::collections::{BTreeMap, HashSet};
+use std::str::FromStr;
 
 use axelar_wasm_std::permission_control::Permission;
 use axelar_wasm_std::snapshot::{Participant, Snapshot};
 use axelar_wasm_std::{
     address, nonempty, permission_control, FnExt, MajorityThreshold, VerificationStatus,
 };
-use cosmwasm_std::{wasm_execute, Addr, DepsMut, Env, QuerierWrapper, Response, Storage, SubMsg};
+use cosmwasm_std::{
+    wasm_execute, Addr, DepsMut, Env, HexBinary, QuerierWrapper, Response, Storage, SubMsg, Uint128,
+};
 use error_stack::{report, Result, ResultExt};
 use itertools::Itertools;
 use multisig::msg::Signer;
@@ -63,16 +66,27 @@ pub fn construct_proof(
         .map_err(ContractError::from)?
         .ok_or(ContractError::NoVerifierSet)?;
 
-    let digest = config
+    let digest: Vec<u8> = config
         .encoder
-        .digest(&config.domain_separator, &verifier_set, &payload)?;
+        .digest(&config.domain_separator, &verifier_set, &payload)?
+        .into();
 
     let start_sig_msg = multisig::msg::ExecuteMsg::StartSigningSession {
         verifier_set_id: verifier_set.id(),
         msg: digest.into(),
         chain_name: config.chain_name,
-        sig_verifier: None,
+        sig_verifier: Some(
+            "axelar1rv940hhxe3288j42zazt7c7fmql4udsgy9cjzmeq646gt7gl02hq54seyr".to_string(),
+        ),
     };
+
+    // TODO:
+    // run this in unit-test
+    // send the message to ampd
+    // ampd -> tofnd
+    // get the ampd result
+    // translate to Aleo
+    // give it to aleo
 
     let wasm_msg =
         wasm_execute(config.multisig, &start_sig_msg, vec![]).map_err(ContractError::from)?;
@@ -83,16 +97,16 @@ pub fn construct_proof(
 fn messages(
     querier: QuerierWrapper,
     message_ids: Vec<CrossChainId>,
-    gateway: Addr,
+    gateway_addr: Addr,
     chain_name: ChainName,
 ) -> Result<Vec<Message>, ContractError> {
     let length = message_ids.len();
 
-    let gateway: gateway_api::Client = client::ContractClient::new(querier, &gateway).into();
+    let gateway: gateway_api::Client = client::ContractClient::new(querier, &gateway_addr).into();
 
-    let messages = gateway
-        .outgoing_messages(message_ids)
-        .change_context(ContractError::FailedToGetMessages)?;
+    let messages = gateway.outgoing_messages(message_ids).change_context(
+        ContractError::FailedToGetMessages(gateway_addr, chain_name.clone()),
+    )?;
 
     assert_eq!(
         messages.len(),
@@ -225,67 +239,90 @@ pub fn update_verifier_set(
     let multisig: multisig::Client =
         client::ContractClient::new(deps.querier, &config.multisig).into();
 
-    let cur_verifier_set = CURRENT_VERIFIER_SET
-        .may_load(deps.storage)
+    let new_verifier_set = make_verifier_set(&deps, &env, &config)?;
+    CURRENT_VERIFIER_SET
+        .save(deps.storage, &new_verifier_set)
         .map_err(ContractError::from)?;
 
-    match cur_verifier_set {
-        None => {
-            // if no verifier set, just store it and return
-            let new_verifier_set = make_verifier_set(&deps, &env, &config)?;
-            CURRENT_VERIFIER_SET
-                .save(deps.storage, &new_verifier_set)
-                .map_err(ContractError::from)?;
+    Ok(Response::new()
+        .add_message(multisig.register_verifier_set(new_verifier_set.clone()))
+        .add_message(
+            coordinator.set_active_verifiers(
+                new_verifier_set
+                    .signers
+                    .values()
+                    .map(|signer| signer.address.to_string())
+                    .collect::<HashSet<String>>(),
+            ),
+        ))
 
-            Ok(Response::new()
-                .add_message(multisig.register_verifier_set(new_verifier_set.clone()))
-                .add_message(
-                    coordinator.set_active_verifiers(
-                        new_verifier_set
-                            .signers
-                            .values()
-                            .map(|signer| signer.address.to_string())
-                            .collect::<HashSet<String>>(),
-                    ),
-                ))
-        }
-        Some(cur_verifier_set) => {
-            let new_verifier_set = next_verifier_set(&deps, &env, &config)?
-                .ok_or(ContractError::VerifierSetUnchanged)?;
+    // let cur_verifier_set = CURRENT_VERIFIER_SET
+    //     .may_load(deps.storage)
+    //     .map_err(ContractError::from)?;
+    //
+    // match cur_verifier_set {
+    //     None => {
+    //         // if no verifier set, just store it and return
+    //         let new_verifier_set = make_verifier_set(&deps, &env, &config)?;
+    //         CURRENT_VERIFIER_SET
+    //             .save(deps.storage, &new_verifier_set)
+    //             .map_err(ContractError::from)?;
+    //
+    //         Ok(Response::new()
+    //             .add_message(multisig.register_verifier_set(new_verifier_set.clone()))
+    //             .add_message(
+    //                 coordinator.set_active_verifiers(
+    //                     new_verifier_set
+    //                         .signers
+    //                         .values()
+    //                         .map(|signer| signer.address.to_string())
+    //                         .collect::<HashSet<String>>(),
+    //                 ),
+    //             ))
+    //     }
+    //     Some(cur_verifier_set) => {
+    //         let new_verifier_set = next_verifier_set(&deps, &env, &config)?
+    //             .ok_or(ContractError::VerifierSetUnchanged)?;
+    //
+    //         save_next_verifier_set(deps.storage, &new_verifier_set)?;
+    //
+    //         let payload = Payload::VerifierSet(new_verifier_set.clone());
+    //         let payload_id = payload.id();
+    //         PAYLOAD
+    //             .save(deps.storage, &payload_id, &payload)
+    //             .map_err(ContractError::from)?;
+    //         REPLY_TRACKER
+    //             .save(deps.storage, &payload_id)
+    //             .map_err(ContractError::from)?;
+    //
+    //         let digest =
+    //             config
+    //                 .encoder
+    //                 .digest(&config.domain_separator, &cur_verifier_set, &payload)?;
+    //
+    //         let verifier_union_set = all_active_verifiers(deps.storage)?;
+    //
+    //         Ok(Response::new()
+    //             .add_submessage(SubMsg::reply_on_success(
+    //                 multisig.start_signing_session(
+    //                     cur_verifier_set.id(),
+    //                     digest.into(),
+    //                     config.chain_name,
+    //                     None, // TODO: sig_verifier
+    //                 ),
+    //                 START_MULTISIG_REPLY_ID,
+    //             ))
+    //             .add_message(coordinator.set_active_verifiers(
+    //                 verifier_union_set.iter().map(|v| v.to_string()).collect(),
+    //             )))
+    //     }
+    // }
+}
 
-            save_next_verifier_set(deps.storage, &new_verifier_set)?;
+pub fn clean_verifier_set(deps: DepsMut) -> error_stack::Result<Response, ContractError> {
+    CURRENT_VERIFIER_SET.remove(deps.storage);
 
-            let payload = Payload::VerifierSet(new_verifier_set.clone());
-            let payload_id = payload.id();
-            PAYLOAD
-                .save(deps.storage, &payload_id, &payload)
-                .map_err(ContractError::from)?;
-            REPLY_TRACKER
-                .save(deps.storage, &payload_id)
-                .map_err(ContractError::from)?;
-
-            let digest =
-                config
-                    .encoder
-                    .digest(&config.domain_separator, &cur_verifier_set, &payload)?;
-
-            let verifier_union_set = all_active_verifiers(deps.storage)?;
-
-            Ok(Response::new()
-                .add_submessage(SubMsg::reply_on_success(
-                    multisig.start_signing_session(
-                        cur_verifier_set.id(),
-                        digest.into(),
-                        config.chain_name,
-                        None,
-                    ),
-                    START_MULTISIG_REPLY_ID,
-                ))
-                .add_message(coordinator.set_active_verifiers(
-                    verifier_union_set.iter().map(|v| v.to_string()).collect(),
-                )))
-        }
-    }
+    Ok(Response::new())
 }
 
 fn ensure_verifier_set_verification(

--- a/contracts/multisig-prover/src/encoding/aleo.rs
+++ b/contracts/multisig-prover/src/encoding/aleo.rs
@@ -26,7 +26,6 @@ pub fn payload_digest<N: Network>(
                 .change_context(ContractError::InvalidMessage)?
                 .then(Messages::from);
 
-            // println!("messages: {:?}", messages.to_aleo_string());
             messages
                 .0
                 .first()
@@ -46,18 +45,13 @@ pub fn payload_digest<N: Network>(
         ContractError::AleoError("Failed to convert domain separator to u128".to_string())
     })?);
     let domain_separator: [u128; 2] = [part1, part2];
-    // println!("domain_separator: {:02x?}", domain_separator);
 
     let payload_digest = PayloadDigest::new(&domain_separator, verifier_set, data_hash)
         .map_err(|e| ContractError::AleoError(e.to_string()))?;
 
-    // println!("payload_digest: {:?}", payload_digest);
-
     let hash = payload_digest
         .bhp::<N>()
         .map_err(|e| ContractError::AleoError(e.to_string()))?;
-
-    // println!("payload_digest hash: {:?}", hash);
 
     let next = hash.strip_suffix("group");
     let hash = next.unwrap_or(&hash);
@@ -127,9 +121,8 @@ mod tests {
             source_address: "aleo10fmsqwh059uqm74x6t6zgj93wfxtep0avevcxz0n4w9uawymkv9s7whsau"
                 .parse()
                 .unwrap(),
-            // .to_string(),
             destination_chain: "aleo-2".parse().unwrap(),
-            destination_address: "foo".parse().unwrap(), // to_string(),
+            destination_address: "foo".parse().unwrap(),
             payload_hash: [
                 0xa4, 0x32, 0xdc, 0x98, 0x3d, 0xfe, 0x6f, 0xc4, 0x8b, 0xb4, 0x7a, 0x90, 0x91, 0x54,
                 0x65, 0xd9, 0xc8, 0x18, 0x5b, 0x1c, 0x2a, 0xea, 0x5c, 0x87, 0xf8, 0x58, 0x18, 0xcb,
@@ -172,7 +165,6 @@ mod tests {
         res.unwrap()
     }
 
-    // type Curr = snarkvm_cosmwasm::network::TestnetV0;
     type Curr = snarkvm::prelude::TestnetV0;
 
     use tofn::aleo_schnorr::keygen;
@@ -185,9 +177,7 @@ mod tests {
         let msg = tofn::sdk::api::MessageDigest::from(digest);
         let signature = tofn::aleo_schnorr::sign(&key_pair, &msg).unwrap();
 
-        // println!("encoded_signature: {:?}", signature);
         let signature_str = String::from_utf8(signature.clone()).unwrap();
-        // println!("encoded_signature: {:?}", signature_str);
         let verify_key = key_pair.encoded_verifying_key();
 
         let signer = Signer {
@@ -196,15 +186,9 @@ mod tests {
             pub_key: PublicKey::AleoSchnorr(HexBinary::from(verify_key.as_bytes())),
         };
 
-        // println!("verify_key: {:?}", verify_key);
-        // println!("signer: {:?}", signer);
-
         let signature = multisig::key::Signature::AleoSchnorr(HexBinary::from(&signature[..]));
 
-        println!("--> addr: {:?}", verify_key);
-        println!("--> signature: {:?}", signature_str);
         let digest = Uint256::from_le_bytes(digest);
-        println!("--> digest: {}group", digest);
 
         SignerWithSig { signer, signature }
     }
@@ -231,7 +215,6 @@ mod tests {
             4860541,
         );
 
-        // let digest = aleo_digest();
         let digest = payload_digest::<snarkvm_cosmwasm::network::TestnetV0>(
             &domain_separator,
             &verifier_set,

--- a/contracts/multisig-prover/src/encoding/aleo.rs
+++ b/contracts/multisig-prover/src/encoding/aleo.rs
@@ -1,0 +1,259 @@
+use std::str::FromStr as _;
+
+use aleo_gateway::{AleoValue, Message, Messages, PayloadDigest, WeightedSigners};
+use axelar_wasm_std::hash::Hash;
+use axelar_wasm_std::FnExt;
+use cosmwasm_std::{HexBinary, Uint256};
+use error_stack::{Result, ResultExt};
+use multisig::msg::SignerWithSig;
+use multisig::verifier_set::VerifierSet;
+use snarkvm_cosmwasm::program::Network;
+
+use crate::error::ContractError;
+use crate::payload::Payload;
+
+pub fn payload_digest<N: Network>(
+    domain_separator: &Hash,
+    verifier_set: &VerifierSet,
+    payload: &Payload,
+) -> Result<Hash, ContractError> {
+    let data_hash = match payload {
+        Payload::Messages(messages) => {
+            let messages = messages
+                .iter()
+                .map(Message::try_from)
+                .collect::<Result<Vec<_>, _>>()
+                .change_context(ContractError::InvalidMessage)?
+                .then(Messages::from);
+
+            // println!("messages: {:?}", messages.to_aleo_string());
+            messages
+                .0
+                .first()
+                .ok_or(ContractError::InvalidMessage)?
+                .bhp::<N>()
+        }
+        Payload::VerifierSet(verifier_set) => WeightedSigners::try_from(verifier_set)
+            .change_context(ContractError::InvalidVerifierSet)?
+            .bhp::<N>(),
+    }
+    .map_err(|e| ContractError::AleoError(e.to_string()))?;
+
+    let part1 = u128::from_le_bytes(domain_separator[0..16].try_into().map_err(|_| {
+        ContractError::AleoError("Failed to convert domain separator to u128".to_string())
+    })?);
+    let part2 = u128::from_le_bytes(domain_separator[16..32].try_into().map_err(|_| {
+        ContractError::AleoError("Failed to convert domain separator to u128".to_string())
+    })?);
+    let domain_separator: [u128; 2] = [part1, part2];
+    // println!("domain_separator: {:02x?}", domain_separator);
+
+    let payload_digest = PayloadDigest::new(&domain_separator, verifier_set, data_hash)
+        .map_err(|e| ContractError::AleoError(e.to_string()))?;
+
+    // println!("payload_digest: {:?}", payload_digest);
+
+    let hash = payload_digest
+        .bhp::<N>()
+        .map_err(|e| ContractError::AleoError(e.to_string()))?;
+
+    // println!("payload_digest hash: {:?}", hash);
+
+    let next = hash.strip_suffix("group");
+    let hash = next.unwrap_or(&hash);
+
+    let hash = Uint256::from_str(&hash).unwrap();
+    let hash = hash.to_le_bytes();
+
+    Ok(hash)
+}
+
+/// The relayer will use this data to submit the payload to the contract.
+pub fn encode_execute_data(
+    domain_separator: &Hash,
+    verifier_set: &VerifierSet,
+    signatures: Vec<SignerWithSig>,
+    payload: &Payload,
+) -> Result<HexBinary, ContractError> {
+    let payload = match payload {
+        Payload::Messages(messages) => messages
+            .iter()
+            .map(Message::try_from)
+            .collect::<Result<Vec<_>, _>>()
+            .change_context(ContractError::InvalidMessage)?
+            .then(Messages::from),
+        Payload::VerifierSet(verifier_set) => todo!(),
+    };
+
+    let proof = aleo_gateway::Proof::new(
+        verifier_set.clone(),
+        signatures.first().ok_or(ContractError::Proof)?.clone(),
+    )
+    .change_context(ContractError::Proof)?;
+
+    let execute_data = aleo_gateway::ExecuteData::new(
+        proof,
+        payload.0.first().ok_or(ContractError::Proof)?.clone(),
+    );
+
+    let execute_data = execute_data
+        .to_aleo_string()
+        .map_err(|e| ContractError::AleoError(e.to_string()))?;
+
+    Ok(HexBinary::from(execute_data.as_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use axelar_wasm_std::Participant;
+    use cosmwasm_std::Addr;
+    use multisig::key::PublicKey;
+    use multisig::msg::Signer;
+    use prost::Message;
+    use router_api::{ChainName, ChainNameRaw};
+
+    use super::*;
+
+    fn message() -> router_api::Message {
+        router_api::Message {
+            cc_id: router_api::CrossChainId {
+                source_chain: ChainNameRaw::from_str("aleo-2").unwrap(),
+                message_id: "au1h9zxxrshyratfx0g0p5w8myqxk3ydfyxc948jysk0nxcna59ssqq0n3n3y"
+                    .parse()
+                    .unwrap(),
+            },
+            source_address: "aleo10fmsqwh059uqm74x6t6zgj93wfxtep0avevcxz0n4w9uawymkv9s7whsau"
+                .parse()
+                .unwrap(),
+            // .to_string(),
+            destination_chain: "aleo-2".parse().unwrap(),
+            destination_address: "foo".parse().unwrap(), // to_string(),
+            payload_hash: [
+                0xa4, 0x32, 0xdc, 0x98, 0x3d, 0xfe, 0x6f, 0xc4, 0x8b, 0xb4, 0x7a, 0x90, 0x91, 0x54,
+                0x65, 0xd9, 0xc8, 0x18, 0x5b, 0x1c, 0x2a, 0xea, 0x5c, 0x87, 0xf8, 0x58, 0x18, 0xcb,
+                0xa3, 0x50, 0x51, 0xc6,
+            ],
+        }
+    }
+
+    fn aleo_digest() -> Hash {
+        let domain_separator = [
+            105u8, 115u8, 199u8, 41u8, 53u8, 96u8, 68u8, 100u8, 178u8, 136u8, 39u8, 20u8, 27u8,
+            10u8, 70u8, 58u8, 248u8, 227u8, 72u8, 118u8, 22u8, 222u8, 105u8, 197u8, 170u8, 12u8,
+            120u8, 83u8, 146u8, 201u8, 251u8, 159u8,
+        ];
+
+        let verifier_set = VerifierSet::new(
+            vec![
+                (Participant {
+                    address: Addr::unchecked("axelar1ckguw8l9peg6sykx30cy35t6l0wpfu23xycme7"),
+                    weight: 1.try_into().unwrap(),
+                },
+                PublicKey::AleoSchnorr(HexBinary::from(hex::decode("616c656f313435746a396871726e76336871796c72656d3670377a6a797863326b727979703368646d34687434386e746a336535747475787339787339616b").unwrap())),
+                )],
+            1u128.try_into().unwrap(),
+            4860541,
+        );
+
+        let message = message();
+
+        // The hash of the payload, send from the relayer of the source chain
+        let payload = Payload::Messages(vec![message]);
+
+        let res = payload_digest::<snarkvm_cosmwasm::network::TestnetV0>(
+            &domain_separator,
+            &verifier_set,
+            &payload,
+        );
+        println!("payload digest: {:?}", res);
+
+        res.unwrap()
+    }
+
+    // type Curr = snarkvm_cosmwasm::network::TestnetV0;
+    type Curr = snarkvm::prelude::TestnetV0;
+
+    use tofn::aleo_schnorr::keygen;
+    use tofn::sdk::api::SecretRecoveryKey;
+
+    fn aleo_sig(digest: [u8; 32]) -> SignerWithSig {
+        let arr = [0; 64];
+        let k = SecretRecoveryKey::try_from(&arr[..]).unwrap();
+        let key_pair = keygen::<Curr>(&k, b"tofn nonce").unwrap();
+        let msg = tofn::sdk::api::MessageDigest::from(digest);
+        let signature = tofn::aleo_schnorr::sign(&key_pair, &msg).unwrap();
+
+        // println!("encoded_signature: {:?}", signature);
+        let signature_str = String::from_utf8(signature.clone()).unwrap();
+        // println!("encoded_signature: {:?}", signature_str);
+        let verify_key = key_pair.encoded_verifying_key();
+
+        let signer = Signer {
+            address: Addr::unchecked("aleo-validator".to_string()),
+            weight: 1u128.try_into().unwrap(),
+            pub_key: PublicKey::AleoSchnorr(HexBinary::from(verify_key.as_bytes())),
+        };
+
+        // println!("verify_key: {:?}", verify_key);
+        // println!("signer: {:?}", signer);
+
+        let signature = multisig::key::Signature::AleoSchnorr(HexBinary::from(&signature[..]));
+
+        println!("--> addr: {:?}", verify_key);
+        println!("--> signature: {:?}", signature_str);
+        let digest = Uint256::from_le_bytes(digest);
+        println!("--> digest: {}group", digest);
+
+        SignerWithSig { signer, signature }
+    }
+
+    use std::convert::TryFrom;
+
+    #[test]
+    fn aleo_execute_data() {
+        let domain_separator = [
+            105u8, 115u8, 199u8, 41u8, 53u8, 96u8, 68u8, 100u8, 178u8, 136u8, 39u8, 20u8, 27u8,
+            10u8, 70u8, 58u8, 248u8, 227u8, 72u8, 118u8, 22u8, 222u8, 105u8, 197u8, 170u8, 12u8,
+            120u8, 83u8, 146u8, 201u8, 251u8, 159u8,
+        ];
+
+        let verifier_set = VerifierSet::new(
+            vec![
+                (Participant {
+                    address: Addr::unchecked("axelar1ckguw8l9peg6sykx30cy35t6l0wpfu23xycme7"),
+                    weight: 1.try_into().unwrap(),
+                },
+                PublicKey::AleoSchnorr(HexBinary::from(hex::decode("616c656f313435746a396871726e76336871796c72656d3670377a6a797863326b727979703368646d34687434386e746a336535747475787339787339616b").unwrap())),
+                )],
+            1u128.try_into().unwrap(),
+            4860541,
+        );
+
+        // let digest = aleo_digest();
+        let digest = payload_digest::<snarkvm_cosmwasm::network::TestnetV0>(
+            &domain_separator,
+            &verifier_set,
+            &Payload::Messages(vec![message()]),
+        ).unwrap();
+
+        println!("digest: {:?}", digest);
+
+        let execute_data = encode_execute_data(
+            &domain_separator,
+            &verifier_set,
+            vec![aleo_sig(digest)],
+            &Payload::Messages(vec![message()]),
+        )
+        .unwrap();
+
+        println!(
+            "execute_data: {:?}",
+            String::from_utf8(execute_data.as_slice().to_vec()).unwrap()
+        );
+
+        let m = message();
+        println!("message: {:?}", aleo_gateway::Message::try_from(&m).unwrap().to_aleo_string());
+    }
+}

--- a/contracts/multisig-prover/src/encoding/mod.rs
+++ b/contracts/multisig-prover/src/encoding/mod.rs
@@ -1,4 +1,5 @@
 mod abi;
+mod aleo;
 mod bcs;
 mod stellar_xdr;
 
@@ -18,6 +19,7 @@ pub enum Encoder {
     Abi,
     Bcs,
     StellarXdr,
+    Aleo,
 }
 
 impl Encoder {
@@ -33,6 +35,7 @@ impl Encoder {
             Encoder::StellarXdr => {
                 stellar_xdr::payload_digest(domain_separator, verifier_set, payload)
             }
+            Encoder::Aleo => aleo::payload_digest::<snarkvm_cosmwasm::network::TestnetV0>(domain_separator, verifier_set, payload),
         }
     }
 
@@ -47,6 +50,9 @@ impl Encoder {
             Encoder::Abi => abi::encode_execute_data(domain_separator, verifier_set, sigs, payload),
             Encoder::Bcs => bcs::encode_execute_data(domain_separator, verifier_set, sigs, payload),
             Encoder::StellarXdr => stellar_xdr::encode_execute_data(verifier_set, sigs, payload),
+            Encoder::Aleo => {
+                aleo::encode_execute_data(domain_separator, verifier_set, sigs, payload)
+            }
         }
     }
 }

--- a/contracts/multisig-prover/src/error.rs
+++ b/contracts/multisig-prover/src/error.rs
@@ -1,5 +1,5 @@
 use axelar_wasm_std::{nonempty, IntoContractError};
-use cosmwasm_std::StdError;
+use cosmwasm_std::{Addr, StdError};
 use cw_utils::ParseReplyError;
 use router_api::ChainName;
 use thiserror::Error;
@@ -82,8 +82,11 @@ pub enum ContractError {
     #[error("failed to serialize data for the external gateway")]
     SerializeData,
 
-    #[error("failed to get outgoing messages from gateway")]
-    FailedToGetMessages,
+    #[error("failed to get outgoing messages from gateway: '{0}', '{1}'")]
+    FailedToGetMessages(Addr, ChainName),
+
+    #[error("Aleo error: {0}")]
+    AleoError(String),
 
     #[error("failed to build verifier set")]
     FailedToBuildVerifierSet,

--- a/contracts/multisig-prover/src/msg.rs
+++ b/contracts/multisig-prover/src/msg.rs
@@ -67,6 +67,9 @@ pub enum ExecuteMsg {
     #[permission(Elevated)]
     UpdateVerifierSet,
 
+    #[permission(Elevated)]
+    CleanVerifierSet,
+
     #[permission(Any)]
     ConfirmVerifierSet,
     // Updates the signing threshold. The threshold currently in use does not change.

--- a/contracts/multisig/Cargo.toml
+++ b/contracts/multisig/Cargo.toml
@@ -37,6 +37,7 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
+aleo-types = { workspace = true }
 axelar-wasm-std = { workspace = true, features = ["derive"] }
 client = { workspace = true }
 cosmwasm-crypto = { workspace = true }
@@ -61,12 +62,16 @@ sha3 = { workspace = true }
 signature-verifier-api = { workspace = true }
 thiserror = { workspace = true }
 
+rand_chacha = "0.3"
+multisig-aleo = { path = "../multisig-aleo" }
+
 [dev-dependencies]
 curve25519-dalek = "4.1.3"
 cw-multi-test = { workspace = true }
 ed25519-dalek = { workspace = true, features = ["digest", "rand_core"] }
 goldie = { workspace = true }
 hex = "0.4"
+snarkvm-cosmwasm = { workspace = true }
 
 [lints]
 workspace = true

--- a/contracts/multisig/src/contract.rs
+++ b/contracts/multisig/src/contract.rs
@@ -36,9 +36,6 @@ pub fn migrate(
     _env: Env,
     _msg: Empty,
 ) -> Result<Response, axelar_wasm_std::error::ContractError> {
-    // cw2::assert_contract_version(deps.storage, CONTRACT_NAME, BASE_VERSION)?;
-    // cw2::set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
     Ok(Response::default())
 }
 

--- a/contracts/multisig/src/signing.rs
+++ b/contracts/multisig/src/signing.rs
@@ -375,6 +375,7 @@ mod tests {
             let sig_bytes = match config.key_type {
                 KeyType::Ecdsa =>   "a58c9543b9df54578ec45838948e19afb1c6e4c86b34d9899b10b44e619ea74e19b457611e41a047030ed233af437d7ecff84de97cb6b3c13d73d22874e03511",
                 KeyType::Ed25519 => "1fe264eb7258d48d8feedea4d237ccb20157fbe5eb412bc971d758d072b036a99b06d20853c1f23cdf82085917e08dda2fcfbb5d4d7ee17d74e4988ae81d0308",
+                KeyType::AleoSchnorr => todo!(),
             };
 
             let invalid_sig: Signature = (config.key_type, HexBinary::from_hex(sig_bytes).unwrap())

--- a/contracts/multisig/src/test/common.rs
+++ b/contracts/multisig/src/test/common.rs
@@ -131,6 +131,73 @@ pub mod ed25519_test_data {
     }
 }
 
+// pub mod aleo_schnorr_test_data {
+//     // APrivateKey1zkpEjXSofaQtApqm33wYLmHiGNLb99VZqLeRW19xWKHQWZW
+//     // AViewKey1gmHkeDm2NEvJSWUTRf9SCwaEU6uSjdYnaSXa7dsn67QW
+//     // aleo1et20lkz4f4a849mmnpz4670gpaekp030prm69eymaep8jppglsyslhyf9n
+//
+//     use std::str::FromStr;
+//
+//     use cosmwasm_std::testing::MockApi;
+//     use rand_chacha::rand_core::SeedableRng;
+//     // use k256::ecdsa::signature::SignerMut;
+//     use sha3::{Digest, Keccak256};
+//     use snarkvm_wasm::account::PrivateKey;
+//
+//     use super::*;
+//
+//     pub fn new(
+//         address: Addr,
+//         private_key: PrivateKey<snarkvm_wasm::network::TestnetV0>,
+//     ) -> TestSigner {
+//         let address_hash = Keccak256::digest(address.as_bytes());
+//         let verifying_key = snarkvm_wasm::account::Address::try_from(&private_key).unwrap();
+//         let signature = snarkvm_wasm::account::signature::Signature::sign_bytes(
+//             &private_key,
+//             message().as_slice(),
+//             &mut rand_chacha::ChaChaRng::from_entropy(),
+//         )
+//         .unwrap();
+//
+//         TestSigner {
+//             address,
+//             pub_key: verifying_key.to_string().as_bytes().to_vec().into(),
+//             signature: signature.to_string().as_bytes().to_vec().into(),
+//             signed_address: HexBinary::default(),
+//         }
+//     }
+//
+//     pub fn pub_key() -> HexBinary {
+//         HexBinary::from(
+//             "aleo1et20lkz4f4a849mmnpz4670gpaekp030prm69eymaep8jppglsyslhyf9n".as_bytes(),
+//         )
+//     }
+//
+//     pub fn signature() -> HexBinary {
+//         HexBinary::from("sign156wgsta9htrmyav5a6lrex6qu0eherjgvthkheelv3gkdxgtksq2ndv3547e7gq0xnwallk5tc407cyxkexnhvv3qqtfmyhqs095sqg5hht9cgrfl42000szdz9kg0wkvut6ff5czfgj6ctr7j7k7dxlqyz483xpxr5c70wjwh6a233d2puds04vfy9plrgzsz2vpqlypc0qqca3azj".as_bytes())
+//     }
+//
+//     pub fn message() -> HexBinary {
+//         HexBinary::from_hex("fa0609efd1dfeedfdcc8ba51520fae2d5176b7621d2560f071e801b0817e1537")
+//             .unwrap()
+//     }
+//
+//     pub fn signers() -> Vec<TestSigner> {
+//         let api = MockApi::default();
+//         let addresses = vec!["signer1", "signer2", "signer3"]
+//             .into_iter()
+//             .map(|name| api.addr_make(name));
+//         let signing_keys = vec!["APrivateKey1zkpEjXSofaQtApqm33wYLmHiGNLb99VZqLeRW19xWKHQWZW"]
+//             .into_iter()
+//             .map(|key| PrivateKey::from_str(key).unwrap());
+//
+//         addresses
+//             .zip(signing_keys)
+//             .map(|(address, signing_key)| new(address, signing_key))
+//             .collect()
+//     }
+// }
+
 #[allow(clippy::arithmetic_side_effects)]
 pub fn build_verifier_set(key_type: KeyType, signers: &[TestSigner]) -> VerifierSet {
     let mut total_weight = Uint128::zero();

--- a/contracts/voting-verifier/src/contract.rs
+++ b/contracts/voting-verifier/src/contract.rs
@@ -1,5 +1,6 @@
-use axelar_wasm_std::address::validate_address;
-use axelar_wasm_std::{address, permission_control, FnExt};
+use axelar_wasm_std::address::validate_contract_address;
+use axelar_wasm_std::nonempty::Uint64;
+use axelar_wasm_std::{address, permission_control, FnExt, MajorityThreshold, Threshold};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
@@ -31,7 +32,7 @@ pub fn instantiate(
     let governance = address::validate_cosmwasm_address(deps.api, &msg.governance_address)?;
     permission_control::set_governance(deps.storage, &governance)?;
 
-    validate_address(&msg.source_gateway_address, &msg.address_format)
+    validate_contract_address(&msg.source_gateway_address, &msg.address_format)
         .change_context(ContractError::InvalidSourceGatewayAddress)?;
 
     let config = Config {
@@ -111,9 +112,48 @@ pub fn migrate(
     _env: Env,
     _msg: Empty,
 ) -> Result<Response, axelar_wasm_std::error::ContractError> {
-    cw2::assert_contract_version(deps.storage, CONTRACT_NAME, BASE_VERSION)?;
-
+    // TODO: THIS FUNCTION SHOULD BE REVERTED, AND THE CODE ADDED BELOW SHOULD BE DELETED
+    // cw2::assert_contract_version(deps.storage, CONTRACT_NAME, BASE_VERSION)?;
+    //
     cw2::set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    /*
+    {
+      "service_registry_contract": "axelar1c9fkszt5lq34vvvlat3fxj6yv7ejtqapz04e97vtc9m5z9cwnamq8zjlhz",
+      "service_name": "validators",
+      "source_gateway_address": "vzevxifdoj.aleo",
+      "voting_threshold": ["1", "1"],
+      "block_expiry": "10",
+      "confirmation_height": 1,
+      "source_chain": "aleo",
+      "rewards_contract": "axelar1vaj9sfzc3z0gpel90wu4ljutncutv0wuhvvwfsh30rqxq422z89qnd989l",
+      "msg_id_format": "bech32m",
+      "address_format": "aleo"
+    }
+        */
+
+    let config = Config {
+        service_name: "validators".parse().unwrap(),
+        service_registry_contract: cosmwasm_std::Addr::unchecked(
+            "axelar1c9fkszt5lq34vvvlat3fxj6yv7ejtqapz04e97vtc9m5z9cwnamq8zjlhz",
+        ),
+        source_gateway_address: "vzevxifdoj.aleo".parse().unwrap(),
+        voting_threshold: MajorityThreshold::try_from(Threshold::try_from((1, 1)).unwrap())
+            .unwrap(),
+        block_expiry: Uint64::try_from(10u64).unwrap(),
+        confirmation_height: 1,
+        source_chain: "aleo-2".parse().unwrap(),
+        rewards_contract: cosmwasm_std::Addr::unchecked(
+            "axelar1vaj9sfzc3z0gpel90wu4ljutncutv0wuhvvwfsh30rqxq422z89qnd989l",
+        ),
+        msg_id_format: axelar_wasm_std::msg_id::MessageIdFormat::Bech32m {
+            prefix: "au".to_string().try_into().unwrap(),
+            length: 61,
+        },
+        address_format: address::AddressFormat::Aleo,
+    };
+
+    CONFIG.save(deps.storage, &config)?;
 
     Ok(Response::default())
 }
@@ -351,6 +391,11 @@ mod test {
                 should_fail: false,
             },
             TestCase {
+                source_gateway_address: "gateway.aleo".to_string(),
+                address_format: AddressFormat::Aleo,
+                should_fail: false,
+            },
+            TestCase {
                 source_gateway_address: "0x4f4495243837681061C4743b74B3eEdf548D56A5".to_string(),
                 address_format: AddressFormat::Eip55,
                 should_fail: true,
@@ -425,6 +470,12 @@ mod test {
                 address_format: AddressFormat::Sui,
                 should_fail: true,
             },
+            TestCase {
+                source_gateway_address:
+                    "aleo1q3t7cjwk9ncxcdxfm8r5ax83mzudd923gffncv5egfjyevfevuyscvcvz".to_string(),
+                address_format: AddressFormat::Aleo,
+                should_fail: true,
+            },
         ];
 
         for TestCase {
@@ -466,6 +517,93 @@ mod test {
                 assert_ok!(result);
             }
         }
+    }
+
+    fn setup_aleo(
+        verifiers: Vec<Verifier>,
+        msg_id_format: &MessageIdFormat,
+    ) -> OwnedDeps<MockStorage, MockApi, MockQuerier, Empty> {
+        // TODO: THIS IS WIP. JUST FOR SANITY TESTING
+        let mut deps = mock_dependencies();
+
+        instantiate(
+            deps.as_mut(),
+            mock_env(),
+            mock_info("admin", &[]),
+            InstantiateMsg {
+                governance_address: GOVERNANCE.parse().unwrap(),
+                service_registry_address: SERVICE_REGISTRY_ADDRESS.parse().unwrap(),
+                service_name: SERVICE_NAME.parse().unwrap(),
+                source_gateway_address: "gateway.aleo".parse().unwrap(),
+                voting_threshold: initial_voting_threshold(),
+                block_expiry: POLL_BLOCK_EXPIRY.try_into().unwrap(),
+                confirmation_height: 100,
+                source_chain: source_chain(),
+                rewards_address: REWARDS_ADDRESS.parse().unwrap(),
+                msg_id_format: msg_id_format.clone(),
+                address_format: AddressFormat::Aleo,
+            },
+        )
+        .unwrap();
+
+        deps.querier.update_wasm(move |wq| match wq {
+            WasmQuery::Smart { contract_addr, .. } if contract_addr == SERVICE_REGISTRY_ADDRESS => {
+                Ok(to_json_binary(
+                    &verifiers
+                        .clone()
+                        .into_iter()
+                        .map(|v| WeightedVerifier {
+                            verifier_info: v,
+                            weight: VERIFIER_WEIGHT,
+                        })
+                        .collect::<Vec<WeightedVerifier>>(),
+                )
+                .into())
+                .into()
+            }
+            _ => panic!("no mock for this query"),
+        });
+
+        deps
+    }
+
+    #[test]
+    fn test_drive() {
+        // TODO: THIS IS WIP. JUST FOR SANITY TESTING
+        let msg_id_format = MessageIdFormat::HexTxHashAndEventIndex;
+        let verifiers = verifiers(2);
+        let mut deps = setup_aleo(verifiers.clone(), &msg_id_format);
+
+        let msg = ExecuteMsg::VerifyMessages(vec![
+            Message {
+                cc_id: CrossChainId::new(source_chain(), message_id("id", 1, &msg_id_format))
+                    .unwrap(),
+                source_address: "aleo1thg4clvgc2d0vpl6jzgnzw7zvdulq7r4xuluw66lq2wg7sw4hszs00d8dd"
+                    .to_owned()
+                    .parse()
+                    .unwrap(),
+                destination_chain: "destination-chain1".parse().unwrap(),
+                destination_address: "destination-address1".parse().unwrap(),
+                payload_hash: [0; 32],
+            },
+            Message {
+                cc_id: CrossChainId::new(source_chain(), message_id("id", 2, &msg_id_format))
+                    .unwrap(),
+                source_address: "aleo1thg4clvgc2d0vpl6jzgnzw7zvdulq7r4xuluw66lq2wg7sw4hszs00d8dd"
+                    .to_owned()
+                    .parse()
+                    .unwrap(),
+                destination_chain: "destination-chain2".parse().unwrap(),
+                destination_address: "destination-address2".parse().unwrap(),
+                payload_hash: [0; 32],
+            },
+        ]);
+        assert_ok!(execute(
+            deps.as_mut(),
+            mock_env(),
+            mock_info(SENDER, &[]),
+            msg
+        ));
     }
 
     #[test]

--- a/external-gateways/stellar/src/lib.rs
+++ b/external-gateways/stellar/src/lib.rs
@@ -215,6 +215,7 @@ impl TryFrom<&VerifierSet> for WeightedSigners {
                     weight: signer.weight.into(),
                 }),
                 PublicKey::Ecdsa(_) => Err(Report::new(Error::UnsupportedPublicKey)),
+                PublicKey::AleoSchnorr(_) => Err(Report::new(Error::UnsupportedPublicKey)),
             })
             .collect::<Result<Vec<_>, _>>()?;
 

--- a/packages/aleo-gateway/Cargo.toml
+++ b/packages/aleo-gateway/Cargo.toml
@@ -18,8 +18,6 @@ regex = { version = "1.10.0", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-# snarkos-account = { version = "3.1.0" }
-# snarkvm = { version = "1.1.0" }
 rand = "0.8"
 
 [lints]

--- a/packages/aleo-gateway/Cargo.toml
+++ b/packages/aleo-gateway/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "aleo-gateway"
+version = "0.1.0"
+rust-version.workspace = true
+edition.workspace = true
+
+[dependencies]
+aleo-types = { workspace = true }
+router-api = { workspace = true }
+error-stack = { workspace = true }
+thiserror = { workspace = true }
+cosmwasm-std = { workspace = true }
+hex.workspace = true
+multisig = { workspace = true, features = ["library"] }
+snarkvm-cosmwasm = { workspace = true }
+regex = { version = "1.10.0", default-features = false, features = [
+  "std",
+] }
+
+[dev-dependencies]
+# snarkos-account = { version = "3.1.0" }
+# snarkvm = { version = "1.1.0" }
+rand = "0.8"
+
+[lints]
+workspace = true

--- a/packages/aleo-gateway/src/execute_data.rs
+++ b/packages/aleo-gateway/src/execute_data.rs
@@ -1,0 +1,27 @@
+use error_stack::Report;
+
+use crate::proof::Proof;
+use crate::{AleoValue, Error, Message};
+
+pub struct ExecuteData {
+    proof: Proof,
+    payload: Message,
+}
+
+impl ExecuteData {
+    pub fn new(proof: Proof, payload: Message) -> ExecuteData {
+        ExecuteData { proof, payload }
+    }
+}
+
+impl AleoValue for ExecuteData {
+    fn to_aleo_string(&self) -> Result<String, Report<Error>> {
+        let res = format!(
+            r#"{{ proof: {}, message: {} }}"#,
+            self.proof.to_aleo_string()?,
+            self.payload.to_aleo_string()?
+        );
+
+        Ok(res)
+    }
+}

--- a/packages/aleo-gateway/src/lib.rs
+++ b/packages/aleo-gateway/src/lib.rs
@@ -1,0 +1,503 @@
+use std::str::FromStr as _;
+
+use error_stack::Report;
+use snarkvm_cosmwasm::network::Network;
+use snarkvm_cosmwasm::program::ToBits;
+use thiserror::Error;
+
+mod execute_data;
+mod message;
+mod messages;
+mod payload_digest;
+mod proof;
+mod raw_signature;
+mod signer_with_signature;
+mod string_encoder;
+mod weighted_signer;
+mod weighted_signers;
+
+pub use execute_data::*;
+pub use message::*;
+pub use messages::*;
+pub use payload_digest::*;
+pub use proof::*;
+pub use raw_signature::*;
+pub use signer_with_signature::*;
+pub use string_encoder::*;
+pub use weighted_signer::*;
+pub use weighted_signers::*;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("AleoGateway: {0}")]
+    AleoGateway(String),
+    #[error("Unsupported Public Key: {0}")]
+    UnsupportedPublicKey(String),
+    #[error("Aleo: {0}")]
+    Aleo(#[from] snarkvm_cosmwasm::program::Error),
+    #[error("Hex: {0}")]
+    Hex(#[from] hex::FromHexError),
+    #[error("AleoTypes: {0}")]
+    AleoTypes(#[from] aleo_types::Error),
+    #[error("InvalidSourceChainLength: expected: {expected}, actual: {actual}")]
+    InvalidEncodedStringLength { expected: usize, actual: usize },
+    #[error("Invalid ascii character")]
+    InvalidAscii,
+}
+
+pub trait AleoValue {
+    fn to_aleo_string(&self) -> Result<String, Report<Error>>;
+
+    fn hash<N: Network>(&self) -> Result<[u8; 32], Report<Error>> {
+        let input = self.to_aleo_string()?;
+        hash::<std::string::String, N>(input)
+    }
+
+    fn bhp<N: Network>(&self) -> Result<String, Report<Error>> {
+        let input = self.to_aleo_string()?;
+        aleo_hash::<std::string::String, N>(input)
+    }
+}
+
+pub fn aleo_hash<T: AsRef<str>, N: Network>(input: T) -> Result<String, Report<Error>> {
+    let aleo_value: Vec<bool> = snarkvm_cosmwasm::program::Value::<N>::from_str(input.as_ref())
+        .map_err(|e| {
+            Report::new(Error::Aleo(e))
+                .attach_printable(format!("input: '{:?}'", input.as_ref().to_owned()))
+        })?
+        .to_bits_le();
+
+    let bits = N::hash_keccak256(&aleo_value).map_err(|e| {
+        Report::new(Error::Aleo(e))
+            .attach_printable(format!("input2: '{:?}'", input.as_ref().to_owned()))
+    })?;
+
+    let group = N::hash_to_group_bhp256(&bits).unwrap();
+
+    Ok(group.to_string())
+}
+
+fn hash<T: AsRef<str>, N: Network>(input: T) -> Result<[u8; 32], Report<Error>> {
+    let aleo_value: Vec<bool> = snarkvm_cosmwasm::program::Value::<N>::from_str(input.as_ref())
+        .map_err(|e| {
+            Report::new(Error::Aleo(e))
+                .attach_printable(format!("input: '{:?}'", input.as_ref().to_owned()))
+        })?
+        .to_bits_le();
+
+    let bits = N::hash_keccak256(&aleo_value).map_err(|e| {
+        Report::new(Error::Aleo(e))
+            .attach_printable(format!("input2: '{:?}'", input.as_ref().to_owned()))
+    })?;
+
+    let mut hash = [0u8; 32];
+    for (i, b) in bits.chunks(8).enumerate() {
+        let mut byte = 0u8;
+        for (i, bit) in b.iter().enumerate() {
+            if *bit {
+                byte |= 1 << i;
+            }
+        }
+        hash[i] = byte;
+    }
+
+    Ok(hash)
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::BTreeMap;
+
+    use cosmwasm_std::{Addr, HexBinary};
+    use multisig::msg::Signer;
+    use router_api::{CrossChainId, Message as RouterMessage};
+    // use snarkvm::prelude::PrivateKey;
+    use snarkvm_cosmwasm::account::PrivateKey;
+    use snarkvm_cosmwasm::network::ToFields;
+    use snarkvm_cosmwasm::types::{Address, Field};
+    use string_encoder::StringEncoder;
+
+    use super::*;
+
+    fn router_message() -> RouterMessage {
+        let source_chain = "aleo-2";
+        let message_id = "au1dudq5uvhtvqry59cfm5nz4pwu95hyrak427nqqk2uvg5n530hg9su50yfm";
+        let source_address = "aleo10fmsqwh059uqm74x6t6zgj93wfxtep0avevcxz0n4w9uawymkv9s7whsau";
+        let destination_chain = "aleo-2";
+        let destination_address = "666f6f";
+        // let destination_address = "666f6f0000000000000000000000000000000000";
+        let payload_hash = "a432dc983dfe6fc48bb47a90915465d9c8185b1c2aea5c87f85818cba35051c6";
+
+        RouterMessage {
+            cc_id: CrossChainId::new(source_chain, message_id).unwrap(),
+            source_address: source_address.parse().unwrap(),
+            destination_address: destination_address.parse().unwrap(),
+            destination_chain: destination_chain.parse().unwrap(),
+            payload_hash: HexBinary::from_hex(payload_hash)
+                .unwrap()
+                .to_array::<32>()
+                .unwrap(),
+        }
+    }
+
+    // fn message(router_message: RouterMessage) -> Message {
+    //     Message::try_from(&router_messages).unwrap()
+    // }
+
+    // fn from_aleo_string(input: String) {
+    //     const PATTERN: &str = r#"\{source_chain: \[([0-9]+u128, [0-9]+u128)\], message_id: \[([0-9]+u128, [0-9]+u128, [0-9]+u128, [0-9]+u128, [0-9]+u128, [0-9]+u128, [0-9]+u128, [0-9]+u128)\], source_address: \[([0-9]+u128, [0-9]+u128, [0-9]+u128, [0-9]+u128)\], contract_address: \[([0-9]+u128, [0-9]+u128, [0-9]+u128, [0-9]+u128)\], payload_hash: \[([0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8)\]\}"#;
+    //
+    //     let reg = regex::Regex::new(PATTERN).unwrap();
+    //
+    //     let (_, [source_chain, message_id, source_address, contract_address, payload_hash]) =
+    //         reg.captures(input.as_str()).unwrap().extract();
+    //
+    //     let source_chain = StringEncoder::from_aleo_value(source_chain).unwrap();
+    //     let message_id = StringEncoder::from_aleo_value(message_id).unwrap();
+    //     let source_address = StringEncoder::from_aleo_value(source_address).unwrap();
+    //     let contract_address = StringEncoder::from_aleo_value(contract_address).unwrap();
+    //
+    //     println!("source_chain: {:?}", source_chain.decode());
+    //     println!("message_id: {:?}", message_id.decode());
+    //     println!("source_address: {:?}", source_address.decode());
+    //     println!("contract_address: {:?}", contract_address.decode());
+    //     println!("payload_hash: {:?}", payload_hash);
+    // }
+
+    #[test]
+    fn sanity_test_encode_decode() {
+        let router_message = router_message();
+        let message = Message::try_from(&router_message).unwrap();
+        let aleo_string = message.to_aleo_string().unwrap();
+        println!("aleo_string: {:?}", aleo_string);
+
+        const PATTERN: &str = r#"\{source_chain: \[([0-9]+u128, [0-9]+u128)\], message_id: \[([0-9]+u128, [0-9]+u128, [0-9]+u128, [0-9]+u128, [0-9]+u128, [0-9]+u128, [0-9]+u128, [0-9]+u128)\], source_address: \[([0-9]+u128, [0-9]+u128, [0-9]+u128, [0-9]+u128)\], contract_address: \[([0-9]+u128, [0-9]+u128, [0-9]+u128, [0-9]+u128)\], payload_hash: \[([0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8, [0-9]+u8)\]\}"#;
+
+        let reg = regex::Regex::new(PATTERN).unwrap();
+
+        let (_, [source_chain, message_id, source_address, contract_address, payload_hash]) =
+            reg.captures(aleo_string.as_str()).unwrap().extract();
+
+        let source_chain = StringEncoder::from_aleo_value(source_chain)
+            .unwrap()
+            .decode();
+        let message_id = StringEncoder::from_aleo_value(message_id).unwrap().decode();
+        let source_address = StringEncoder::from_aleo_value(source_address)
+            .unwrap()
+            .decode();
+        let contract_address = StringEncoder::from_aleo_value(contract_address)
+            .unwrap()
+            .decode();
+        let payload_hash = "a432dc983dfe6fc48bb47a90915465d9c8185b1c2aea5c87f85818cba35051c6";
+
+        println!("source_chain: {:?}", source_chain);
+        println!("message_id: {:?}", message_id);
+        println!("source_address: {:?}", source_address);
+        println!("contract_address: {:?}", contract_address);
+
+        let next_message = Message {
+            cc_id: CrossChainId::new(source_chain.clone(), message_id).unwrap(),
+            source_address: source_address.parse().unwrap(),
+            destination_address: contract_address.parse().unwrap(),
+            destination_chain: source_chain.parse().unwrap(),
+            payload_hash: message.payload_hash,
+        };
+
+        assert_eq!(message, next_message);
+    }
+
+    #[test]
+    fn router_message_to_gateway_message() {
+        let source_chain = "aleo-2";
+        let message_id = "au1dudq5uvhtvqry59cfm5nz4pwu95hyrak427nqqk2uvg5n530hg9su50yfm";
+        let source_address = "aleo10fmsqwh059uqm74x6t6zgj93wfxtep0avevcxz0n4w9uawymkv9s7whsau";
+        let destination_chain = "aleo-2";
+        let destination_address = "666f6f0000000000000000000000000000000000";
+        let payload_hash = "a432dc983dfe6fc48bb47a90915465d9c8185b1c2aea5c87f85818cba35051c6";
+
+        let router_messages = RouterMessage {
+            cc_id: CrossChainId::new(source_chain, message_id).unwrap(),
+            source_address: source_address.parse().unwrap(),
+            destination_address: destination_address.parse().unwrap(),
+            destination_chain: destination_chain.parse().unwrap(),
+            payload_hash: HexBinary::from_hex(payload_hash)
+                .unwrap()
+                .to_array::<32>()
+                .unwrap(),
+        };
+
+        let message = Message::try_from(&router_messages).unwrap();
+        println!("messages: {:?}", message.to_aleo_string());
+        // assert_eq!(message.to_aleo_string().unwrap(), "{source_chain: [97u8, 108u8, 101u8, 111u8, 45u8, 50u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8], message_id: [24949u16, 12644u16, 30052u16, 28981u16, 30070u16, 26740u16, 30321u16, 29305u16, 13625u16, 25446u16, 27957u16, 28282u16, 13424u16, 30581u16, 14645u16, 26745u16, 29281u16, 27444u16, 12855u16, 28273u16, 29035u16, 12917u16, 30311u16, 13678u16, 13619u16, 12392u16, 26425u16, 29557u16, 13616u16, 31078u16, 27904u16], source_address: [24940u16, 25967u16, 12592u16, 26221u16, 29553u16, 30568u16, 12341u16, 14709u16, 29037u16, 14132u16, 30774u16, 29750u16, 31335u16, 27193u16, 13175u16, 26232u16, 29797u16, 28720u16, 24950u16, 25974u16, 25464u16, 31280u16, 28212u16, 30521u16, 30049u16, 30585u16, 28011u16, 30265u16, 29495u16, 30568u16, 29537u16, 29952u16], contract_address: [102u8, 111u8, 111u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8], payload_hash: [164u8, 50u8, 220u8, 152u8, 61u8, 254u8, 111u8, 196u8, 139u8, 180u8, 122u8, 144u8, 145u8, 84u8, 101u8, 217u8, 200u8, 24u8, 91u8, 28u8, 42u8, 234u8, 92u8, 135u8, 248u8, 88u8, 24u8, 203u8, 163u8, 80u8, 81u8, 198u8]}");
+        // assert_eq!(
+        //     messages.hash().unwrap(),
+        //     [
+        //         214, 16, 153, 136, 99, 187, 96, 122, 5, 161, 119, 97, 3, 227, 66, 18, 220, 166,
+        //         126, 242, 200, 101, 255, 21, 252, 192, 138, 54, 210, 195, 215, 116
+        //     ]
+        // );
+    }
+
+    // #[test]
+    // fn verifier_set_to_wighted_signers() {
+    //     let verifier_set = VerifierSet {
+    //         signers: BTreeMap::from_iter(vec![
+    //             (
+    //                 "aleo1xpc0kpexvqc29eskjfkuyrervtqr8a8tptnmp7rhdg964xlw55psq5dnk4".to_string(),
+    //                 Signer {
+    //                     address: Addr::unchecked(
+    //                         "aleo1xpc0kpexvqc29eskjfkuyrervtqr8a8tptnmp7rhdg964xlw55psq5dnk4",
+    //                     ),
+    //                     weight: 1u8.into(),
+    //                     pub_key: PublicKey::AleoSchnorr(HexBinary::from(
+    //                         "aleo1xpc0kpexvqc29eskjfkuyrervtqr8a8tptnmp7rhdg964xlw55psq5dnk4"
+    //                             .as_bytes(),
+    //                     )),
+    //                 },
+    //             ),
+    //             (
+    //                 "aleo1p8utxn802p9wrextsfjynz04rg6eq36404jxvt40sy89jpfl0qzq20l35n".to_string(),
+    //                 Signer {
+    //                     address: Addr::unchecked(
+    //                         "aleo1p8utxn802p9wrextsfjynz04rg6eq36404jxvt40sy89jpfl0qzq20l35n",
+    //                     ),
+    //                     weight: 1u8.into(),
+    //                     pub_key: PublicKey::AleoSchnorr(HexBinary::from(
+    //                         "aleo1p8utxn802p9wrextsfjynz04rg6eq36404jxvt40sy89jpfl0qzq20l35n"
+    //                             .as_bytes(),
+    //                     )),
+    //                 },
+    //             ),
+    //         ]),
+    //         threshold: 2u8.into(),
+    //         created_at: 100u64,
+    //     };
+    //
+    //     let weighted_signers = WeightedSigners::try_from(&verifier_set).unwrap();
+    //
+    //     println!("weighted_signers: {:?}", weighted_signers.to_aleo_string());
+    //     println!("hash: {:?}", weighted_signers.hash().unwrap());
+    // }
+    //
+    // fn message() -> Message {
+    //     let source_chain = "chain0";
+    //     let message_id = "au14zeyyly2s2nc8f4vze5u2gs27uyjv72qds66cvre3tlwrewqdurqpsj839";
+    //     let source_address = "aleo10fmsqwh059uqm74x6t6zgj93wfxtep0avevcxz0n4w9uawymkv9s7whsau";
+    //     let destination_chain = "chain1";
+    //     let destination_address = "666f6f0000000000000000000000000000000000";
+    //     let payload_hash = "8c3685dc41c2eca11426f8035742fb97ea9f14931152670a5703f18fe8b392f0";
+    //
+    //     let router_messages = RouterMessage {
+    //         cc_id: CrossChainId::new(source_chain, message_id).unwrap(),
+    //         source_address: source_address.parse().unwrap(),
+    //         destination_address: destination_address.parse().unwrap(),
+    //         destination_chain: destination_chain.parse().unwrap(),
+    //         payload_hash: HexBinary::from_hex(payload_hash)
+    //             .unwrap()
+    //             .to_array::<32>()
+    //             .unwrap(),
+    //     };
+    //     Message::try_from(&router_messages).unwrap()
+    // }
+    //
+    // fn weighted_signers() -> WeightedSigners {
+    //     let verifier_set = VerifierSet {
+    //         signers: BTreeMap::from_iter(vec![
+    //             (
+    //                 "aleo1xpc0kpexvqc29eskjfkuyrervtqr8a8tptnmp7rhdg964xlw55psq5dnk4".to_string(),
+    //                 Signer {
+    //                     address: Addr::unchecked(
+    //                         "aleo1xpc0kpexvqc29eskjfkuyrervtqr8a8tptnmp7rhdg964xlw55psq5dnk4",
+    //                     ),
+    //                     weight: 1u8.into(),
+    //                     pub_key: PublicKey::AleoSchnorr(HexBinary::from(
+    //                         "aleo1xpc0kpexvqc29eskjfkuyrervtqr8a8tptnmp7rhdg964xlw55psq5dnk4"
+    //                             .as_bytes(),
+    //                     )),
+    //                 },
+    //             ),
+    //             (
+    //                 "aleo1p8utxn802p9wrextsfjynz04rg6eq36404jxvt40sy89jpfl0qzq20l35n".to_string(),
+    //                 Signer {
+    //                     address: Addr::unchecked(
+    //                         "aleo1p8utxn802p9wrextsfjynz04rg6eq36404jxvt40sy89jpfl0qzq20l35n",
+    //                     ),
+    //                     weight: 1u8.into(),
+    //                     pub_key: PublicKey::AleoSchnorr(HexBinary::from(
+    //                         "aleo1p8utxn802p9wrextsfjynz04rg6eq36404jxvt40sy89jpfl0qzq20l35n"
+    //                             .as_bytes(),
+    //                     )),
+    //                 },
+    //             ),
+    //         ]),
+    //         threshold: 2u8.into(),
+    //         created_at: 100u64,
+    //     };
+    //
+    //     WeightedSigners::try_from(&verifier_set).unwrap()
+    // }
+    //
+    // #[test]
+    // fn payload_digest() {
+    //     let messages = Messages::from(vec![message()]);
+    //     let weighted_signers = weighted_signers();
+    //
+    //     let messages_hash = messages.hash().unwrap();
+    //     let weighted_signers_hash = weighted_signers.hash().unwrap();
+    //     let domain_separator: [u8; 32] =
+    //         hex::decode("6973c72935604464b28827141b0a463af8e3487616de69c5aa0c785392c9fb9f")
+    //             .unwrap()
+    //             .try_into()
+    //             .unwrap();
+    //
+    //     let payload_digest =
+    //         PayloadDigest::new(&domain_separator, &weighted_signers_hash, &messages_hash);
+    //
+    //     let hash = hash(payload_digest.to_aleo_string()).unwrap();
+    //     assert_eq!(
+    //         hash,
+    //         [
+    //             43u8, 248u8, 246u8, 8u8, 215u8, 130u8, 185u8, 164u8, 19u8, 56u8, 205u8, 182u8,
+    //             249u8, 113u8, 213u8, 193u8, 20u8, 116u8, 38u8, 252u8, 144u8, 133u8, 179u8, 34u8,
+    //             30u8, 137u8, 68u8, 203u8, 100u8, 157u8, 71u8, 143u8
+    //         ]
+    //     );
+    // }
+
+    use multisig::key::PublicKey;
+    use multisig::msg::SignerWithSig;
+    use multisig::verifier_set::{self, VerifierSet};
+    // use snarkvm_::prelude::{Field, Network, PrivateKey, Signature, ToFields};
+
+    fn aleo_encoded<N: Network>(data: &[u8; 32]) -> Vec<Field<N>> {
+        let message = [
+            "[",
+            data.as_ref()
+                .iter()
+                .map(|b| format!("{:?}u8", b))
+                .collect::<Vec<_>>()
+                .join(", ")
+                .as_str(),
+            "]",
+        ]
+        .concat();
+
+        snarkvm_cosmwasm::program::Value::from_str(message.as_str())
+            .unwrap()
+            .to_fields()
+            .unwrap()
+    }
+
+    pub fn payload_digest<N: Network>(verifier_set: &VerifierSet) -> [u8; 32] {
+        let message = router_message();
+        let message = Message::try_from(&message).unwrap();
+        let data_hash = message.hash::<N>().unwrap();
+        println!("data_hash: {:?}", data_hash);
+
+        // let addr2 = "aleo17ge8zcz2js90h8mvgpr4w5wqqy56jlt2txznh4zavvvrtrzra5qs7v0n84";
+
+        // 6973c72935604464b28827141b0a463af8e3487616de69c5aa0c785392c9fb9f
+        let domain_separator =
+            hex::decode("6973c72935604464b28827141b0a463af8e3487616de69c5aa0c785392c9fb9f")
+                .unwrap();
+        let part1 = u128::from_le_bytes(domain_separator[0..16].try_into().unwrap());
+        let part2 = u128::from_le_bytes(domain_separator[16..32].try_into().unwrap());
+        let domain_separator: [u128; 2] = [part1, part2];
+        println!("domain_separator: {:2x?}", domain_separator);
+
+        let payload_digest =
+            PayloadDigest::new(&domain_separator, verifier_set, &data_hash).unwrap();
+
+        payload_digest.hash::<N>().unwrap()
+    }
+
+    #[test]
+    fn proof() {
+        // APrivateKey1zkp2BXKmUopUZoU7b2necZ4xSxJnBazytJoSTXiPDqvqUny
+        // AViewKey1dYXjvYok2j5543n2Bkdy5mQqhtsKWv5QorWmCyJp3rMu
+        // let addr1 = "aleo1hhssuewasdcya3xjepae5eum0dqja0m4z6carnr5qfp6lnqtxyqskavctq";
+
+        //
+        // APrivateKey1zkpB9x9aKfPwHBALJFCpENtteCkBkFPCCSmgyVWeqZ6PgKy
+        // AViewKey1hoTRJKFTK3VUiKDFBVCfFBqH2atcT4eTFmNYysNe9xch
+        // let addr2 = "aleo17ge8zcz2js90h8mvgpr4w5wqqy56jlt2txznh4zavvvrtrzra5qs7v0n84";
+
+        // let verifier_set = VerifierSet {
+        //     signers: BTreeMap::from_iter(vec![
+        //         (
+        //             addr1.to_string(),
+        //             Signer {
+        //                 address: Addr::unchecked(addr1),
+        //                 weight: 1u8.into(),
+        //                 pub_key: PublicKey::AleoSchnorr(HexBinary::from(addr1.as_bytes())),
+        //             },
+        //         ),
+        //         (
+        //             addr2.to_string(),
+        //             Signer {
+        //                 address: Addr::unchecked(addr2),
+        //                 weight: 1u8.into(),
+        //                 pub_key: PublicKey::AleoSchnorr(HexBinary::from(addr2.as_bytes())),
+        //             },
+        //         ),
+        //     ]),
+        //     threshold: 2u8.into(),
+        //     created_at: 100u64,
+        // };
+
+        let private_key: PrivateKey<snarkvm_cosmwasm::network::TestnetV0> =
+            PrivateKey::new(&mut rand::thread_rng()).unwrap();
+        let addr = Address::try_from(private_key).unwrap();
+        let addr = addr.to_string();
+
+        let verifier_set = VerifierSet {
+            signers: BTreeMap::from_iter(vec![(
+                addr.to_string(),
+                Signer {
+                    address: Addr::unchecked(addr.as_str()),
+                    weight: 1u8.into(),
+                    pub_key: PublicKey::AleoSchnorr(HexBinary::from(addr.as_str().as_bytes())),
+                },
+            )]),
+            threshold: 2u8.into(),
+            created_at: 100u64,
+        };
+
+        let payload_digest = payload_digest::<snarkvm_cosmwasm::network::TestnetV0>(&verifier_set);
+        println!("payload_digest: {:?}", payload_digest);
+        let aleo_value = aleo_encoded(&payload_digest);
+
+        let signature = snarkvm_cosmwasm::program::Signature::sign(
+            &private_key,
+            &aleo_value,
+            &mut rand::thread_rng(),
+        )
+        .unwrap();
+
+        let sign = signature.to_string();
+
+        //foo
+        // let sign1 = "sign1enc46v36a9kdc7wenwmd8pm27x9hphvqw4f05suqjuxky2rjdqqvqvl3w09u7sg99ky7kcelprw7ww2aglmunfjhmatzm5hx0fhdyqzqutkjzvshmqjnxvfdu7qnkrplyesp88uwarr38z44mwfe998aqnr6tvq6qwastx9942fphg99l522t89kvrswfdea5nxttgsxwqwsx7wdty9";
+        // bar
+        // let sign2 = "sign1zq7azu97z7rdkchqe9nlun7t5sjnyhlrxks93fyu3f9yfu68qcpr4zlwvqtka36lcaq06yxf3u6h2jkytc5ajdh0t0xr5vjtfjrvqqzkwlnfxjjxg6gr0lzlxth7rq6xq27828zs6s75tlskrwvw2hfhpks52z8m5un66eqt0yp8ehe6498ljtd4skqyu8ftfesvh28qypeqjpxrglp";
+
+        let signer_with_sig = SignerWithSig {
+            signer: Signer {
+                address: Addr::unchecked(addr.to_string()),
+                weight: 1u8.into(),
+                pub_key: PublicKey::AleoSchnorr(HexBinary::from(addr.to_string().as_bytes())),
+            },
+            signature: multisig::key::Signature::AleoSchnorr(HexBinary::from(sign.as_bytes())),
+        };
+
+        let proof = Proof::new(verifier_set, signer_with_sig).unwrap();
+        let aleo_string = proof.to_aleo_string().unwrap();
+        println!("proof: {:?}", aleo_string);
+
+        let router_message = router_message();
+        let m = Message::try_from(&router_message).unwrap();
+        let execute_data = ExecuteData::new(proof, m);
+        let res = execute_data.to_aleo_string().unwrap();
+        println!("execute_data: {:?}", res);
+    }
+}

--- a/packages/aleo-gateway/src/lib.rs
+++ b/packages/aleo-gateway/src/lib.rs
@@ -111,7 +111,6 @@ mod test {
     use cosmwasm_std::{Addr, HexBinary};
     use multisig::msg::Signer;
     use router_api::{CrossChainId, Message as RouterMessage};
-    // use snarkvm::prelude::PrivateKey;
     use snarkvm_cosmwasm::account::PrivateKey;
     use snarkvm_cosmwasm::network::ToFields;
     use snarkvm_cosmwasm::types::{Address, Field};

--- a/packages/aleo-gateway/src/message.rs
+++ b/packages/aleo-gateway/src/message.rs
@@ -1,0 +1,160 @@
+use std::str::FromStr as _;
+
+// use cosmwasm_std::Uint256;
+use error_stack::{ensure, Report};
+use snarkvm_cosmwasm::network::Network;
+use snarkvm_cosmwasm::program::ToBits as _;
+
+use crate::string_encoder::StringEncoder;
+use crate::{AleoValue, Error};
+
+/*
+    struct Message {
+        // ascii encoded chain name
+        source_chain: [u128; 2],
+        // TODO: unit test all valid message_id formats
+        message_id: [u128; 8],
+        // TODO: unit test few valid source addresses
+        source_address: [u128; 4],
+        // detination contract on aleo
+        contract_address: [u128; 4], // This is the program name
+        // hash of the payload
+        payload_hash: [u8; 32],
+    }
+*/
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Message {
+    pub cc_id: router_api::CrossChainId,
+    pub source_address: String,
+    pub destination_chain: router_api::ChainName,
+    pub destination_address: String,
+    pub payload_hash: [u8; 32], // The hash of the payload, send from the relayer of the source chain
+}
+
+impl TryFrom<&router_api::Message> for Message {
+    type Error = Report<Error>;
+
+    fn try_from(value: &router_api::Message) -> Result<Self, Self::Error> {
+        Ok(Message {
+            cc_id: value.cc_id.clone(),
+            source_address: value.source_address.to_string(),
+            destination_chain: value.destination_chain.clone(),
+            destination_address: value.destination_address.to_string(),
+            payload_hash: value.payload_hash,
+        })
+    }
+}
+
+fn bytes_to_bits(bytes: &Vec<u8>) -> Vec<bool> {
+    bytes
+        .iter()
+        .flat_map(|&byte| (0..8).rev().map(move |i| (byte >> i) & 1 == 1))
+        .collect()
+}
+
+impl AleoValue for Message {
+    fn to_aleo_string(&self) -> Result<String, Report<Error>> {
+        const SOURCE_CHAIN_LEN: usize = 2;
+        let source_chain = StringEncoder::encode_string(self.cc_id.source_chain.as_ref())?;
+        let source_chain_len = source_chain.u128_len();
+        ensure!(
+            source_chain_len <= SOURCE_CHAIN_LEN,
+            Error::InvalidEncodedStringLength {
+                expected: SOURCE_CHAIN_LEN,
+                actual: source_chain.u128_len()
+            }
+        );
+
+        const MESSAGE_ID_LEN: usize = 8;
+        let message_id = StringEncoder::encode_string(self.cc_id.message_id.as_str())?;
+        let message_id_len = message_id.u128_len();
+        ensure!(
+            message_id_len <= MESSAGE_ID_LEN,
+            Error::InvalidEncodedStringLength {
+                expected: MESSAGE_ID_LEN,
+                actual: message_id.u128_len()
+            }
+        );
+
+        const SOURCE_ADDRESS_LEN: usize = 4;
+        let source_address = StringEncoder::encode_string(self.source_address.as_str())?;
+        let source_address_len = source_address.u128_len();
+        ensure!(
+            source_address_len <= SOURCE_ADDRESS_LEN,
+            Error::InvalidEncodedStringLength {
+                expected: SOURCE_ADDRESS_LEN,
+                actual: source_address.u128_len()
+            }
+        );
+
+        const CONTRACT_ADDRESS_LEN: usize = 4;
+        let contract_address = StringEncoder::encode_string(self.destination_address.as_str())?;
+        let contract_address_len = contract_address.u128_len();
+        ensure!(
+            contract_address_len <= CONTRACT_ADDRESS_LEN,
+            Error::InvalidEncodedStringLength {
+                expected: CONTRACT_ADDRESS_LEN,
+                actual: contract_address.u128_len()
+            }
+        );
+
+        // TODO: check if we can know at this point that only Aleo can be the destination chain
+        let payload_hash = if self.cc_id.source_chain == "aleo-2" {
+            let n = cosmwasm_std::Uint256::from_le_bytes(self.payload_hash);
+            format!("{n}group")
+        } else {
+            let reverse_hash = self.payload_hash.iter().map(|b| b.reverse_bits()).collect();
+            let keccak_bits: Vec<bool> = bytes_to_bits(&reverse_hash);
+
+            let group =
+                <snarkvm_cosmwasm::network::TestnetV0>::hash_to_group_bhp256(&keccak_bits).unwrap();
+
+            format!("{group}")
+        };
+
+        let res = format!(
+            r#"{{source_chain: [{}], message_id: [{}], source_address: [{}], contract_address: [{}], payload_hash: {} }}"#,
+            source_chain
+                .consume()
+                .into_iter()
+                .map(|c| format!("{}u128", c as u128))
+                .chain(
+                    std::iter::repeat("0u128".to_string())
+                        .take(SOURCE_CHAIN_LEN - source_chain_len)
+                )
+                .collect::<Vec<_>>()
+                .join(", "),
+            message_id
+                .consume()
+                .into_iter()
+                .map(|c| format!("{}u128", c as u128))
+                .chain(std::iter::repeat("0u128".to_string()).take(MESSAGE_ID_LEN - message_id_len))
+                .collect::<Vec<_>>()
+                .join(", "),
+            source_address
+                .consume()
+                .into_iter()
+                .map(|c| format!("{}u128", c as u128))
+                .chain(
+                    std::iter::repeat("0u128".to_string())
+                        .take(SOURCE_ADDRESS_LEN - source_address_len)
+                )
+                .collect::<Vec<_>>()
+                .join(", "),
+            contract_address
+                .consume()
+                .into_iter()
+                .map(|c| format!("{}u128", c as u128))
+                .chain(
+                    std::iter::repeat("0u128".to_string())
+                        .take(CONTRACT_ADDRESS_LEN - contract_address_len)
+                )
+                .collect::<Vec<_>>()
+                .join(", "),
+            payload_hash
+        );
+
+        Ok(res)
+    }
+}

--- a/packages/aleo-gateway/src/messages.rs
+++ b/packages/aleo-gateway/src/messages.rs
@@ -1,0 +1,28 @@
+use error_stack::Report;
+
+use crate::message::Message;
+use crate::{AleoValue, Error};
+
+#[derive(Debug)]
+pub struct Messages(pub Vec<Message>);
+
+impl From<Vec<Message>> for Messages {
+    fn from(v: Vec<Message>) -> Self {
+        Messages(v)
+    }
+}
+
+impl AleoValue for Messages {
+    fn to_aleo_string(&self) -> Result<String, Report<Error>> {
+        let res = format!(
+            r#"{{ messages: [{}] }}"#,
+            self.0
+                .iter()
+                .map(Message::to_aleo_string)
+                .collect::<Result<Vec<_>, Report<Error>>>()?
+                .join(", ")
+        );
+
+        Ok(res)
+    }
+}

--- a/packages/aleo-gateway/src/payload_digest.rs
+++ b/packages/aleo-gateway/src/payload_digest.rs
@@ -1,0 +1,65 @@
+use aleo_types::address::Address;
+use error_stack::Report;
+use multisig::verifier_set::{self, VerifierSet};
+
+use crate::{AleoValue, Error};
+
+#[derive(Debug)]
+pub struct PayloadDigest<'a> {
+    domain_separator: &'a [u128; 2],
+    signer: Address,
+    data_hash: String,
+}
+
+impl<'a> PayloadDigest<'a> {
+    pub fn new(
+        domain_separator: &'a [u128; 2],
+        verifier_set: &VerifierSet,
+        data_hash: String,
+    ) -> Result<PayloadDigest<'a>, Report<Error>> {
+        let address = verifier_set
+            .signers
+            .values()
+            .next()
+            .map(|verifier| match &verifier.pub_key {
+                multisig::key::PublicKey::AleoSchnorr(key) => {
+                    Ok(Address::try_from(key).map_err(|e| {
+                        Report::new(Error::AleoGateway(format!(
+                            "Failed to parse address: {}",
+                            e
+                        )))
+                    })?)
+                }
+                multisig::key::PublicKey::Ecdsa(_) => Err(Report::new(
+                    Error::UnsupportedPublicKey("received Ecdsa".to_string()),
+                )),
+                multisig::key::PublicKey::Ed25519(_) => Err(Report::new(
+                    Error::UnsupportedPublicKey("received Ed25519".to_string()),
+                )),
+            })
+            .ok_or_else(|| Report::new(Error::AleoGateway("No signers found".to_string())))??;
+
+        Ok(PayloadDigest {
+            domain_separator,
+            signer: address,
+            data_hash,
+        })
+    }
+}
+
+impl AleoValue for PayloadDigest<'_> {
+    fn to_aleo_string(&self) -> Result<String, Report<Error>> {
+        let res = format!(
+            r#"{{ domain_separator: [{}], signer: {}, data_hash: {} }}"#,
+            self.domain_separator
+                .iter()
+                .map(|b| format!("{}u128", b))
+                .collect::<Vec<_>>()
+                .join(", "),
+            self.signer,
+            self.data_hash
+        );
+
+        Ok(res)
+    }
+}

--- a/packages/aleo-gateway/src/proof.rs
+++ b/packages/aleo-gateway/src/proof.rs
@@ -1,0 +1,77 @@
+use std::ptr::addr_of_mut;
+
+use aleo_types::address::Address;
+use error_stack::Report;
+use multisig::msg::SignerWithSig;
+use multisig::verifier_set::VerifierSet;
+
+use crate::raw_signature::RawSignature;
+use crate::weighted_signers::WeightedSigners;
+use crate::{AleoValue, Error};
+
+#[derive(Clone, Debug)]
+pub struct Proof {
+    pub weighted_signer: Address,
+    pub signature: RawSignature,
+    pub nonce: [u128; 2],
+}
+
+impl Proof {
+    pub fn new(
+        verifier_set: VerifierSet,
+        signer_with_signature: SignerWithSig,
+    ) -> Result<Self, Report<Error>> {
+        let address = verifier_set
+            .signers
+            .values()
+            .next()
+            .map(|verifier| match &verifier.pub_key {
+                multisig::key::PublicKey::AleoSchnorr(key) => {
+                    Ok(Address::try_from(key).map_err(|e| {
+                        Report::new(Error::AleoGateway(format!(
+                            "Failed to parse address: {}",
+                            e
+                        )))
+                    })?)
+                }
+                multisig::key::PublicKey::Ecdsa(_) => Err(Report::new(
+                    Error::UnsupportedPublicKey("received Ecdsa".to_string()),
+                )),
+                multisig::key::PublicKey::Ed25519(_) => Err(Report::new(
+                    Error::UnsupportedPublicKey("received Ed25519".to_string()),
+                )),
+            })
+            .ok_or_else(|| Report::new(Error::AleoGateway("No signers found".to_string())))??;
+
+        let signature = RawSignature {
+            signature: match signer_with_signature.signature {
+                multisig::key::Signature::AleoSchnorr(sig) => sig.to_vec(),
+                _ => {
+                    return Err(Report::new(Error::UnsupportedPublicKey(
+                        "Missing Aleo schnorr signature".to_string(),
+                    )))
+                }
+            },
+        };
+
+        Ok(Proof {
+            weighted_signer: address,
+            signature,
+            nonce: [3, 1],
+        })
+    }
+}
+
+impl AleoValue for Proof {
+    fn to_aleo_string(&self) -> Result<String, Report<Error>> {
+        let res = format!(
+            r#"{{ weighted_signer: {}, signaturee: {}, nonce: [ {}u128, {}u128 ] }}"#,
+            self.weighted_signer.to_string(),
+            self.signature.to_aleo_string()?,
+            self.nonce[0],
+            self.nonce[1],
+        );
+
+        Ok(res)
+    }
+}

--- a/packages/aleo-gateway/src/raw_signature.rs
+++ b/packages/aleo-gateway/src/raw_signature.rs
@@ -1,0 +1,21 @@
+use error_stack::Report;
+
+use crate::{AleoValue, Error};
+
+// TODO: nonce is skipped
+#[derive(Clone, Debug)]
+pub struct RawSignature {
+    pub signature: Vec<u8>,
+}
+
+impl AleoValue for RawSignature {
+    fn to_aleo_string(&self) -> Result<String, Report<Error>> {
+        let res = String::from_utf8(self.signature.clone()).map_err(|e| {
+            Report::new(Error::AleoGateway(format!(
+                "Failed to convert to utf8: {}",
+                e
+            )))
+        })?;
+        Ok(res)
+    }
+}

--- a/packages/aleo-gateway/src/signer_with_signature.rs
+++ b/packages/aleo-gateway/src/signer_with_signature.rs
@@ -1,0 +1,8 @@
+use crate::raw_signature::RawSignature;
+use crate::weighted_signer::WeightedSigner;
+
+#[derive(Clone, Debug)]
+pub struct SignerWithSignature {
+    pub signer: WeightedSigner,
+    pub signature: RawSignature,
+}

--- a/packages/aleo-gateway/src/string_encoder.rs
+++ b/packages/aleo-gateway/src/string_encoder.rs
@@ -1,0 +1,120 @@
+use std::convert::TryFrom;
+
+use error_stack::Report;
+
+use crate::{AleoValue, Error};
+
+pub struct StringEncoder {
+    pub buf: Vec<u128>,
+}
+
+impl StringEncoder {
+    /// Creates a new StringEncoder from an ASCII string
+    pub fn encode_string(input: &str) -> Result<Self, Report<Error>> {
+        // Verify the input is ASCII
+        if !input.is_ascii() {
+            return Err(Report::new(Error::InvalidAscii));
+        }
+
+        let bytes = input.as_bytes();
+        let mut buf = Vec::with_capacity((bytes.len() + 15) / 16);
+        let mut current_value: u128 = 0;
+        let mut position = 0;
+
+        for &byte in bytes {
+            // Shift left by 8 and add new byte
+            current_value = (current_value << 8) | u128::from(byte);
+            position += 1;
+
+            // When we have 16 bytes, push to result
+            if position == 16 {
+                buf.push(current_value);
+                current_value = 0;
+                position = 0;
+            }
+        }
+
+        // Handle any remaining bytes
+        if position > 0 {
+            // Left shift remaining bytes to maintain consistency
+            current_value <<= 8 * (16 - position);
+            buf.push(current_value);
+        }
+
+        Ok(Self { buf })
+    }
+
+    // aleo_value expected to be a string of u128 values separated by ", "
+    // example: "1234567890u128, 9876543210u128"
+    pub fn from_aleo_value(aleo_value: &str) -> Result<Self, Report<Error>> {
+        Ok(Self {
+            buf: aleo_value
+                .split(", ")
+                .map(|s| s.replace("u128", "").parse::<u128>())
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| Error::AleoGateway(format!("Failed to parse u128: {e:?}")))?,
+        })
+    }
+
+    pub fn u128_len(&self) -> usize {
+        self.buf.len()
+    }
+
+    pub fn consume(self) -> Vec<u128> {
+        self.buf
+    }
+
+    /// Decodes and consumes the StringEncoder, returning the original ASCII string
+    pub fn decode(&self) -> String {
+        let mut result = Vec::new();
+
+        for (i, value) in self.buf.iter().enumerate() {
+            // Extract all possible bytes from the u128
+            for j in 0..16 {
+                let shift = 8 * (15 - j);
+                let byte = ((value >> shift) & 0xFF) as u8;
+                // Only add non-zero bytes from the last chunk
+                if i < self.buf.len() - 1 || byte != 0 {
+                    result.push(byte);
+                }
+            }
+        }
+
+        // Trim any trailing zeros
+        while result.last() == Some(&0) {
+            result.pop();
+        }
+
+        // Safe to unwrap as we verified ASCII in new()
+        String::from_utf8(result).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode_decode() {
+        let test_str = "foo";
+        let encoded = StringEncoder::encode_string(test_str).unwrap();
+        let decoded = encoded.decode();
+        assert_eq!(test_str, decoded);
+    }
+
+    #[test]
+    fn test_long_string() {
+        let test_str = "This is a longer test string that will span multiple u128 values!";
+        let encoded = StringEncoder::encode_string(test_str).unwrap();
+        let decoded = encoded.decode();
+        assert_eq!(test_str, decoded);
+    }
+
+    #[test]
+    fn test_empty_string() {
+        let test_str = "";
+        let encoded = StringEncoder::encode_string(test_str).unwrap();
+        let decoded = encoded.decode();
+        assert_eq!(test_str, decoded);
+    }
+}

--- a/packages/aleo-gateway/src/weighted_signer.rs
+++ b/packages/aleo-gateway/src/weighted_signer.rs
@@ -1,0 +1,21 @@
+use aleo_types::address::Address;
+use error_stack::Report;
+
+use crate::{AleoValue, Error};
+
+#[derive(Debug, Clone)]
+pub struct WeightedSigner {
+    pub signer: Address,
+    pub weight: u128,
+}
+
+impl AleoValue for WeightedSigner {
+    fn to_aleo_string(&self) -> Result<String, Report<Error>> {
+        let res = format!(
+            r#"{{signer: {}, weight: {}u128}}"#,
+            self.signer.0, self.weight
+        );
+
+        Ok(res)
+    }
+}

--- a/packages/aleo-gateway/src/weighted_signers.rs
+++ b/packages/aleo-gateway/src/weighted_signers.rs
@@ -1,0 +1,78 @@
+use aleo_types::address::Address;
+use cosmwasm_std::Uint128;
+use error_stack::Report;
+use multisig::key::PublicKey;
+use multisig::verifier_set::VerifierSet;
+
+use crate::weighted_signer::WeightedSigner;
+use crate::{AleoValue, Error};
+
+#[derive(Debug, Clone)]
+pub struct WeightedSigners {
+    signers: Vec<WeightedSigner>, // TODO: [WeightedSigner; 32],
+    threshold: Uint128,
+    nonce: [u64; 4],
+}
+
+impl TryFrom<&VerifierSet> for WeightedSigners {
+    type Error = Report<Error>;
+
+    fn try_from(value: &VerifierSet) -> Result<Self, Self::Error> {
+        let mut signers = value
+            .signers
+            .values()
+            .map(|signer| match &signer.pub_key {
+                PublicKey::AleoSchnorr(key) => Ok(WeightedSigner {
+                    signer: Address::try_from(key).map_err(|e| {
+                        Report::new(Error::AleoGateway(format!(
+                            "Failed to parse address: {}",
+                            e
+                        )))
+                    })?,
+                    weight: signer.weight.into(),
+                }),
+                PublicKey::Ecdsa(_) => Err(Report::new(Error::UnsupportedPublicKey(
+                    "received Ecdsa".to_string(),
+                ))),
+                PublicKey::Ed25519(_) => Err(Report::new(Error::UnsupportedPublicKey(
+                    "received Ed25519".to_string(),
+                ))),
+            })
+            .chain(std::iter::repeat_with(|| {
+                Ok(WeightedSigner {
+                    signer: Address::default(),
+                    weight: Default::default(),
+                })
+            }))
+            .take(32)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        signers.sort_by(|signer1, signer2| signer1.signer.cmp(&signer2.signer));
+
+        let threshold = value.threshold;
+        let nonce = [0, 0, 0, value.created_at];
+
+        Ok(WeightedSigners {
+            signers,
+            threshold,
+            nonce,
+        })
+    }
+}
+
+impl AleoValue for WeightedSigners {
+    fn to_aleo_string(&self) -> Result<String, Report<Error>> {
+        let signers = self
+            .signers
+            .iter()
+            .map(WeightedSigner::to_aleo_string)
+            .collect::<Result<Vec<_>, Report<Error>>>()?
+            .join(", ");
+        let res = format!(
+            r#"{{ signers: [ {} ], threshold: {}u128, nonce: [ {}u64, {}u64, {}u64, {}u64 ] }}"#,
+            signers, self.threshold, self.nonce[0], self.nonce[1], self.nonce[2], self.nonce[3]
+        );
+
+        Ok(res)
+    }
+}

--- a/packages/aleo-types/Cargo.toml
+++ b/packages/aleo-types/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "aleo-types"
+version = "0.1.0"
+edition = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+cosmwasm-std = { workspace = true }
+error-stack = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+bech32 = { workspace = true }
+valuable = "0.1.0"
+hex = { workspace = true }
+
+[dev-dependencies]
+axelar-wasm-std = { workspace = true }
+assert_ok = { workspace = true }
+
+[lints]
+workspace = true

--- a/packages/aleo-types/src/address.rs
+++ b/packages/aleo-types/src/address.rs
@@ -1,0 +1,96 @@
+use std::{fmt::Display, str::FromStr};
+
+use cosmwasm_std::HexBinary;
+use error_stack::{ensure, Report, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::{verify_becnh32, Error};
+
+pub const ALEO_ADDRESS_LEN: usize = 63;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, PartialOrd, Ord)]
+pub struct Address(pub String);
+
+impl Default for Address {
+    fn default() -> Self {
+        // Self("aleo1cpwac324ulhwk55wpljtq5kserrzj8dj6qw35fje7ypt2sqpv5ysj8p76w".to_string())
+        Self("aleo1qtrn0h0pakusngjemdehzljqthu3e8vfwl5qj2zccc5cgasutq8qjy2afr".to_string())
+    }
+}
+
+impl Display for Address {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Address {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.0.as_bytes().to_vec()
+    }
+}
+
+impl FromStr for Address {
+    type Err = Report<Error>;
+
+    fn from_str(address: &str) -> Result<Self, Error> {
+        const PREFIX: &str = "aleo";
+
+        ensure!(
+            address.len() == ALEO_ADDRESS_LEN,
+            Error::InvalidAleoAddress(format!(
+                "Expected address len is {}. Address '{}' is of len {}",
+                ALEO_ADDRESS_LEN,
+                address,
+                address.len()
+            ))
+        );
+
+        verify_becnh32(address, PREFIX).map_err(|e| Error::InvalidAleoAddress(e.to_string()))?;
+
+        Ok(Self(address.to_string()))
+    }
+}
+
+impl TryFrom<&HexBinary> for Address {
+    type Error = Report<Error>;
+
+    fn try_from(hex: &HexBinary) -> Result<Self, Error> {
+        let address =
+            std::str::from_utf8(&hex).map_err(|e| Error::InvalidAleoAddress(e.to_string()))?;
+        Address::from_str(address)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_ok::assert_ok;
+    use axelar_wasm_std::assert_err_contains;
+
+    use super::*;
+
+    #[test]
+    fn validate_aleo_address() {
+        let addr = "aleo1pqgvl3prke38qwyywqhgd0qu44msp3wks4cqpk3d8m8vxu30wvfql7nmvs";
+        assert_ok!(Address::from_str(addr));
+    }
+
+    #[test]
+    fn validate_aleo_address_errors() {
+        let addr = "aleo1pqgvl3prke38qwyywqhgd0qu44msp3wks4cqpk3d8m8vxu30wvfql7nmv";
+        let r = Address::from_str(addr);
+        println!("-->{r:?}");
+        assert_err_contains!(
+            Address::from_str(addr),
+            crate::Error,
+            crate::Error::InvalidAleoAddress(..)
+        );
+
+        let addr = "aleo2pqgvl3prke38qwyywqhgd0qu44msp3wks4cqpk3d8m8vxu30wvfql7nmvs";
+        assert_err_contains!(
+            Address::from_str(addr),
+            crate::Error,
+            crate::Error::InvalidAleoAddress(..)
+        );
+    }
+}

--- a/packages/aleo-types/src/lib.rs
+++ b/packages/aleo-types/src/lib.rs
@@ -1,0 +1,43 @@
+pub mod address;
+pub mod program;
+pub mod transaction;
+pub mod transition;
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Invalid aleo address: '{0}'")]
+    InvalidAleoAddress(String),
+    #[error("Invalid aleo transition id: '{0}'")]
+    InvalidAleoTransition(String),
+    #[error("Invalid aleo transaction id: '{0}'")]
+    InvalidAleoTransaction(String),
+    #[error("Invalid aleo program name: '{0}'")]
+    InvalidProgramName(String),
+    #[error("Bech32m verification failed")]
+    Bech32m(#[from] bech32::primitives::decode::CheckedHrpstringError),
+    #[error("Bech32m: {0}")]
+    Bech32mLocalVerification(String),
+}
+
+use bech32::primitives::decode::CheckedHrpstring;
+use bech32::Bech32m;
+use error_stack::{bail, ensure, Report};
+
+fn verify_becnh32(input: &str, prefix: &str) -> Result<(), Report<Error>> {
+    let checked = CheckedHrpstring::new::<Bech32m>(input).map_err(Error::Bech32m)?;
+
+    ensure!(
+        checked.hrp().as_str() == prefix,
+        Error::Bech32mLocalVerification(format!("Failed to validate prefix: '{prefix}'"))
+    );
+
+    if checked.data_part_ascii_no_checksum().is_empty() {
+        bail!(Error::Bech32mLocalVerification(
+            "No data part found".to_string()
+        ));
+    }
+
+    Ok(())
+}

--- a/packages/aleo-types/src/program.rs
+++ b/packages/aleo-types/src/program.rs
@@ -1,0 +1,107 @@
+use std::str::FromStr;
+
+use error_stack::{ensure, Report, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::Error;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Program (String);
+
+impl TryFrom<String> for Program {
+    type Error = Report<Error>;
+
+    fn try_from(name: String) -> Result<Self, Error> {
+        Program::from_str(&name)
+    }
+}
+
+impl FromStr for Program {
+    type Err = Report<Error>;
+
+    fn from_str(name: &str) -> Result<Self, Error> {
+        const SUFFIX: &str = ".aleo";
+
+        ensure!(
+            name.len() > SUFFIX.len(),
+            Error::InvalidProgramName(name.to_string())
+        );
+
+        ensure!(
+            name.ends_with(SUFFIX),
+            Error::InvalidProgramName(name.to_string())
+        );
+
+        ensure!(
+            name.chars()
+                .next()
+                .ok_or(Error::InvalidProgramName(name.to_string()))?
+                .is_ascii_lowercase(),
+            Error::InvalidProgramName(name.to_string())
+        );
+
+        ensure!(
+            name.chars()
+                .skip(1)
+                .take(
+                    name.len()
+                        .saturating_sub(SUFFIX.len().saturating_add(1)),
+                )
+                .all(|c| c.is_ascii_alphanumeric() || c == '_'),
+            Error::InvalidProgramName(name.to_string())
+        );
+
+        Ok(Self (name.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_ok::assert_ok;
+    use axelar_wasm_std::assert_err_contains;
+
+    use super::*;
+
+    #[test]
+    fn validate_aleo_program_name() {
+        let program_name = "hello.aleo";
+        assert_ok!(Program::from_str(program_name));
+
+        let program_name = "hello123.aleo";
+        assert_ok!(Program::from_str(program_name));
+
+        let program_name = "hello_123.aleo";
+        assert_ok!(Program::from_str(program_name));
+    }
+
+    #[test]
+    fn validate_aleo_program_name_errors() {
+        let program_name = "hello";
+        assert_err_contains!(
+            Program::from_str(program_name),
+            Error,
+            Error::InvalidProgramName(..)
+        );
+
+        let program_name = ".aleo";
+        assert_err_contains!(
+            Program::from_str(program_name),
+            Error,
+            Error::InvalidProgramName(..)
+        );
+
+        let program_name = "";
+        assert_err_contains!(
+            Program::from_str(program_name),
+            Error,
+            Error::InvalidProgramName(..)
+        );
+
+        let program_name = "hello$.aleo";
+        assert_err_contains!(
+            Program::from_str(program_name),
+            Error,
+            Error::InvalidProgramName(..)
+        );
+    }
+}

--- a/packages/aleo-types/src/transaction.rs
+++ b/packages/aleo-types/src/transaction.rs
@@ -1,0 +1,67 @@
+use std::fmt::Display;
+use std::str::FromStr;
+
+use error_stack::{Report, ResultExt};
+use serde::{Deserialize, Serialize};
+
+use crate::{verify_becnh32, Error};
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
+pub struct Transaction {
+    transition_id: String,
+}
+
+impl FromStr for Transaction {
+    type Err = Report<Error>;
+
+    fn from_str(transaction_id: &str) -> Result<Self, Self::Err>
+    where
+        Self: Sized,
+    {
+        const PREFIX: &str = "at";
+
+        verify_becnh32(transaction_id, PREFIX)
+            .change_context(Error::InvalidAleoTransaction(transaction_id.to_string()))?;
+
+        Ok(Self {
+            transition_id: transaction_id.to_string(),
+        })
+    }
+}
+
+impl Display for Transaction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.transition_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_ok::assert_ok;
+    use axelar_wasm_std::assert_err_contains;
+
+    use super::*;
+
+    #[test]
+    fn validate_aleo_transaction() {
+        let addr = "at1pvhkv0gt5qfnljte2nlav7u9rqrafgf04hzwkfu97sctynwghvqskfua6g";
+        assert_ok!(Transaction::from_str(addr));
+    }
+
+    #[test]
+    fn validate_aleo_transaction_errors() {
+        let addr = "au1pvhkv0gt5qfnljte2nlav7u9rqrafgf04hzwkfu97sctynwghvqskfua6g";
+        assert_err_contains!(
+            Transaction::from_str(addr),
+            crate::Error,
+            crate::Error::InvalidAleoTransaction(..)
+        );
+
+        let addr = "at1fnywazjhsvpvga7yszfhye3ftnsd6q35qpmuw4ugl9sghqtmucxqk4ksv9";
+        assert_err_contains!(
+            Transaction::from_str(addr),
+            crate::Error,
+            crate::Error::InvalidAleoTransaction(..)
+        );
+    }
+}

--- a/packages/aleo-types/src/transition.rs
+++ b/packages/aleo-types/src/transition.rs
@@ -1,0 +1,70 @@
+use std::fmt::Display;
+use std::str::FromStr;
+
+use error_stack::{Report, ResultExt};
+use serde::{Deserialize, Serialize};
+use valuable::Valuable;
+
+use crate::{verify_becnh32, Error};
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone, Valuable)]
+pub struct Transition(String);
+
+impl FromStr for Transition {
+    type Err = Report<Error>;
+
+    fn from_str(transition_id: &str) -> Result<Self, Self::Err>
+    where
+        Self: Sized,
+    {
+        const PREFIX: &str = "au";
+
+        verify_becnh32(transition_id, PREFIX)
+            .change_context(Error::InvalidAleoTransition(transition_id.to_string()))?;
+
+        Ok(Self(transition_id.to_string()))
+    }
+}
+
+impl Display for Transition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl AsRef<str> for Transition {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_ok::assert_ok;
+    use axelar_wasm_std::assert_err_contains;
+
+    use super::*;
+
+    #[test]
+    fn validate_aleo_transition() {
+        let addr = "au1fnywazjhsvpvga7yszfhye3ftnsd6q35qpmuw4ugl9sghqtmucxqk4ksv8";
+        assert_ok!(Transition::from_str(addr));
+    }
+
+    #[test]
+    fn validate_aleo_transition_errors() {
+        let addr = "at1fnywazjhsvpvga7yszfhye3ftnsd6q35qpmuw4ugl9sghqtmucxqk4ksv8";
+        assert_err_contains!(
+            Transition::from_str(addr),
+            crate::Error,
+            crate::Error::InvalidAleoTransition(..)
+        );
+
+        let addr = "au1fnywazjhsvpvga7yszfhye3ftnsd6q35qpmuw4ugl9sghqtmucxqk4ksv9";
+        assert_err_contains!(
+            Transition::from_str(addr),
+            crate::Error,
+            crate::Error::InvalidAleoTransition(..)
+        );
+    }
+}

--- a/packages/axelar-wasm-std/Cargo.toml
+++ b/packages/axelar-wasm-std/Cargo.toml
@@ -22,6 +22,7 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
+aleo-types = { workspace = true }
 alloy-primitives = { workspace = true }
 axelar-wasm-std-derive = { workspace = true, optional = true }
 bech32 = { workspace = true }

--- a/packages/evm-gateway/Cargo.toml
+++ b/packages/evm-gateway/Cargo.toml
@@ -17,5 +17,7 @@ router-api = { workspace = true }
 sha3 = { workspace = true }
 thiserror = { workspace = true }
 
+# ethers = { version = "2.0.14" }
+
 [lints]
 workspace = true

--- a/packages/router-api/src/primitives.rs
+++ b/packages/router-api/src/primitives.rs
@@ -189,7 +189,7 @@ impl Display for CrossChainId {
 #[cw_serde]
 #[serde(try_from = "String")]
 #[derive(Eq, Hash, Valuable)]
-pub struct ChainName(String);
+pub struct ChainName(String); // TODO: can this be empty?
 
 impl FromStr for ChainName {
     type Err = Error;
@@ -343,6 +343,13 @@ impl From<ChainNameRaw> for String {
         d.0
     }
 }
+
+impl<'a> From<&'a ChainNameRaw> for &'a str {
+    fn from(d: &'a ChainNameRaw) -> Self {
+        d.0.as_str()
+    }
+}
+
 
 impl TryFrom<String> for ChainNameRaw {
     type Error = Error;

--- a/packages/sui-gateway/src/lib.rs
+++ b/packages/sui-gateway/src/lib.rs
@@ -63,6 +63,7 @@ impl TryFrom<VerifierSet> for WeightedSigners {
                     weight: signer.weight.into(),
                 }),
                 PublicKey::Ed25519(_) => Err(Report::new(Error::UnsupportedPublicKey)),
+                PublicKey::AleoSchnorr(_) => Err(Report::new(Error::UnsupportedPublicKey)),
             })
             .collect::<Result<Vec<_>, _>>()?;
         signers.sort_by(|signer1, signer2| signer1.pub_key.cmp(&signer2.pub_key));


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `exported` mod. If those types have already been defined somewhere else, then they should get re-exported in the `exported` mod


## Steps to Test

## Expected Behaviour

## Notes
