### PR TITLE
1. Support proofs with multiple messages and multiple signers.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,8 @@ dependencies = [
  "multisig",
  "rand 0.8.5",
  "router-api",
+ "serde",
+ "serde_with 3.12.0",
  "snarkvm-cosmwasm",
  "thiserror 1.0.69",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,6 @@ dependencies = [
  "cosmwasm-std",
  "error-stack",
  "hex",
- "lazy_static",
  "serde",
  "serde_json",
  "thiserror 1.0.69",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,7 @@ dependencies = [
  "cosmwasm-std",
  "error-stack",
  "hex",
+ "lazy_static",
  "serde",
  "serde_json",
  "thiserror 1.0.69",

--- a/ampd/src/aleo/error.rs
+++ b/ampd/src/aleo/error.rs
@@ -24,8 +24,6 @@ pub enum Error {
     InvalidChainName,
     #[error("Invalid source address")]
     InvalidSourceAddress,
-    #[error("Failed to create AleoID: {0}")]
-    FailedToCreateAleoID(String),
     #[error("Failed to create hash payload: {0}")]
     PayloadHash(String),
     #[error("Failed to find transition '{0}' in transaction")]

--- a/ampd/src/aleo/error.rs
+++ b/ampd/src/aleo/error.rs
@@ -29,7 +29,7 @@ pub enum Error {
     #[error("Failed to find transition '{0}' in transaction")]
     TransitionNotFoundInTransaction(String),
     #[error("Failed to convert aleo string to json")]
-    JsonParseError(String),
+    JsonParse(String),
     #[error("Failed to create CallContract receipt: {0}")]
     CalledContractReceipt(String),
     #[error("More than one SCM found")]

--- a/ampd/src/aleo/error.rs
+++ b/ampd/src/aleo/error.rs
@@ -32,4 +32,8 @@ pub enum Error {
     JsonParseError(String),
     #[error("Failed to create CallContract receipt: {0}")]
     CalledContractReceipt(String),
+    #[error("More than one SCM found")]
+    MoreThanOneSCM,
+    #[error("Call contract does not match")]
+    CallConractDoesNotMatch,
 }

--- a/ampd/src/aleo/error.rs
+++ b/ampd/src/aleo/error.rs
@@ -1,0 +1,37 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Request error: {0}")]
+    RequestFailed(#[from] reqwest::Error),
+    #[error("url: {0}")]
+    Url(#[from] url::ParseError),
+    #[error("Request error")]
+    Request,
+    #[error("Transaction '{0}' not found")]
+    TransactionNotFound(String),
+    #[error("Transition '{0}' not found")]
+    TransitionNotFound(String),
+    #[error("Failed to find callContract")]
+    CallContractNotFound,
+    #[error("Failed to find signerRotation")]
+    SignerRotationNotFound,
+    #[error("Failed to find user call")]
+    UserCallnotFound,
+    #[error("The program name is invalid: {0}")]
+    InvalidProgramName(String),
+    #[error("The provided chain name is invalid")]
+    InvalidChainName,
+    #[error("Invalid source address")]
+    InvalidSourceAddress,
+    #[error("Failed to create AleoID: {0}")]
+    FailedToCreateAleoID(String),
+    #[error("Failed to create hash payload: {0}")]
+    PayloadHash(String),
+    #[error("Failed to find transition '{0}' in transaction")]
+    TransitionNotFoundInTransaction(String),
+    #[error("Failed to convert aleo string to json")]
+    JsonParseError(String),
+    #[error("Failed to create CallContract receipt: {0}")]
+    CalledContractReceipt(String),
+}

--- a/ampd/src/aleo/http_client.rs
+++ b/ampd/src/aleo/http_client.rs
@@ -90,6 +90,7 @@ pub mod tests {
     use std::str::FromStr;
 
     use aleo_types::program::Program;
+    use snarkvm_cosmwasm::network::TestnetV0;
 
     use super::*;
     use crate::aleo::ReceiptBuilder;
@@ -172,7 +173,7 @@ pub mod tests {
             .unwrap()
             .get_transition()
             .unwrap()
-            .check_call_contract();
+            .check_call_contract::<TestnetV0>();
         assert!(res.is_ok());
     }
 
@@ -194,7 +195,7 @@ pub mod tests {
             .unwrap()
             .get_transition()
             .unwrap()
-            .check_call_contract();
+            .check_call_contract::<TestnetV0>();
         assert!(res.is_ok());
     }
 }

--- a/ampd/src/aleo/http_client.rs
+++ b/ampd/src/aleo/http_client.rs
@@ -1,132 +1,11 @@
-use std::str::FromStr;
-
-use aleo_types::address::Address;
 use aleo_types::transaction::Transaction;
 use aleo_types::transition::Transition;
-use aleo_utils::block_processor::IdValuePair;
-use aleo_utils::json_like;
-use aleo_utils::string_encoder::StringEncoder;
 use async_trait::async_trait;
-use error_stack::{ensure, Report, Result, ResultExt};
+use error_stack::{Result, ResultExt};
 use mockall::automock;
-use router_api::ChainName;
-use serde::{Deserialize, Serialize};
-use sha3::{Digest, Keccak256};
-use thiserror::Error;
-use tracing::{error, info};
 
-use crate::types::Hash;
+use crate::aleo::error::Error;
 use crate::url::Url;
-
-#[derive(Error, Debug)]
-pub enum Error {
-    #[error("Request error")]
-    Request,
-    #[error("Transaction '{0}' not found")]
-    TransactionNotFound(String),
-    #[error("Transition '{0}' not found")]
-    TransitionNotFound(String),
-    #[error("Failed to find callContract")]
-    CallnotFound,
-    #[error("Failed to find user call")]
-    UserCallnotFound,
-    #[error("The provided chain name is invalid")]
-    InvalidChainName,
-    #[error("Invalid source address")]
-    InvalidSourceAddress,
-    #[error("Failed to create AleoID: {0}")]
-    FailedToCreateAleoID(String),
-    #[error("Failed to create hash payload: {0}")]
-    PayloadHash(String),
-}
-
-#[derive(Debug)]
-pub enum Receipt {
-    Found(TransitionReceipt),
-    NotFound(Transition, Report<Error>),
-}
-
-#[derive(Debug)]
-pub struct TransitionReceipt {
-    pub transition: Transition,
-    pub destination_address: String,
-    pub destination_chain: ChainName,
-    pub source_address: Address,
-    pub payload: Vec<u8>,
-}
-
-impl PartialEq<crate::handlers::aleo_verify_msg::Message> for TransitionReceipt {
-    fn eq(&self, message: &crate::handlers::aleo_verify_msg::Message) -> bool {
-        info!(
-            "transition_id: chain.{} == msg.{} ({})",
-            self.transition,
-            message.tx_id,
-            self.transition == message.tx_id
-        );
-        info!(
-            "destination_address: chain.{} == msg.{} ({})",
-            self.destination_address,
-            message.destination_address,
-            self.destination_address == message.destination_address
-        );
-        info!(
-            "destination_chain: chain.{} == msg.{} ({})",
-            self.destination_chain,
-            message.destination_chain,
-            self.destination_chain == message.destination_chain
-        );
-        info!(
-            "source_address: chain.{:?} == msg.{:?} ({})",
-            self.source_address,
-            message.source_address,
-            self.source_address == message.source_address
-        );
-
-        let payload_hash = match payload_hash(&self.payload, self.destination_chain.as_ref()) {
-            Ok(hash) => hash,
-            Err(e) => {
-                error!("payload_hash: {}", e);
-                return false;
-            }
-        };
-
-        info!(
-            "payload_hash: chain.{:?} == msg.{:?} ({})",
-            payload_hash,
-            message.payload_hash,
-            payload_hash == message.payload_hash
-        );
-
-        self.transition == message.tx_id
-            && self.destination_address == message.destination_address
-            && self.destination_chain == message.destination_chain
-            && self.source_address == message.source_address
-            && payload_hash == message.payload_hash
-    }
-}
-
-fn payload_hash(payload: &[u8], destination_chain: &str) -> std::result::Result<Hash, Error> {
-    let payload = std::str::from_utf8(payload).map_err(|e| Error::PayloadHash(e.to_string()))?;
-    let payload_hash = if destination_chain.starts_with("eth") {
-        let payload =
-            json_like::into_json(payload).map_err(|e| Error::PayloadHash(e.to_string()))?;
-        let payload: Vec<u8> =
-            serde_json::from_str(&payload).map_err(|e| Error::PayloadHash(e.to_string()))?;
-        let payload =
-            std::str::from_utf8(&payload).map_err(|e| Error::PayloadHash(e.to_string()))?;
-        let payload = solabi::encode(&payload);
-        let payload_hash = keccak256(&payload).to_vec();
-        Hash::from_slice(&payload_hash)
-    } else {
-        // Keccak + bhp hash
-        let payload_hash =
-            aleo_gateway::hash::<&str, snarkvm_cosmwasm::network::TestnetV0>(payload)
-                .map_err(|e| Error::PayloadHash(e.to_string()))?;
-        Hash::from_slice(&payload_hash)
-    };
-
-    Ok(payload_hash)
-}
 
 #[automock]
 #[async_trait]
@@ -144,12 +23,6 @@ pub struct Client {
     client: reqwest::Client,
     base_url: Url,
     network: String,
-}
-
-#[derive(Default, Debug)]
-struct ParsedOutput {
-    payload: Vec<u8>,
-    call_contract: CallContract,
 }
 
 impl Client {
@@ -197,11 +70,12 @@ impl ClientTrait for Client {
             "{}{}/{ENDPOINT}/{}",
             self.base_url, self.network, &transition_id
         );
+
         tracing::debug!(%url);
 
         let response = self
             .client
-            .get(&url)
+            .get(url)
             .send()
             .await
             .change_context(Error::Request)?;
@@ -210,174 +84,17 @@ impl ClientTrait for Client {
     }
 }
 
-pub struct ClientWrapper<'a, C: ClientTrait> {
-    client: &'a C,
-}
-
-#[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq)]
-pub struct CallContract {
-    pub(crate) caller: String,
-    pub(crate) sender: String,
-    pub(crate) destination_chain: Vec<u128>,
-    pub(crate) destination_address: Vec<u128>,
-}
-
-impl CallContract {
-    pub fn destination_chain(&self) -> String {
-        let encoded_string = StringEncoder {
-            buf: self.destination_chain.clone(),
-        };
-        encoded_string.decode()
-    }
-
-    pub fn destination_address(&self) -> Result<String, error_stack::Report<Error>> {
-        let encoded_string = StringEncoder {
-            buf: self.destination_address.clone(),
-        };
-        let ascii_string = encoded_string.decode();
-        Ok(ascii_string)
-    }
-}
-
-impl<'a, C> ClientWrapper<'a, C>
-where
-    C: ClientTrait + Send + Sync + 'static,
-{
-    pub fn new(client: &'a C) -> Self {
-        Self { client }
-    }
-
-    fn find_call_contract(&self, outputs: &[IdValuePair]) -> Option<CallContract> {
-        if outputs.len() != 1 {
-            return None;
-        }
-
-        outputs
-            .first()
-            .and_then(|o| match o {
-                IdValuePair {
-                    id: _,
-                    value: Some(value),
-                } => Some(value),
-                _ => None,
-            })
-            .and_then(|value| {
-                let json = json_like::into_json(value.to_string().as_str()).unwrap();
-                serde_json::from_str::<CallContract>(&json).ok()
-            })
-    }
-
-    fn parse_user_output(&self, outputs: &[IdValuePair]) -> Result<ParsedOutput, Error> {
-        if outputs.len() != 2 {
-            return Err(Report::new(Error::UserCallnotFound));
-        }
-
-        // ParsedOutput
-        let mut parsed_output = ParsedOutput::default();
-
-        // TODO: there mast be a better way
-        for o in outputs {
-            if let IdValuePair {
-                id: _,
-                value: Some(plaintext),
-            } = o
-            {
-                let json = json_like::into_json(plaintext.to_string().as_str()).unwrap();
-                let parsed = serde_json::from_str::<CallContract>(&json);
-
-                if let Ok(call_contract) = parsed {
-                    parsed_output.call_contract = call_contract;
-                } else {
-                    parsed_output.payload = plaintext.to_string().as_bytes().to_vec();
-                }
-            }
-        }
-
-        Ok(parsed_output)
-    }
-
-    #[tracing::instrument(skip(self))]
-    pub async fn transition_receipt(
-        &self,
-        transition_id: &Transition,
-        gateway_contract: &str,
-    ) -> Result<Receipt, Error> {
-        let transaction = self.client.find_transaction(transition_id).await?;
-        let transaction = transaction.trim_matches('"');
-
-        // Find transaction
-        let transaction_id = Transaction::from_str(transaction)
-            .change_context(Error::TransactionNotFound(transaction.to_string()))?;
-
-        let transaction = self.client.get_transaction(&transaction_id).await?;
-        let gateway_transition = transaction
-            .execution
-            .transitions
-            .iter()
-            .find(|t| t.program.as_str() == gateway_contract)
-            .ok_or(Error::TransitionNotFound(transition_id.to_string()))?;
-
-        // Get the outputs of the transition
-        // The transition should have only the gateway call
-        let outputs = &gateway_transition.outputs;
-        let call_contract_call = self.find_call_contract(outputs);
-        let call_contract = call_contract_call.ok_or(Error::CallnotFound)?;
-
-        let scm = gateway_transition.scm.as_str();
-
-        let gateway_calls_count = transaction
-            .execution
-            .transitions
-            .iter()
-            .filter(|t| t.scm == scm && t.program == gateway_contract)
-            .count();
-
-        ensure!(gateway_calls_count == 1, Error::CallnotFound);
-
-        let same_scm: Vec<_> = transaction
-            .execution
-            .transitions
-            .iter()
-            .filter(|t| t.scm == scm && t.id != gateway_transition.id)
-            .collect();
-
-        ensure!(gateway_calls_count == 1, Error::UserCallnotFound);
-
-        let parsed_output = self.parse_user_output(&same_scm[0].outputs)?;
-
-        ensure!(
-            parsed_output.call_contract == call_contract,
-            Error::UserCallnotFound
-        );
-
-        Ok(Receipt::Found(TransitionReceipt {
-            transition: transition_id.clone(),
-            destination_address: call_contract
-                .destination_address()
-                .map_err(|e| Report::new(Error::FailedToCreateAleoID(e.to_string())))?,
-            destination_chain: ChainName::try_from(call_contract.destination_chain())
-                .change_context(Error::InvalidChainName)?,
-            source_address: Address::from_str(call_contract.sender.to_string().as_ref())
-                .change_context(Error::InvalidSourceAddress)?,
-            payload: parsed_output.payload,
-        }))
-    }
-}
-
-fn keccak256(payload: impl AsRef<[u8]>) -> [u8; 32] {
-    let mut hasher = Keccak256::new();
-    hasher.update(payload);
-    hasher.finalize().into()
-}
-
 #[cfg(test)]
 pub mod tests {
     use std::collections::HashMap;
     use std::str::FromStr;
 
-    use super::*;
+    use aleo_types::program::Program;
 
-    pub fn mock_client_2() -> MockClientTrait {
+    use super::*;
+    use crate::aleo::ReceiptBuilder;
+
+    pub fn mock_client_1() -> MockClientTrait {
         let mut mock_client = MockClientTrait::new();
 
         let transaction_id = "at1dgmvx30f79wt6w8fcjurwtsc5zak4efg4ayyme79862xylve7gxsq3nfh6";
@@ -407,7 +124,7 @@ pub mod tests {
         mock_client
     }
 
-    pub fn mock_client_3() -> MockClientTrait {
+    pub fn mock_client_2() -> MockClientTrait {
         let mut mock_client = MockClientTrait::new();
 
         let transaction_id = "at14gry4nauteg5sp00p6d2pj93dhpsm5857ml8y3xg57nkpszhav9qk0tgvd";
@@ -438,30 +155,46 @@ pub mod tests {
     }
 
     #[tokio::test]
-    async fn foo_test() {
-        let client = mock_client_2();
+    async fn sanity_test1() {
+        let client = mock_client_1();
         let transision_id = "au1zn24gzpgkr936qv49g466vfccg8aykcv05rk39s239hjxwrtsu8sltpsd8";
         let transition = Transition::from_str(transision_id).unwrap();
-        let client = ClientWrapper::new(&client);
         let gateway_contract = "gateway_base.aleo";
+        let program = Program::from_str(gateway_contract).unwrap();
 
-        let res = client
-            .transition_receipt(&transition, gateway_contract)
-            .await;
+        let res = ReceiptBuilder::new(&client, &program)
+            .unwrap()
+            .get_transaction_id(&transition)
+            .await
+            .unwrap()
+            .get_transaction()
+            .await
+            .unwrap()
+            .get_transition()
+            .unwrap()
+            .check_call_contract();
         assert!(res.is_ok());
     }
 
     #[tokio::test]
-    async fn flow_test() {
-        let client = mock_client_3();
+    async fn sanity_test2() {
+        let client = mock_client_2();
         let transision_id = "au17kdp7a7p6xuq6h0z3qrdydn4f6fjaufvzvlgkdd6vzpr87lgcgrq8qx6st";
         let transition = Transition::from_str(transision_id).unwrap();
-        let client = ClientWrapper::new(&client);
         let gateway_contract = "ac64caccf8221554ec3f89bf.aleo";
+        let program = Program::from_str(gateway_contract).unwrap();
 
-        let res = client
-            .transition_receipt(&transition, gateway_contract)
-            .await;
+        let res = ReceiptBuilder::new(&client, &program)
+            .unwrap()
+            .get_transaction_id(&transition)
+            .await
+            .unwrap()
+            .get_transaction()
+            .await
+            .unwrap()
+            .get_transition()
+            .unwrap()
+            .check_call_contract();
         assert!(res.is_ok());
     }
 }

--- a/ampd/src/aleo/mod.rs
+++ b/ampd/src/aleo/mod.rs
@@ -1,2 +1,7 @@
+pub(crate) mod error;
 pub(crate) mod http_client;
+pub(crate) mod receipt_builder;
+pub(crate) mod utils;
 pub(crate) mod verifier;
+
+pub use receipt_builder::*;

--- a/ampd/src/aleo/receipt_builder.rs
+++ b/ampd/src/aleo/receipt_builder.rs
@@ -202,8 +202,7 @@ where
 
     pub fn check_signer_rotation(self) -> Result<Receipt<SignerRotation>, Error> {
         let outputs = self.state.transition.outputs;
-        let signer_rotation =
-            find_in_outputs(&outputs).ok_or(Error::SignerRotationNotFound)?;
+        let signer_rotation = find_in_outputs(&outputs).ok_or(Error::SignerRotationNotFound)?;
         let scm = self.state.transition.scm.as_str();
 
         let signers_rotation_calls = self

--- a/ampd/src/aleo/receipt_builder.rs
+++ b/ampd/src/aleo/receipt_builder.rs
@@ -1,0 +1,230 @@
+use std::str::FromStr;
+
+use aleo_types::address::Address;
+use aleo_types::program::Program;
+use aleo_types::transaction::Transaction;
+use aleo_types::transition::Transition;
+use error_stack::{ensure, Report, Result, ResultExt};
+use router_api::ChainName;
+use serde::{Deserialize, Serialize};
+
+use crate::aleo::error::Error;
+use crate::aleo::http_client::ClientTrait;
+use crate::aleo::utils::*;
+
+mod call_contract;
+mod receipt;
+mod signer_rotation;
+
+pub use call_contract::{CallContract, CallContractReceipt};
+pub use receipt::{FoundReceipt, Receipt};
+pub use signer_rotation::SignerRotation;
+
+// State types for the type state pattern
+/// Initial state of the builder
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Initial;
+
+/// State after finding the transaction ID from a transition ID
+#[derive(Debug, Serialize, Deserialize)]
+pub struct StateTransactionId {
+    transaction_id: Transaction,
+}
+
+/// State after retrieving the transaction
+#[derive(Debug, Deserialize)]
+pub struct StateTransactionFound {
+    transaction: aleo_utils::block_processor::Transaction,
+}
+
+/// State after finding the transition in the transaction
+#[derive(Debug, Deserialize)]
+pub struct StateTransitionFound {
+    transaction: aleo_utils::block_processor::Transaction,
+    transition: aleo_utils::block_processor::Transition,
+}
+
+/// Builder for verifying Aleo receipts using a type-state pattern
+///
+/// The builder progresses through multiple states to verify a receipt:
+/// 1. Initial → Find transaction ID from transition ID
+/// 2. StateTransactionId → Retrieve transaction
+/// 3. StateTransactionFound → Find target transition
+/// 4. StateTransitionFound → Verify receipt (CallContract or SignerRotation)
+pub struct ReceiptBuilder<'a, C: ClientTrait, S> {
+    client: &'a C,
+    target_contract: Program, // The target program can be the CallContract or the
+    state: S,
+}
+
+impl<'a, C> ReceiptBuilder<'a, C, Initial>
+where
+    C: ClientTrait + Send + Sync + 'static,
+{
+    pub fn new(client: &'a C, target_contract: &'a str) -> Result<Self, Error> {
+        let target_contract = Program::from_str(target_contract)
+            .change_context(Error::InvalidProgramName(target_contract.to_string()))?;
+
+        Ok(Self {
+            client,
+            target_contract,
+            state: Initial,
+        })
+    }
+
+    pub async fn get_transaction_id(
+        self,
+        transition_id: &Transition,
+    ) -> Result<ReceiptBuilder<'a, C, StateTransactionId>, Error> {
+        let transaction_id = self
+            .client
+            .find_transaction(transition_id)
+            .await
+            .change_context(Error::TransitionNotFound(transition_id.to_string()))?;
+
+        let transaction = transaction_id.trim_matches('"');
+
+        Ok(ReceiptBuilder {
+            client: self.client,
+            target_contract: self.target_contract,
+            state: StateTransactionId {
+                transaction_id: Transaction::from_str(transaction)
+                    .change_context(Error::TransactionNotFound(transaction.to_string()))?,
+            },
+        })
+    }
+}
+
+impl<'a, C> ReceiptBuilder<'a, C, StateTransactionId>
+where
+    C: ClientTrait + Send + Sync + 'static,
+{
+    /// Retrieve the transaction from the transaction ID and transition to the next state
+    pub async fn get_transaction(
+        self,
+    ) -> Result<ReceiptBuilder<'a, C, StateTransactionFound>, Error> {
+        let transaction = self
+            .client
+            .get_transaction(&self.state.transaction_id)
+            .await
+            .change_context(Error::TransactionNotFound(
+                self.state.transaction_id.to_string(),
+            ))?;
+
+        Ok(ReceiptBuilder {
+            client: self.client,
+            target_contract: self.target_contract,
+            state: StateTransactionFound { transaction },
+        })
+    }
+}
+
+impl<'a, C> ReceiptBuilder<'a, C, StateTransactionFound>
+where
+    C: ClientTrait + Send + Sync + 'static,
+{
+    pub fn get_transition(self) -> Result<ReceiptBuilder<'a, C, StateTransitionFound>, Error> {
+        let transition = self
+            .state
+            .transaction
+            .execution
+            .transitions
+            .iter()
+            .find(|t| t.program.as_str() == self.target_contract.as_str())
+            .ok_or(Error::TransitionNotFoundInTransaction(
+                self.target_contract.to_string(),
+            ))?
+            .clone();
+
+        Ok(ReceiptBuilder {
+            client: self.client,
+            target_contract: self.target_contract,
+            state: StateTransitionFound {
+                transaction: self.state.transaction,
+                transition,
+            },
+        })
+    }
+}
+
+impl<'a, C> ReceiptBuilder<'a, C, StateTransitionFound>
+where
+    C: ClientTrait + Send + Sync + 'static,
+{
+    pub fn check_call_contract(self) -> Result<Receipt, Error> {
+        let outputs = self.state.transition.outputs;
+        let call_contract = find_call_contract(&outputs).ok_or(Error::CallContractNotFound)?;
+        let scm = self.state.transition.scm.as_str();
+
+        let gateway_calls_count = self
+            .state
+            .transaction
+            .execution
+            .transitions
+            .iter()
+            .filter(|t| t.scm == scm && t.program == self.target_contract.as_str())
+            .count();
+
+        ensure!(gateway_calls_count == 1, Error::CallContractNotFound);
+
+        let same_scm: Vec<_> = self
+            .state
+            .transaction
+            .execution
+            .transitions
+            .iter()
+            .filter(|t| t.scm == scm && t.id != self.state.transition.id)
+            .collect();
+
+        ensure!(same_scm.len() == 1, Error::UserCallnotFound);
+
+        let parsed_output =
+            parse_user_output(&same_scm[0].outputs).change_context(Error::UserCallnotFound)?;
+
+        ensure!(
+            parsed_output.call_contract == call_contract,
+            Error::UserCallnotFound
+        );
+
+        Ok(Receipt::Found(FoundReceipt::CallContract(
+            CallContractReceipt {
+                transition: Transition::from_str(self.state.transition.id.as_str())
+                    .map_err(|e| Report::new(Error::CalledContractReceipt(e.to_string())))?,
+                destination_address: call_contract
+                    .destination_address()
+                    .map_err(|e| Report::new(Error::FailedToCreateAleoID(e.to_string())))?,
+                destination_chain: ChainName::try_from(call_contract.destination_chain())
+                    .change_context(Error::InvalidChainName)?,
+                source_address: Address::from_str(call_contract.sender.to_string().as_ref())
+                    .change_context(Error::InvalidSourceAddress)?,
+                payload: parsed_output.payload,
+            },
+        )))
+    }
+
+    pub fn check_signer_rotation(self) -> Result<Receipt, Error> {
+        let outputs = self.state.transition.outputs;
+        let signer_rotation =
+            find_signer_rotation(&outputs).ok_or(Error::SignerRotationNotFound)?;
+        let scm = self.state.transition.scm.as_str();
+
+        let signers_rotation_calls = self
+            .state
+            .transaction
+            .execution
+            .transitions
+            .iter()
+            .filter(|t| {
+                t.scm == scm
+                    && t.program == self.target_contract.as_str()
+                    && t.id != self.state.transition.id
+            })
+            .count();
+
+        ensure!(signers_rotation_calls == 1, Error::SignerRotationNotFound);
+
+        Ok(Receipt::Found(FoundReceipt::SignerRotation(
+            signer_rotation,
+        )))
+    }
+}

--- a/ampd/src/aleo/receipt_builder.rs
+++ b/ampd/src/aleo/receipt_builder.rs
@@ -154,7 +154,7 @@ where
 {
     pub fn check_call_contract<N: Network>(self) -> Result<Receipt<CallContractReceipt<N>>, Error> {
         let outputs = self.state.transition.outputs;
-        let call_contract = find_call_contract(&outputs).ok_or(Error::CallContractNotFound)?;
+        let call_contract = find_in_outputs(&outputs).ok_or(Error::CallContractNotFound)?;
         let scm = self.state.transition.scm.as_str();
 
         let gateway_calls_count = self
@@ -203,7 +203,7 @@ where
     pub fn check_signer_rotation(self) -> Result<Receipt<SignerRotation>, Error> {
         let outputs = self.state.transition.outputs;
         let signer_rotation =
-            find_signer_rotation(&outputs).ok_or(Error::SignerRotationNotFound)?;
+            find_in_outputs(&outputs).ok_or(Error::SignerRotationNotFound)?;
         let scm = self.state.transition.scm.as_str();
 
         let signers_rotation_calls = self

--- a/ampd/src/aleo/receipt_builder.rs
+++ b/ampd/src/aleo/receipt_builder.rs
@@ -177,14 +177,14 @@ where
             .filter(|t| t.scm == scm && t.id != self.state.transition.id)
             .collect();
 
-        ensure!(same_scm.len() == 1, Error::UserCallnotFound);
+        ensure!(same_scm.len() == 1, Error::MoreThanOneSCM);
 
         let parsed_output =
             parse_user_output(&same_scm[0].outputs).change_context(Error::UserCallnotFound)?;
 
         ensure!(
             parsed_output.call_contract == call_contract,
-            Error::UserCallnotFound
+            Error::CallConractDoesNotMatch
         );
 
         Ok(Receipt::Found(CallContractReceipt {

--- a/ampd/src/aleo/receipt_builder/call_contract.rs
+++ b/ampd/src/aleo/receipt_builder/call_contract.rs
@@ -1,0 +1,125 @@
+use aleo_types::address::Address;
+use aleo_types::transition::Transition;
+use aleo_utils::json_like;
+use aleo_utils::string_encoder::StringEncoder;
+use error_stack::Result;
+use router_api::ChainName;
+use serde::{Deserialize, Serialize};
+use sha3::{Digest, Keccak256};
+use tracing::{error, info};
+
+use crate::aleo::error::Error;
+use crate::types::Hash;
+
+#[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct CallContract {
+    pub(crate) caller: String,
+    pub(crate) sender: String,
+    pub(crate) destination_chain: Vec<u128>,
+    pub(crate) destination_address: Vec<u128>,
+}
+
+impl CallContract {
+    pub fn destination_chain(&self) -> String {
+        let encoded_string = StringEncoder {
+            buf: self.destination_chain.clone(),
+        };
+        encoded_string.decode()
+    }
+
+    pub fn destination_address(&self) -> Result<String, error_stack::Report<Error>> {
+        let encoded_string = StringEncoder {
+            buf: self.destination_address.clone(),
+        };
+        let ascii_string = encoded_string.decode();
+        Ok(ascii_string)
+    }
+}
+
+#[derive(Debug)]
+pub struct CallContractReceipt {
+    pub transition: Transition,
+    pub destination_address: String,
+    pub destination_chain: ChainName,
+    pub source_address: Address,
+    pub payload: Vec<u8>,
+}
+
+impl PartialEq<crate::handlers::aleo_verify_msg::Message> for CallContractReceipt {
+    fn eq(&self, message: &crate::handlers::aleo_verify_msg::Message) -> bool {
+        info!(
+            "transition_id: chain.{} == msg.{} ({})",
+            self.transition,
+            message.tx_id,
+            self.transition == message.tx_id
+        );
+        info!(
+            "destination_address: chain.{} == msg.{} ({})",
+            self.destination_address,
+            message.destination_address,
+            self.destination_address == message.destination_address
+        );
+        info!(
+            "destination_chain: chain.{} == msg.{} ({})",
+            self.destination_chain,
+            message.destination_chain,
+            self.destination_chain == message.destination_chain
+        );
+        info!(
+            "source_address: chain.{:?} == msg.{:?} ({})",
+            self.source_address,
+            message.source_address,
+            self.source_address == message.source_address
+        );
+
+        let payload_hash = match payload_hash(&self.payload, self.destination_chain.as_ref()) {
+            Ok(hash) => hash,
+            Err(e) => {
+                error!("payload_hash: {}", e);
+                return false;
+            }
+        };
+
+        info!(
+            "payload_hash: chain.{:?} == msg.{:?} ({})",
+            payload_hash,
+            message.payload_hash,
+            payload_hash == message.payload_hash
+        );
+
+        self.transition == message.tx_id
+            && self.destination_address == message.destination_address
+            && self.destination_chain == message.destination_chain
+            && self.source_address == message.source_address
+            && payload_hash == message.payload_hash
+    }
+}
+
+fn payload_hash(payload: &[u8], destination_chain: &str) -> std::result::Result<Hash, Error> {
+    let payload = std::str::from_utf8(payload).map_err(|e| Error::PayloadHash(e.to_string()))?;
+    let payload_hash = if destination_chain.starts_with("eth") {
+        let payload =
+            json_like::into_json(payload).map_err(|e| Error::PayloadHash(e.to_string()))?;
+        let payload: Vec<u8> =
+            serde_json::from_str(&payload).map_err(|e| Error::PayloadHash(e.to_string()))?;
+        let payload =
+            std::str::from_utf8(&payload).map_err(|e| Error::PayloadHash(e.to_string()))?;
+        let payload = solabi::encode(&payload);
+        let payload_hash = keccak256(&payload).to_vec();
+        Hash::from_slice(&payload_hash)
+    } else {
+        // Keccak + bhp hash
+        let payload_hash =
+            aleo_gateway::hash::<&str, snarkvm_cosmwasm::network::TestnetV0>(payload)
+                .map_err(|e| Error::PayloadHash(e.to_string()))?;
+        Hash::from_slice(&payload_hash)
+    };
+
+    Ok(payload_hash)
+}
+
+fn keccak256(payload: impl AsRef<[u8]>) -> [u8; 32] {
+    let mut hasher = Keccak256::new();
+    hasher.update(payload);
+    hasher.finalize().into()
+}

--- a/ampd/src/aleo/receipt_builder/receipt.rs
+++ b/ampd/src/aleo/receipt_builder/receipt.rs
@@ -1,0 +1,17 @@
+use aleo_types::transition::Transition;
+use error_stack::Report;
+
+use crate::aleo::error::Error;
+use crate::aleo::receipt_builder::{CallContractReceipt, SignerRotation};
+
+#[derive(Debug)]
+pub enum Receipt {
+    Found(FoundReceipt),
+    NotFound(Transition, Report<Error>),
+}
+
+#[derive(Debug)]
+pub enum FoundReceipt {
+    CallContract(CallContractReceipt),
+    SignerRotation(SignerRotation),
+}

--- a/ampd/src/aleo/receipt_builder/receipt.rs
+++ b/ampd/src/aleo/receipt_builder/receipt.rs
@@ -2,16 +2,9 @@ use aleo_types::transition::Transition;
 use error_stack::Report;
 
 use crate::aleo::error::Error;
-use crate::aleo::receipt_builder::{CallContractReceipt, SignerRotation};
 
 #[derive(Debug)]
-pub enum Receipt {
-    Found(FoundReceipt),
+pub enum Receipt<T> {
+    Found(T),
     NotFound(Transition, Report<Error>),
-}
-
-#[derive(Debug)]
-pub enum FoundReceipt {
-    CallContract(CallContractReceipt),
-    SignerRotation(SignerRotation),
 }

--- a/ampd/src/aleo/receipt_builder/signer_rotation.rs
+++ b/ampd/src/aleo/receipt_builder/signer_rotation.rs
@@ -1,0 +1,10 @@
+use aleo_gateway::WeightedSigners;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+pub struct SignerRotation {
+    pub(crate) message_id: String,
+    pub(crate) block_height: u32,
+    pub(crate) signers_hash: String,
+    pub(crate) weighted_signers: WeightedSigners,
+}

--- a/ampd/src/aleo/utils.rs
+++ b/ampd/src/aleo/utils.rs
@@ -68,28 +68,21 @@ fn find_in_outputs<T: for<'de> serde::Deserialize<'de>>(outputs: &[IdValuePair])
             _ => None,
         })
         .and_then(|value| {
-            let json = json_like::into_json(value.to_string().as_str()).ok()?;
+            let json = json_like::into_json(value).ok()?;
             serde_json::from_str::<T>(&json).ok()
         })
 }
 
-macro_rules! define_finder {
-    ($name:ident, $type:ty, $doc:expr) => {
-        #[doc = $doc]
-        pub fn $name(outputs: &[IdValuePair]) -> Option<$type> {
-            find_in_outputs(outputs)
-        }
-    };
+/// Find CallContract in the outputs
+pub fn find_call_contract(
+    outputs: &[IdValuePair],
+) -> Option<crate::aleo::receipt_builder::CallContract> {
+    find_in_outputs(outputs)
 }
 
-define_finder!(
-    find_call_contract,
-    crate::aleo::receipt_builder::CallContract,
-    "Find CallContract in the outputs"
-);
-
-define_finder!(
-    find_signer_rotation,
-    crate::aleo::receipt_builder::SignerRotation,
-    "Find SignerRotation in the outputs"
-);
+/// Find SignerRotation in the outputs
+pub fn find_signer_rotation(
+    outputs: &[IdValuePair],
+) -> Option<crate::aleo::receipt_builder::SignerRotation> {
+    find_in_outputs(outputs)
+}

--- a/ampd/src/aleo/utils.rs
+++ b/ampd/src/aleo/utils.rs
@@ -54,37 +54,13 @@ pub fn parse_user_output(outputs: &[IdValuePair]) -> Result<ParsedOutput, Error>
 }
 
 /// Generic function to find a specific type in the outputs
-fn find_in_outputs<T: for<'de> serde::Deserialize<'de>>(outputs: &[IdValuePair]) -> Option<T> {
+pub fn find_in_outputs<T: for<'de> serde::Deserialize<'de>>(outputs: &[IdValuePair]) -> Option<T> {
     // Only proceed if there's exactly one output
     if outputs.len() != 1 {
         return None;
     }
 
-    outputs
-        .first()
-        .and_then(|o| match o {
-            IdValuePair {
-                id: _,
-                value: Some(value),
-            } => Some(value),
-            _ => None,
-        })
-        .and_then(|value| {
-            let json = json_like::into_json(value).ok()?;
-            serde_json::from_str::<T>(&json).ok()
-        })
-}
-
-/// Find CallContract in the outputs
-pub fn find_call_contract(
-    outputs: &[IdValuePair],
-) -> Option<crate::aleo::receipt_builder::CallContract> {
-    find_in_outputs(outputs)
-}
-
-/// Find SignerRotation in the outputs
-pub fn find_signer_rotation(
-    outputs: &[IdValuePair],
-) -> Option<crate::aleo::receipt_builder::SignerRotation> {
-    find_in_outputs(outputs)
+    let value = &outputs.first()?.value;
+    let json = json_like::into_json(value.as_ref()?).ok()?;
+    serde_json::from_str(&json).ok()
 }

--- a/ampd/src/aleo/utils.rs
+++ b/ampd/src/aleo/utils.rs
@@ -26,7 +26,7 @@ pub fn parse_user_output(outputs: &[IdValuePair]) -> Result<ParsedOutput, Error>
         if let Some(plaintext) = &output.value {
             // Convert to JSON with proper error handling
             let json = json_like::into_json(plaintext.as_str()).map_err(|_| {
-                Error::JsonParseError(format!("Failed to convert output to JSON: {}", plaintext))
+                Error::JsonParse(format!("Failed to convert output to JSON: {}", plaintext))
             })?;
 
             // Try to parse as CallContract

--- a/ampd/src/aleo/utils.rs
+++ b/ampd/src/aleo/utils.rs
@@ -1,0 +1,95 @@
+use aleo_utils::block_processor::IdValuePair;
+use aleo_utils::json_like;
+use error_stack::{Report, Result};
+use tracing::debug;
+
+use crate::aleo::error::Error;
+use crate::aleo::receipt_builder::CallContract;
+
+#[derive(Default, Debug)]
+pub struct ParsedOutput {
+    pub payload: Vec<u8>,
+    pub call_contract: CallContract,
+}
+
+pub fn parse_user_output(outputs: &[IdValuePair]) -> Result<ParsedOutput, Error> {
+    if outputs.len() != 2 {
+        return Err(Report::new(Error::UserCallnotFound)
+            .attach_printable(format!("Expected exactly 2 outputs, got {}", outputs.len())));
+    }
+
+    let mut parsed_output = ParsedOutput::default();
+
+    for output in outputs {
+        if let Some(plaintext) = &output.value {
+            // Convert to JSON with proper error handling
+            let json = json_like::into_json(plaintext.as_str()).map_err(|_| {
+                Error::JsonParseError(format!("Failed to convert output to JSON: {}", plaintext))
+            })?;
+
+            // Try to parse as CallContract
+            match serde_json::from_str::<CallContract>(&json) {
+                Ok(call_contract) => {
+                    parsed_output.call_contract = call_contract;
+                }
+                Err(e) => {
+                    debug!("Failed to parse as CallContract: {}", e);
+
+                    // Store the raw payload by directly converting bytes
+                    parsed_output.payload = plaintext.as_bytes().to_vec();
+                }
+            }
+        }
+    }
+
+    // Validate that we parsed something
+    if parsed_output.call_contract == CallContract::default() && parsed_output.payload.is_empty() {
+        return Err(Report::new(Error::UserCallnotFound)
+            .attach_printable("No valid user output found in transaction"));
+    }
+
+    Ok(parsed_output)
+}
+
+/// Generic function to find a specific type in the outputs
+fn find_in_outputs<T: for<'de> serde::Deserialize<'de>>(outputs: &[IdValuePair]) -> Option<T> {
+    // Only proceed if there's exactly one output
+    if outputs.len() != 1 {
+        return None;
+    }
+
+    outputs
+        .first()
+        .and_then(|o| match o {
+            IdValuePair {
+                id: _,
+                value: Some(value),
+            } => Some(value),
+            _ => None,
+        })
+        .and_then(|value| {
+            let json = json_like::into_json(value.to_string().as_str()).ok()?;
+            serde_json::from_str::<T>(&json).ok()
+        })
+}
+
+macro_rules! define_finder {
+    ($name:ident, $type:ty, $doc:expr) => {
+        #[doc = $doc]
+        pub fn $name(outputs: &[IdValuePair]) -> Option<$type> {
+            find_in_outputs(outputs)
+        }
+    };
+}
+
+define_finder!(
+    find_call_contract,
+    crate::aleo::receipt_builder::CallContract,
+    "Find CallContract in the outputs"
+);
+
+define_finder!(
+    find_signer_rotation,
+    crate::aleo::receipt_builder::SignerRotation,
+    "Find SignerRotation in the outputs"
+);

--- a/ampd/src/aleo/utils.rs
+++ b/ampd/src/aleo/utils.rs
@@ -12,6 +12,8 @@ pub struct ParsedOutput {
     pub call_contract: CallContract,
 }
 
+/// Find the call contract from outputs.
+/// CallContract consist of the CallContract data and the raw payload.
 pub fn parse_user_output(outputs: &[IdValuePair]) -> Result<ParsedOutput, Error> {
     if outputs.len() != 2 {
         return Err(Report::new(Error::UserCallnotFound)
@@ -35,7 +37,7 @@ pub fn parse_user_output(outputs: &[IdValuePair]) -> Result<ParsedOutput, Error>
                 Err(e) => {
                     debug!("Failed to parse as CallContract: {}", e);
 
-                    // Store the raw payload by directly converting bytes
+                    // Store it as the raw payload by directly converting bytes
                     parsed_output.payload = plaintext.as_bytes().to_vec();
                 }
             }
@@ -43,7 +45,7 @@ pub fn parse_user_output(outputs: &[IdValuePair]) -> Result<ParsedOutput, Error>
     }
 
     // Validate that we parsed something
-    if parsed_output.call_contract == CallContract::default() && parsed_output.payload.is_empty() {
+    if parsed_output.call_contract == CallContract::default() || parsed_output.payload.is_empty() {
         return Err(Report::new(Error::UserCallnotFound)
             .attach_printable("No valid user output found in transaction"));
     }

--- a/ampd/src/aleo/verifier.rs
+++ b/ampd/src/aleo/verifier.rs
@@ -33,7 +33,7 @@ pub fn verify_verifier_set(
 ) -> Vote {
     let res = match receipt {
         Receipt::Found(signer_rotation) => WeightedSigners::try_from(&msg.verifier_set)
-            .map_or(false, |other| other == signer_rotation.weighted_signers),
+            .is_ok_and(|other| other == signer_rotation.weighted_signers),
         Receipt::NotFound(transition, e) => {
             warn!("AleoMessageId: {:?} is not verified: {:?}", transition, e);
 

--- a/ampd/src/aleo/verifier.rs
+++ b/ampd/src/aleo/verifier.rs
@@ -1,17 +1,20 @@
+use aleo_gateway::WeightedSigners;
 use axelar_wasm_std::voting::Vote;
 use tracing::warn;
 
-use super::http_client::Receipt;
+use crate::aleo::receipt_builder::{FoundReceipt, Receipt};
 use crate::handlers::aleo_verify_msg::Message;
+use crate::handlers::aleo_verify_verifier_set::VerifierSetConfirmation;
 
 fn verify(receipt: &Receipt, msg: &Message) -> Vote {
     let res = match receipt {
-        Receipt::Found(transition_receipt) => transition_receipt == msg,
+        Receipt::Found(FoundReceipt::CallContract(transition_receipt)) => transition_receipt == msg,
         Receipt::NotFound(transition, e) => {
             warn!("AleoMessageId: {:?} is not verified: {:?}", transition, e);
 
             false
         }
+        Receipt::Found(FoundReceipt::SignerRotation(_)) => todo!(),
     };
 
     match res {
@@ -22,4 +25,25 @@ fn verify(receipt: &Receipt, msg: &Message) -> Vote {
 
 pub fn verify_message(receipt: &Receipt, msg: &Message) -> Vote {
     verify(receipt, msg)
+}
+
+// TODO: use the full message for comparison
+pub fn verify_verifier_set(receipt: &Receipt, msg: &VerifierSetConfirmation) -> Vote {
+    let res = match receipt {
+        Receipt::Found(FoundReceipt::SignerRotation(transition_receipt)) => {
+            WeightedSigners::try_from(&msg.verifier_set)
+                .map_or(false, |other| other == transition_receipt.weighted_signers)
+        }
+        Receipt::NotFound(transition, e) => {
+            warn!("AleoMessageId: {:?} is not verified: {:?}", transition, e);
+
+            false
+        }
+        Receipt::Found(FoundReceipt::CallContract(_)) => todo!(),
+    };
+
+    match res {
+        true => Vote::SucceededOnChain,
+        false => Vote::FailedOnChain,
+    }
 }

--- a/ampd/src/handlers/aleo_verify_msg.rs
+++ b/ampd/src/handlers/aleo_verify_msg.rs
@@ -102,7 +102,7 @@ where
     N: Network,
 {
     let receipt = async {
-        ReceiptBuilder::new(http_client, &program)?
+        ReceiptBuilder::new(http_client, program)?
             .get_transaction_id(&id)
             .await?
             .get_transaction()

--- a/ampd/src/handlers/aleo_verify_verifier_set.rs
+++ b/ampd/src/handlers/aleo_verify_verifier_set.rs
@@ -17,7 +17,7 @@ use voting_verifier::msg::ExecuteMsg;
 
 use crate::aleo::http_client::ClientTrait as AleoClientTrait;
 use crate::aleo::verifier::verify_verifier_set;
-use crate::aleo::{Receipt, ReceiptBuilder};
+use crate::aleo::{Receipt, ReceiptBuilder, SignerRotation};
 use crate::event_processor::EventHandler;
 use crate::handlers::errors::Error;
 use crate::handlers::errors::Error::DeserializeEvent;
@@ -93,7 +93,7 @@ async fn fetch_transition_receipt<C>(
     http_client: &C,
     program: &str,
     id: &Transition,
-) -> (Transition, Receipt)
+) -> (Transition, Receipt<SignerRotation>)
 where
     C: AleoClientTrait + Send + Sync + 'static,
 {

--- a/ampd/src/handlers/aleo_verify_verifier_set.rs
+++ b/ampd/src/handlers/aleo_verify_verifier_set.rs
@@ -98,7 +98,7 @@ where
     C: AleoClientTrait + Send + Sync + 'static,
 {
     let receipt = async {
-        ReceiptBuilder::new(http_client, &program)?
+        ReceiptBuilder::new(http_client, program)?
             .get_transaction_id(id)
             .await?
             .get_transaction()

--- a/ampd/src/handlers/aleo_verify_verifier_set.rs
+++ b/ampd/src/handlers/aleo_verify_verifier_set.rs
@@ -1,0 +1,285 @@
+use aleo_types::program::Program;
+use aleo_types::transition::Transition;
+use async_trait::async_trait;
+use axelar_wasm_std::voting::{PollId, Vote};
+use cosmrs::cosmwasm::MsgExecuteContract;
+use cosmrs::tx::Msg;
+use events::Error::EventTypeMismatch;
+use events::Event;
+use events_derive::try_from;
+use multisig::verifier_set::VerifierSet;
+use prost_types::Any;
+use router_api::ChainName;
+use serde::Deserialize;
+use tokio::sync::watch::Receiver;
+use tracing::{debug, info, info_span};
+use voting_verifier::msg::ExecuteMsg;
+
+use crate::aleo::http_client::ClientTrait as AleoClientTrait;
+use crate::aleo::verifier::verify_verifier_set;
+use crate::aleo::{Receipt, ReceiptBuilder};
+use crate::event_processor::EventHandler;
+use crate::handlers::errors::Error;
+use crate::handlers::errors::Error::DeserializeEvent;
+use crate::types::TMAddress;
+
+#[derive(Deserialize, Debug)]
+pub struct VerifierSetConfirmation {
+    pub message_id: Transition,
+    pub verifier_set: VerifierSet,
+}
+
+#[derive(Deserialize, Debug)]
+#[try_from("wasm-verifier_set_poll_started")]
+struct PollStartedEvent {
+    verifier_set: VerifierSetConfirmation,
+    poll_id: PollId,
+    source_chain: ChainName,
+    #[allow(dead_code)]
+    source_gateway_address: Program,
+    expires_at: u64,
+    #[allow(dead_code)]
+    confirmation_height: u64,
+    participants: Vec<TMAddress>,
+}
+
+#[derive(Clone)]
+pub struct Handler<C: AleoClientTrait> {
+    verifier: TMAddress,
+    voting_verifier_contract: TMAddress,
+    http_client: C,
+    latest_block_height: Receiver<u64>,
+    chain: ChainName,
+    verifier_set_contract: String,
+}
+
+impl<C> Handler<C>
+where
+    C: AleoClientTrait + Send + Sync,
+{
+    pub fn new(
+        verifier: TMAddress,
+        voting_verifier_contract: TMAddress,
+        chain: ChainName,
+        aleo_client: C,
+        latest_block_height: Receiver<u64>,
+        verifier_set_contract: String,
+    ) -> Self {
+        Self {
+            verifier,
+            voting_verifier_contract,
+            http_client: aleo_client,
+            latest_block_height,
+            chain,
+            verifier_set_contract,
+        }
+    }
+
+    fn vote_msg(&self, poll_id: PollId, vote: Vote) -> MsgExecuteContract {
+        MsgExecuteContract {
+            sender: self.verifier.as_ref().clone(),
+            contract: self.voting_verifier_contract.as_ref().clone(),
+            msg: serde_json::to_vec(&ExecuteMsg::Vote {
+                poll_id,
+                votes: vec![vote],
+            })
+            .expect("vote msg should serialize"),
+            funds: vec![],
+        }
+    }
+}
+
+async fn fetch_transition_receipt<C>(
+    http_client: &C,
+    program: &str,
+    id: &Transition,
+) -> (Transition, Receipt)
+where
+    C: AleoClientTrait + Send + Sync + 'static,
+{
+    let receipt = async {
+        ReceiptBuilder::new(http_client, &program)?
+            .get_transaction_id(id)
+            .await?
+            .get_transaction()
+            .await?
+            .get_transition()?
+            .check_signer_rotation()
+    }
+    .await;
+
+    match receipt {
+        Ok(receipt) => (id.to_owned(), receipt),
+        Err(e) => (id.clone(), Receipt::NotFound(id.to_owned(), e)),
+    }
+}
+
+#[async_trait]
+impl<C> EventHandler for Handler<C>
+where
+    C: AleoClientTrait + Send + Sync + 'static,
+{
+    type Err = Error;
+
+    #[tracing::instrument(skip(self, event))]
+    async fn handle(&self, event: &Event) -> error_stack::Result<Vec<Any>, Self::Err> {
+        debug!("event: {event:?}");
+        if !event.is_from_contract(self.voting_verifier_contract.as_ref()) {
+            return Ok(vec![]);
+        }
+
+        let PollStartedEvent {
+            poll_id,
+            source_chain,
+            source_gateway_address: _,
+            expires_at,
+            confirmation_height: _,
+            participants,
+            verifier_set,
+        } = match event.try_into() as error_stack::Result<_, _> {
+            Err(report) if matches!(report.current_context(), EventTypeMismatch(_)) => {
+                return Ok(vec![])
+            }
+            event => event.change_context(DeserializeEvent)?,
+        };
+
+        if self.chain != source_chain {
+            return Ok(vec![]);
+        }
+
+        if !participants.contains(&self.verifier) {
+            return Ok(vec![]);
+        }
+
+        let latest_block_height = *self.latest_block_height.borrow();
+        if latest_block_height >= expires_at {
+            info!(poll_id = poll_id.to_string(), "skipping expired poll");
+            return Ok(vec![]);
+        }
+
+        // Transition IDs on Aleo chain
+        let transition = &verifier_set.message_id;
+
+        let (_, receipt) = fetch_transition_receipt(
+            &self.http_client,
+            self.verifier_set_contract.as_str(),
+            transition,
+        )
+        .await;
+
+        let poll_id_str: String = poll_id.into();
+        let source_chain_str: String = source_chain.into();
+        let vote = info_span!(
+            "verify messages from an Aleo chain",
+            poll_id = poll_id_str,
+            source_chain = source_chain_str,
+            message_ids = transition.to_string(),
+        )
+        .in_scope(|| {
+            info!("ready to verify messages in poll");
+
+            let vote = verify_verifier_set(&receipt, &verifier_set);
+            info!(
+                vote = ?vote,
+                "ready to vote for messages in poll"
+            );
+
+            vote
+        });
+
+        Ok(vec![self
+            .vote_msg(poll_id, vote)
+            .into_any()
+            .expect("vote msg should serialize")])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::TryInto;
+    use std::str::FromStr;
+
+    use aleo_types::transition::Transition;
+    use axelar_wasm_std::voting::PollId;
+    use events::Event;
+    use multisig::key::KeyType;
+    use multisig::test::common::{aleo_schnorr_test_data, build_verifier_set};
+    use multisig::verifier_set::VerifierSet;
+    use router_api::ChainName;
+    use voting_verifier::events::{PollMetadata, PollStarted, VerifierSetConfirmation};
+
+    use crate::handlers::aleo_verify_verifier_set::PollStartedEvent;
+    use crate::handlers::tests::{into_structured_event, participants};
+    use crate::types::TMAddress;
+    use crate::PREFIX;
+
+    #[test]
+    fn aleo_verify_verifier_set_should_deserialize_correct_event() {
+        let expiration = 100u64;
+        let config = config(None, expiration);
+
+        let event: Event =
+            into_structured_event(poll_started_event(&config), &TMAddress::random(PREFIX));
+        let event: PollStartedEvent = event.try_into().unwrap();
+
+        goldie::assert_debug!(event);
+    }
+
+    struct Config {
+        transition: Transition,
+        verifier_set: VerifierSet,
+        poll_id: PollId,
+        source_chain: ChainName,
+        source_gateway_address: String,
+        confirmation_height: u64,
+        expires_at: u64,
+        participants: Vec<TMAddress>,
+    }
+
+    fn config(verifier: Option<TMAddress>, expires_at: u64) -> Config {
+        let transition =
+            Transition::from_str("au17kdp7a7p6xuq6h0z3qrdydn4f6fjaufvzvlgkdd6vzpr87lgcgrq8qx6st")
+                .unwrap();
+        let key_type = KeyType::AleoSchnorr;
+        let verifier_set = build_verifier_set(key_type, &aleo_schnorr_test_data::signers());
+        let poll_id = PollId::from_str("100").unwrap();
+        let source_chain = ChainName::from_str("aleo-2").unwrap();
+        let source_gateway_address = "mygateway.aleo".to_string();
+        let confirmation_height = 15;
+        let participants = participants(5, verifier);
+
+        Config {
+            transition,
+            verifier_set,
+            poll_id,
+            source_chain,
+            source_gateway_address,
+            confirmation_height,
+            expires_at,
+            participants,
+        }
+    }
+
+    fn poll_started_event(config: &Config) -> PollStarted {
+        PollStarted::VerifierSet {
+            #[allow(deprecated)] // TODO: The below event uses the deprecated tx_id and event_index fields. Remove this attribute when those fields are removed
+            verifier_set: VerifierSetConfirmation {
+                tx_id: "foo".to_string().parse().unwrap(), // this field is deprecated
+                event_index: 0u32, // this field is deprecated
+                message_id: config.transition.to_string().parse().unwrap(),
+                verifier_set: config.verifier_set.clone(),
+            },
+            metadata: PollMetadata {
+                poll_id: config.poll_id,
+                source_chain: config.source_chain.clone(),
+                source_gateway_address: config.source_gateway_address.parse().unwrap(),
+                confirmation_height: config.confirmation_height,
+                expires_at: config.expires_at,
+                participants: config.participants.iter()
+                    .map(|addr| cosmwasm_std::Addr::unchecked(addr.to_string()))
+                    .collect(),
+
+            },
+        }
+    }
+}

--- a/ampd/src/handlers/config.rs
+++ b/ampd/src/handlers/config.rs
@@ -31,7 +31,15 @@ pub enum Config {
         network: String,
         gateway_contract: String,
     },
-    AleoVerifierSetVerifier {},
+    AleoVerifierSetVerifier {
+        cosmwasm_contract: TMAddress,
+        #[serde(flatten, with = "chain")]
+        chain: Chain,
+        timeout: Option<Duration>,
+        base_url: Url,
+        network: String,
+        verifier_contract: String,
+    },
     EvmMsgVerifier {
         cosmwasm_contract: TMAddress,
         #[serde(flatten, with = "chain")]

--- a/ampd/src/handlers/config.rs
+++ b/ampd/src/handlers/config.rs
@@ -30,6 +30,7 @@ pub enum Config {
         base_url: Url,
         network: String,
         gateway_contract: String,
+        network_id: u16,
     },
     AleoVerifierSetVerifier {
         cosmwasm_contract: TMAddress,

--- a/ampd/src/handlers/mod.rs
+++ b/ampd/src/handlers/mod.rs
@@ -1,4 +1,5 @@
 pub mod aleo_verify_msg;
+pub mod aleo_verify_verifier_set;
 pub mod config;
 mod errors;
 pub mod evm_verify_msg;

--- a/ampd/src/handlers/testdata/aleo_verify_verifier_set_should_deserialize_correct_event.golden
+++ b/ampd/src/handlers/testdata/aleo_verify_verifier_set_should_deserialize_correct_event.golden
@@ -1,0 +1,70 @@
+PollStartedEvent {
+    verifier_set: VerifierSetConfirmation {
+        message_id: Transition(
+            String(
+                "au17kdp7a7p6xuq6h0z3qrdydn4f6fjaufvzvlgkdd6vzpr87lgcgrq8qx6st",
+            ),
+        ),
+        verifier_set: VerifierSet {
+            signers: {
+                "cosmwasm1jguu9vd3fty0cr949yawye8gj88n0rjvjtpxa7t93umqpn3j96mqr93mgz": Signer {
+                    address: Addr(
+                        "cosmwasm1jguu9vd3fty0cr949yawye8gj88n0rjvjtpxa7t93umqpn3j96mqr93mgz",
+                    ),
+                    weight: Uint128(
+                        1,
+                    ),
+                    pub_key: AleoSchnorr(
+                        HexBinary(616c656f31657432306c6b7a346634613834396d6d6e707a34363730677061656b7030333070726d363965796d616570386a7070676c7379736c687966396e),
+                    ),
+                },
+            },
+            threshold: Uint128(
+                1,
+            ),
+            created_at: 0,
+        },
+    },
+    poll_id: PollId(
+        Uint64(
+            100,
+        ),
+    ),
+    source_chain: ChainName(
+        "aleo-2",
+    ),
+    source_gateway_address: Program(
+        String(
+            "mygateway.aleo",
+        ),
+    ),
+    expires_at: 100,
+    confirmation_height: 15,
+    participants: [
+        TMAddress(
+            AccountId(
+                "axelar1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq87nk3s",
+            ),
+        ),
+        TMAddress(
+            AccountId(
+                "axelar1qyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpuxy7hs",
+            ),
+        ),
+        TMAddress(
+            AccountId(
+                "axelar1qgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszg9nw3w",
+            ),
+        ),
+        TMAddress(
+            AccountId(
+                "axelar1qvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrqvpsxqcrnayxhw",
+            ),
+        ),
+        TMAddress(
+            AccountId(
+                "axelar1qszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyz29mj8",
+            ),
+        ),
+    ],
+}

--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -253,7 +253,35 @@ where
                         event_processor_config.clone(),
                     )
                 }
-                handlers::config::Config::AleoVerifierSetVerifier {} => todo!(),
+                handlers::config::Config::AleoVerifierSetVerifier {
+                    cosmwasm_contract,
+                    chain,
+                    timeout,
+                    base_url,
+                    network,
+                    verifier_contract,
+                } => {
+                    let rest_client = reqwest::ClientBuilder::new()
+                        .connect_timeout(timeout.unwrap_or(DEFAULT_RPC_TIMEOUT))
+                        .timeout(timeout.unwrap_or(DEFAULT_RPC_TIMEOUT))
+                        .build()
+                        .change_context(Error::Connection)?;
+
+                    let client = aleo::http_client::Client::new(rest_client, base_url, network);
+
+                    self.create_handler_task(
+                        format!("{}-verifier-set-verifier", chain.name),
+                        handlers::aleo_verify_verifier_set::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract,
+                            chain.name,
+                            client,
+                            self.block_height_monitor.latest_block_height(),
+                            verifier_contract,
+                        ),
+                        event_processor_config.clone(),
+                    )
+                }
                 handlers::config::Config::EvmMsgVerifier {
                     chain,
                     cosmwasm_contract,

--- a/contracts/axelarnet-gateway/src/contract.rs
+++ b/contracts/axelarnet-gateway/src/contract.rs
@@ -1,7 +1,7 @@
 use axelar_core_std::nexus;
+use axelar_wasm_addresses::address;
 use axelar_wasm_std::error::ContractError;
 use axelar_wasm_std::{FnExt, IntoContractError};
-use axelar_wasm_addresses::address;
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{

--- a/contracts/axelarnet-gateway/src/contract/execute.rs
+++ b/contracts/axelarnet-gateway/src/contract/execute.rs
@@ -1,9 +1,9 @@
 use std::str::FromStr;
 
 use axelar_core_std::nexus;
+use axelar_wasm_addresses::address;
 use axelar_wasm_std::msg_id::HexTxHashAndEventIndex;
 use axelar_wasm_std::{FnExt, IntoContractError};
-use axelar_wasm_addresses::address;
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
     Addr, CosmosMsg, DepsMut, Event, HexBinary, MessageInfo, QuerierWrapper, Response, Storage,

--- a/contracts/coordinator/src/contract.rs
+++ b/contracts/coordinator/src/contract.rs
@@ -2,10 +2,9 @@ mod execute;
 mod migrations;
 mod query;
 
-use axelar_wasm_std::{permission_control, FnExt};
 use axelar_wasm_addresses::address;
 use axelar_wasm_addresses::address::validate_cosmwasm_address;
-
+use axelar_wasm_std::{permission_control, FnExt};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{

--- a/contracts/gateway/src/contract.rs
+++ b/contracts/gateway/src/contract.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 
+use axelar_wasm_addresses::address;
 use axelar_wasm_std::FnExt;
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
@@ -8,7 +9,6 @@ use cw2::VersionError;
 use error_stack::{report, ResultExt};
 use router_api::client::Router;
 use semver::Version;
-use axelar_wasm_addresses::address;
 
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use crate::state;

--- a/contracts/interchain-token-service/src/contract.rs
+++ b/contracts/interchain-token-service/src/contract.rs
@@ -1,8 +1,8 @@
 use std::fmt::Debug;
 
+use axelar_wasm_addresses::address;
 use axelar_wasm_std::error::ContractError;
 use axelar_wasm_std::{killswitch, permission_control, FnExt, IntoContractError};
-use axelar_wasm_addresses::address;
 use axelarnet_gateway::AxelarExecutableMsg;
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;

--- a/contracts/multisig-prover/src/contract.rs
+++ b/contracts/multisig-prover/src/contract.rs
@@ -170,6 +170,7 @@ mod tests {
     use crate::contract::execute::should_update_verifier_set;
     use crate::encoding::Encoder;
     use crate::msg::{ProofResponse, ProofStatus, VerifierSetResponse};
+    use crate::test::aleo_test_data;
     use crate::test::test_data::{self, TestOperator};
     use crate::test::test_utils::{
         mock_querier_handler, ADMIN, COORDINATOR_ADDRESS, GATEWAY_ADDRESS, GOVERNANCE,
@@ -212,6 +213,53 @@ mod tests {
         .unwrap();
 
         deps
+    }
+
+    pub fn aleo_setup_test_case() -> OwnedDeps<MockStorage, MockApi, MockQuerier, Empty> {
+        let mut deps = mock_dependencies();
+        let api = deps.api;
+
+        deps.querier.update_wasm(mock_querier_handler(
+            aleo_test_data::operators(),
+            VerificationStatus::SucceededOnSourceChain,
+        ));
+
+        instantiate(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&api.addr_make(ADMIN), &[]),
+            InstantiateMsg {
+                admin_address: api.addr_make(ADMIN).to_string(),
+                governance_address: api.addr_make(GOVERNANCE).to_string(),
+                gateway_address: api.addr_make(GATEWAY_ADDRESS).to_string(),
+                multisig_address: api.addr_make(MULTISIG_ADDRESS).to_string(),
+                coordinator_address: api.addr_make(COORDINATOR_ADDRESS).to_string(),
+                service_registry_address: api.addr_make(SERVICE_REGISTRY_ADDRESS).to_string(),
+                voting_verifier_address: api.addr_make(VOTING_VERIFIER_ADDRESS).to_string(),
+                signing_threshold: test_data::threshold(),
+                service_name: SERVICE_NAME.to_string(),
+                chain_name: "ganache-0".to_string(),
+                verifier_set_diff_threshold: 0,
+                encoder: Encoder::Aleo,
+                key_type: multisig::key::KeyType::AleoSchnorr,
+                domain_separator: [0; 32],
+            },
+        )
+        .unwrap();
+
+        deps
+    }
+
+    fn aleo_execute_update_verifier_set(
+        deps: DepsMut,
+    ) -> Result<Response, axelar_wasm_std::error::ContractError> {
+        let msg = ExecuteMsg::UpdateVerifierSet {};
+        execute(
+            deps,
+            mock_env(),
+            message_info(&MockApi::default().addr_make(ADMIN), &[]),
+            msg,
+        )
     }
 
     fn execute_update_verifier_set(
@@ -462,6 +510,28 @@ mod tests {
     }
 
     #[test]
+    fn aleo_test_update_verifier_set_fresh() {
+        let mut deps = aleo_setup_test_case();
+        let verifier_set = query_verifier_set(deps.as_ref());
+        assert!(verifier_set.is_ok());
+        assert!(verifier_set.unwrap().is_none());
+
+        let res = aleo_execute_update_verifier_set(deps.as_mut());
+
+        assert!(res.is_ok());
+
+        let verifier_set = query_verifier_set(deps.as_ref());
+        assert!(verifier_set.is_ok());
+
+        let verifier_set = verifier_set.unwrap().unwrap();
+
+        let expected_verifier_set =
+            test_operators_to_verifier_set(aleo_test_data::operators(), mock_env().block.height);
+
+        assert_eq!(verifier_set, expected_verifier_set.into());
+    }
+
+    #[test]
     fn test_update_verifier_set_from_non_admin_or_governance_should_fail() {
         let mut deps = setup_test_case();
         let api = deps.api;
@@ -511,7 +581,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "this should be enabled when the functionality of signers rotation is reset"]
     fn test_update_verifier_set_remove_one() {
         let mut deps = setup_test_case();
         let res = execute_update_verifier_set(deps.as_mut());
@@ -542,7 +611,36 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "this should be enabled when the functionality of signers rotation is reset"]
+    fn aleo_test_update_verifier_set_remove_one() {
+        let mut deps = aleo_setup_test_case();
+        let res = execute_update_verifier_set(deps.as_mut());
+
+        assert!(res.is_ok());
+
+        let mut new_verifier_set = aleo_test_data::operators();
+        new_verifier_set.pop();
+
+        deps.querier.update_wasm(mock_querier_handler(
+            new_verifier_set,
+            VerificationStatus::SucceededOnSourceChain,
+        ));
+
+        let res = execute_update_verifier_set(deps.as_mut());
+
+        assert!(res.is_ok());
+
+        let verifier_set = query_verifier_set(deps.as_ref());
+        assert!(verifier_set.is_ok());
+
+        let verifier_set = verifier_set.unwrap().unwrap();
+
+        let expected_verifier_set =
+            test_operators_to_verifier_set(aleo_test_data::operators(), mock_env().block.height);
+
+        assert_eq!(verifier_set, expected_verifier_set.into());
+    }
+
+    #[test]
     fn test_update_verifier_set_add_one() {
         let mut deps = setup_test_case();
 
@@ -577,7 +675,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "this should be enabled when the functionality of signers rotation is reset"]
     fn test_update_verifier_set_change_public_key() {
         let mut deps = setup_test_case();
         let res = execute_update_verifier_set(deps.as_mut());
@@ -612,7 +709,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "this should be enabled when the functionality of signers rotation is reset"]
     fn test_update_verifier_set_unchanged() {
         let mut deps = setup_test_case();
         let res = execute_update_verifier_set(deps.as_mut());
@@ -630,7 +726,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "this should be enabled when the functionality of signers rotation is reset"]
     fn test_confirm_verifier_set_unconfirmed() {
         let mut deps = setup_test_case();
         let api = deps.api;
@@ -658,7 +753,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "this should be enabled when the functionality of signers rotation is reset"]
     fn test_confirm_verifier_set_wrong_set() {
         let mut deps = setup_test_case();
         let api = deps.api;
@@ -832,7 +926,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "this should be enabled when the functionality of signers rotation is reset"]
     fn update_signing_threshold_should_change_future_threshold() {
         let mut deps = setup_test_case();
         let api = deps.api;
@@ -856,7 +949,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "this should be enabled when the functionality of signers rotation is reset"]
     fn should_confirm_new_threshold() {
         let mut deps = setup_test_case();
         let api = deps.api;

--- a/contracts/multisig-prover/src/contract.rs
+++ b/contracts/multisig-prover/src/contract.rs
@@ -78,8 +78,8 @@ pub fn execute(
 ) -> Result<Response, axelar_wasm_std::error::ContractError> {
     match msg.ensure_permissions(deps.storage, &info.sender)? {
         ExecuteMsg::ConstructProof(message_ids) => Ok(execute::construct_proof(deps, message_ids)?),
-        ExecuteMsg::UpdateVerifierSet {} => Ok(execute::update_verifier_set(deps, env)?),
-        ExecuteMsg::ConfirmVerifierSet {} => Ok(execute::confirm_verifier_set(deps, info.sender)?),
+        ExecuteMsg::UpdateVerifierSet => Ok(execute::update_verifier_set(deps, env)?),
+        ExecuteMsg::ConfirmVerifierSet => Ok(execute::confirm_verifier_set(deps, info.sender)?),
         ExecuteMsg::UpdateSigningThreshold {
             new_signing_threshold,
         } => Ok(execute::update_signing_threshold(
@@ -115,8 +115,8 @@ pub fn query(
         QueryMsg::Proof {
             multisig_session_id,
         } => to_json_binary(&query::proof(deps, multisig_session_id)?),
-        QueryMsg::CurrentVerifierSet {} => to_json_binary(&query::current_verifier_set(deps)?),
-        QueryMsg::NextVerifierSet {} => to_json_binary(&query::next_verifier_set(deps)?),
+        QueryMsg::CurrentVerifierSet => to_json_binary(&query::current_verifier_set(deps)?),
+        QueryMsg::NextVerifierSet => to_json_binary(&query::next_verifier_set(deps)?),
     }
     .change_context(ContractError::SerializeResponse)
     .map_err(axelar_wasm_std::error::ContractError::from)

--- a/contracts/multisig-prover/src/contract/execute.rs
+++ b/contracts/multisig-prover/src/contract/execute.rs
@@ -69,7 +69,8 @@ pub fn construct_proof(
 
     // This is not needed because we know that we will always use the sig_verifier
     // It is placed here because is needed to pass the unit tests
-    // TODO: make it in a more generic way
+    // To be handle approbriately in the future, the sig verifier should be configured in contract
+    // and it should be passed as a parameter to the contract initialized
     let sig_verifier = (config.chain_name
         == ChainName::from_str("aleo-2").map_err(|_| ContractError::Proof)?)
     .then(|| "axelar1rv940hhxe3288j42zazt7c7fmql4udsgy9cjzmeq646gt7gl02hq54seyr".to_string());

--- a/contracts/multisig-prover/src/contract/execute.rs
+++ b/contracts/multisig-prover/src/contract/execute.rs
@@ -1,18 +1,13 @@
-use std::collections::HashSet;
-#[cfg(test)] // This should be enabled when the functionality of signers rotation is reset
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
+use std::str::FromStr;
 
+use axelar_wasm_addresses::address;
 use axelar_wasm_std::permission_control::Permission;
 use axelar_wasm_std::snapshot::{Participant, Snapshot};
-use axelar_wasm_std::{
-    nonempty, permission_control, FnExt, MajorityThreshold, VerificationStatus,
-};
-use axelar_wasm_addresses::address;
+use axelar_wasm_std::{nonempty, permission_control, FnExt, MajorityThreshold, VerificationStatus};
 use cosmwasm_std::{wasm_execute, Addr, DepsMut, Env, QuerierWrapper, Response, Storage, SubMsg};
 use error_stack::{report, Result, ResultExt};
-#[cfg(test)] // This should be enabled when the functionality of signers rotation is reset
 use itertools::Itertools;
-#[cfg(test)] // This should be enabled when the functionality of signers rotation is reset
 use multisig::msg::Signer;
 use multisig::verifier_set::VerifierSet;
 use router_api::{ChainName, CrossChainId, Message};
@@ -68,18 +63,22 @@ pub fn construct_proof(
         .map_err(ContractError::from)?
         .ok_or(ContractError::NoVerifierSet)?;
 
-    let digest: Vec<u8> = config
+    let digest = config
         .encoder
-        .digest(&config.domain_separator, &verifier_set, &payload)?
-        .into();
+        .digest(&config.domain_separator, &verifier_set, &payload)?;
+
+    // This is not needed because we know that we will always use the sig_verifier
+    // It is placed here because is needed to pass the unit tests
+    // TODO: make it in a more generic way
+    let sig_verifier = (config.chain_name
+        == ChainName::from_str("aleo-2").map_err(|_| ContractError::Proof)?)
+    .then(|| "axelar1rv940hhxe3288j42zazt7c7fmql4udsgy9cjzmeq646gt7gl02hq54seyr".to_string());
 
     let start_sig_msg = multisig::msg::ExecuteMsg::StartSigningSession {
         verifier_set_id: verifier_set.id(),
         msg: digest.into(),
         chain_name: config.chain_name,
-        sig_verifier: Some(
-            "axelar1rv940hhxe3288j42zazt7c7fmql4udsgy9cjzmeq646gt7gl02hq54seyr".to_string(),
-        ),
+        sig_verifier,
     };
 
     let wasm_msg =
@@ -174,7 +173,6 @@ fn make_verifier_set(
     ))
 }
 
-#[cfg(test)] // This should be enabled when the functionality of signers rotation is reset
 fn next_verifier_set(
     deps: &DepsMut,
     env: &Env,
@@ -208,7 +206,6 @@ fn next_verifier_set(
     }
 }
 
-#[cfg(test)] // This should be enabled when the functionality of signers rotation is reset
 fn save_next_verifier_set(
     storage: &mut dyn Storage,
     new_verifier_set: &VerifierSet,
@@ -227,7 +224,6 @@ pub fn update_verifier_set(
     deps: DepsMut,
     env: Env,
 ) -> error_stack::Result<Response, ContractError> {
-    // TODO: restore signers rotation
     let config = CONFIG.load(deps.storage).map_err(ContractError::from)?;
 
     let coordinator: coordinator::Client =
@@ -236,29 +232,67 @@ pub fn update_verifier_set(
     let multisig: multisig::Client =
         client::ContractClient::new(deps.querier, &config.multisig).into();
 
-    let new_verifier_set = make_verifier_set(&deps, &env, &config)?;
-    CURRENT_VERIFIER_SET
-        .save(deps.storage, &new_verifier_set)
+    let cur_verifier_set = CURRENT_VERIFIER_SET
+        .may_load(deps.storage)
         .map_err(ContractError::from)?;
 
-    Ok(Response::new()
-        .add_message(multisig.register_verifier_set(new_verifier_set.clone()))
-        .add_message(
-            coordinator.set_active_verifiers(
-                new_verifier_set
-                    .signers
-                    .values()
-                    .map(|signer| signer.address.to_string())
-                    .collect::<HashSet<String>>(),
-            ),
-        ))
-}
+    match cur_verifier_set {
+        None => {
+            // if no verifier set, just store it and return
+            let new_verifier_set = make_verifier_set(&deps, &env, &config)?;
+            CURRENT_VERIFIER_SET
+                .save(deps.storage, &new_verifier_set)
+                .map_err(ContractError::from)?;
 
-#[cfg(test)] // This should be enabled when the functionality of signers rotation is reset
-pub fn clean_verifier_set(deps: DepsMut) -> error_stack::Result<Response, ContractError> {
-    CURRENT_VERIFIER_SET.remove(deps.storage);
+            Ok(Response::new()
+                .add_message(multisig.register_verifier_set(new_verifier_set.clone()))
+                .add_message(
+                    coordinator.set_active_verifiers(
+                        new_verifier_set
+                            .signers
+                            .values()
+                            .map(|signer| signer.address.to_string())
+                            .collect::<HashSet<String>>(),
+                    ),
+                ))
+        }
+        Some(cur_verifier_set) => {
+            let new_verifier_set = next_verifier_set(&deps, &env, &config)?
+                .ok_or(ContractError::VerifierSetUnchanged)?;
 
-    Ok(Response::new())
+            save_next_verifier_set(deps.storage, &new_verifier_set)?;
+
+            let payload = Payload::VerifierSet(new_verifier_set.clone());
+            let payload_id = payload.id();
+            PAYLOAD
+                .save(deps.storage, &payload_id, &payload)
+                .map_err(ContractError::from)?;
+            REPLY_TRACKER
+                .save(deps.storage, &payload_id)
+                .map_err(ContractError::from)?;
+
+            let digest =
+                config
+                    .encoder
+                    .digest(&config.domain_separator, &cur_verifier_set, &payload)?;
+
+            let verifier_union_set = all_active_verifiers(deps.storage)?;
+
+            Ok(Response::new()
+                .add_submessage(SubMsg::reply_on_success(
+                    multisig.start_signing_session(
+                        cur_verifier_set.id(),
+                        digest.into(),
+                        config.chain_name,
+                        None,
+                    ),
+                    START_MULTISIG_REPLY_ID,
+                ))
+                .add_message(coordinator.set_active_verifiers(
+                    verifier_union_set.iter().map(|v| v.to_string()).collect(),
+                )))
+        }
+    }
 }
 
 fn ensure_verifier_set_verification(
@@ -335,7 +369,6 @@ pub fn all_active_verifiers(storage: &mut dyn Storage) -> Result<HashSet<String>
         .then(Ok)
 }
 
-#[cfg(test)] // This should be enabled when the functionality of signers rotation is reset
 pub fn should_update_verifier_set(
     new_verifiers: &VerifierSet,
     cur_verifiers: &VerifierSet,
@@ -346,7 +379,6 @@ pub fn should_update_verifier_set(
             > max_diff
 }
 
-#[cfg(test)] // This should be enabled when the functionality of signers rotation is reset
 fn signers_symetric_difference_count(
     s1: &BTreeMap<String, Signer>,
     s2: &BTreeMap<String, Signer>,
@@ -354,14 +386,12 @@ fn signers_symetric_difference_count(
     signers_difference_count(s1, s2).saturating_add(signers_difference_count(s2, s1))
 }
 
-#[cfg(test)] // This should be enabled when the functionality of signers rotation is reset
 fn signers_difference_count(s1: &BTreeMap<String, Signer>, s2: &BTreeMap<String, Signer>) -> usize {
     s1.values().filter(|v| !s2.values().contains(v)).count()
 }
 
 // Returns true if there is a different verifier set pending for confirmation, false if there is no
 // verifier set pending or if the pending set is the same
-#[cfg(test)] // This should be enabled when the functionality of signers rotation is reset
 fn different_set_in_progress(storage: &dyn Storage, new_verifier_set: &VerifierSet) -> bool {
     if let Ok(Some(next_verifier_set)) = NEXT_VERIFIER_SET.may_load(storage) {
         return next_verifier_set != *new_verifier_set;

--- a/contracts/multisig-prover/src/contract/execute.rs
+++ b/contracts/multisig-prover/src/contract/execute.rs
@@ -71,9 +71,10 @@ pub fn construct_proof(
     // It is placed here because is needed to pass the unit tests
     // To be handle approbriately in the future, the sig verifier should be configured in contract
     // and it should be passed as a parameter to the contract initialized
+    const MULTISIG_ALEO: &str = "axelar1rv940hhxe3288j42zazt7c7fmql4udsgy9cjzmeq646gt7gl02hq54seyr";
     let sig_verifier = (config.chain_name
         == ChainName::from_str("aleo-2").map_err(|_| ContractError::Proof)?)
-    .then(|| "axelar1rv940hhxe3288j42zazt7c7fmql4udsgy9cjzmeq646gt7gl02hq54seyr".to_string());
+    .then(|| MULTISIG_ALEO.to_string());
 
     let start_sig_msg = multisig::msg::ExecuteMsg::StartSigningSession {
         verifier_set_id: verifier_set.id(),

--- a/contracts/multisig-prover/src/encoding/aleo.rs
+++ b/contracts/multisig-prover/src/encoding/aleo.rs
@@ -34,7 +34,7 @@ pub fn payload_digest<N: Network>(
             group.bhp_string::<N>()
         }
         // TODO: make the WeightedSigners configurable from outside
-        Payload::VerifierSet(verifier_set) => WeightedSigners::<2, 2>::try_from(verifier_set)
+        Payload::VerifierSet(verifier_set) => WeightedSigners::try_from(verifier_set)
             .change_context(ContractError::InvalidVerifierSet)?
             .bhp_string::<N>(),
     }
@@ -95,7 +95,7 @@ pub fn encode_execute_data(
                 .change_context(ContractError::Proof)?;
 
             let execute_data =
-                aleo_gateway::ExecuteDataVerifierSet::<2, 2>::new(proof, verifier_set.clone())
+                aleo_gateway::ExecuteDataVerifierSet::new(proof, verifier_set.clone())
                     .to_aleo_string()
                     .map_err(|e| ContractError::AleoError(e.to_string()))?;
 

--- a/contracts/multisig-prover/src/encoding/aleo.rs
+++ b/contracts/multisig-prover/src/encoding/aleo.rs
@@ -144,6 +144,8 @@ mod tests {
     use tofn::aleo_schnorr::keygen;
     use tofn::sdk::api::SecretRecoveryKey;
 
+    // The bellow comments represent the public and private keys of the signer.
+    // They are useful for manually verifying the function.
     // APrivateKey1zkpFMDCJZbRdcBcjnqjRqCrhcWFf4L9FRRSgbLpS6D47Cmo
     // aleo1v7mmux8wkue8zmuxdfks03rh85qchfmms9fkpflgs4dt87n4jy9s8nzfss
     fn aleo_sig(digest: [u8; 32]) -> SignerWithSig {

--- a/contracts/multisig-prover/src/encoding/aleo.rs
+++ b/contracts/multisig-prover/src/encoding/aleo.rs
@@ -97,11 +97,9 @@ pub fn encode_execute_data(
                 .change_context(ContractError::Proof)?;
 
             let execute_data =
-                aleo_gateway::ExecuteDataVerifierSet::<2, 2>::new(proof, verifier_set.clone());
-
-            let execute_data = execute_data
-                .to_aleo_string()
-                .map_err(|e| ContractError::AleoError(e.to_string()))?;
+                aleo_gateway::ExecuteDataVerifierSet::<2, 2>::new(proof, verifier_set.clone())
+                    .to_aleo_string()
+                    .map_err(|e| ContractError::AleoError(e.to_string()))?;
 
             Ok(HexBinary::from(execute_data.as_bytes()))
         }

--- a/contracts/multisig-prover/src/encoding/aleo.rs
+++ b/contracts/multisig-prover/src/encoding/aleo.rs
@@ -84,9 +84,7 @@ pub fn encode_execute_data(
             let proof = aleo_gateway::Proof::new(verifier_set.clone(), signatures)
                 .change_context(ContractError::Proof)?;
 
-            let execute_data = aleo_gateway::ExecuteDataMessages::new(proof, gmp_messages);
-
-            let execute_data = execute_data
+            let execute_data = aleo_gateway::ExecuteDataMessages::new(proof, gmp_messages)
                 .to_aleo_string()
                 .map_err(|e| ContractError::AleoError(e.to_string()))?;
 

--- a/contracts/multisig-prover/src/test/aleo_test_data.rs
+++ b/contracts/multisig-prover/src/test/aleo_test_data.rs
@@ -1,0 +1,222 @@
+use std::collections::BTreeMap;
+
+use axelar_wasm_std::{nonempty, MajorityThreshold, Participant, Threshold};
+use cosmwasm_std::testing::MockApi;
+use cosmwasm_std::{Addr, HexBinary, Uint128, Uint64};
+use multisig::key::KeyType;
+use multisig::msg::Signer;
+use multisig::verifier_set::VerifierSet;
+use router_api::{CrossChainId, Message};
+
+use super::test_data::TestOperator;
+
+pub fn new_verifier_set() -> VerifierSet {
+    let signers = vec![
+        Signer {
+            address: Addr::unchecked("axelarvaloper1x86a8prx97ekkqej2x636utrdu23y8wupp9gk5"),
+            weight: Uint128::from(10u128),
+            pub_key: multisig::key::PublicKey::AleoSchnorr(
+                HexBinary::from_hex(
+                    hex::encode(
+                        "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px"
+                            .to_string(),
+                    )
+                    .as_str(),
+                )
+                .unwrap(),
+            ),
+        },
+        Signer {
+            address: Addr::unchecked("axelarvaloper1ff675m593vve8yh82lzhdnqfpu7m23cxstr6h4"),
+            weight: Uint128::from(10u128),
+            pub_key: multisig::key::PublicKey::AleoSchnorr(
+                HexBinary::from_hex(
+                    hex::encode(
+                        "aleo1s3ws5tra87fjycnjrwsjcrnw2qxr8jfqqdugnf0xzqqw29q9m5pqem2u4t"
+                            .to_string(),
+                    )
+                    .as_str(),
+                )
+                .unwrap(),
+            ),
+        },
+        Signer {
+            address: Addr::unchecked("axelarvaloper12cwre2gdhyytc3p97z9autzg27hmu4gfzz4rxc"),
+            weight: Uint128::from(10u128),
+            pub_key: multisig::key::PublicKey::AleoSchnorr(
+                HexBinary::from_hex(
+                    hex::encode(
+                        "aleo1ashyu96tjwe63u0gtnnv8z5lhapdu4l5pjsl2kha7fv7hvz2eqxs5dz0rg"
+                            .to_string(),
+                    )
+                    .as_str(),
+                )
+                .unwrap(),
+            ),
+        },
+        Signer {
+            address: Addr::unchecked("axelarvaloper1vs9rdplntrf7ceqdkznjmanrr59qcpjq6le0yw"),
+            weight: Uint128::from(10u128),
+            pub_key: multisig::key::PublicKey::AleoSchnorr(
+                HexBinary::from_hex(
+                    hex::encode("aleo12ux3gdauck0v60westgcpqj7v8rrcr3v346e4jtq04q7kkt22czsh808v2")
+                        .as_str(),
+                )
+                .unwrap(),
+            ),
+        },
+    ];
+
+    let mut btree_signers = BTreeMap::new();
+    for signer in signers {
+        btree_signers.insert(signer.address.clone().to_string(), signer);
+    }
+
+    VerifierSet {
+        signers: btree_signers,
+        threshold: Uint128::from(30u128),
+        created_at: 1,
+    }
+}
+
+pub fn messages() -> Vec<Message> {
+    vec![Message {
+        cc_id: CrossChainId::new(
+            "ganache-1",
+            "0xff822c88807859ff226b58e24f24974a70f04b9442501ae38fd665b3c68f3834-0",
+        )
+        .unwrap(),
+        source_address: "0x52444f1835Adc02086c37Cb226561605e2E1699b"
+            .parse()
+            .unwrap(),
+        destination_address: "0xA4f10f76B86E01B98daF66A3d02a65e14adb0767"
+            .parse()
+            .unwrap(),
+        destination_chain: "ganache-0".parse().unwrap(),
+        payload_hash: HexBinary::from_hex(
+            "8c3685dc41c2eca11426f8035742fb97ea9f14931152670a5703f18fe8b392f0",
+        )
+        .unwrap()
+        .to_array::<32>()
+        .unwrap(),
+    }]
+}
+
+pub fn approve_messages_calldata() -> HexBinary {
+    HexBinary::from_hex("64f1d85a000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000002400000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000000000000000000000000000000000000000160000000000000000000000000a4f10f76b86e01b98daf66a3d02a65e14adb07678c3685dc41c2eca11426f8035742fb97ea9f14931152670a5703f18fe8b392f0000000000000000000000000000000000000000000000000000000000000000967616e616368652d31000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000443078666638323263383838303738353966663232366235386532346632343937346137306630346239343432353031616533386664363635623363363866333833342d3000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002a307835323434346631383335416463303230383663333743623232363536313630356532453136393962000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000050000000000000000000000004ef5c8d81b6417fa80c320b5fc1d3900506dff5400000000000000000000000000000000000000000000000000000000000000010000000000000000000000006c51eec96bf0a8ec799cdd0bbcb4512f8334afe800000000000000000000000000000000000000000000000000000000000000010000000000000000000000007aeb4eebf1e8dcde3016d4e1dca52b4538cf7aaf0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000c5b95c99d883c3204cfc2e73669ce3aa7437f4a60000000000000000000000000000000000000000000000000000000000000001000000000000000000000000ffffde829096dfe8b833997e939865ff57422ea900000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000000000000000000000000000000000000000160000000000000000000000000000000000000000000000000000000000000004172b242d7247fc31d14ce82b32f3ea911808f6f600f362150f9904c974315942927c25f9388cecdbbb0b3723164eea92206775870cd28e1ffd8f1cb9655fb3c4a1b00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004186909155a6ba27f173edf15d283da6a0019fb6afe6b223ca68530464813f468f356e70788faf6d1d9ff7bfcfd9021b560d72408bef4c86c66e3a94b9dee0a34a1b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000419b2d986652fdebe67554f1b33ae6161b205ea84e0dacb07ffde0889791bcab2e5be3b8229eae01f2c22805c87f15cb7f9642e9cba951489edcac5d12ace399391b00000000000000000000000000000000000000000000000000000000000000").unwrap()
+}
+
+pub fn threshold() -> MajorityThreshold {
+    let numerator: nonempty::Uint64 = Uint64::from(2u8).try_into().unwrap();
+    let denominator: nonempty::Uint64 = Uint64::from(3u8).try_into().unwrap();
+    Threshold::try_from((numerator, denominator))
+        .unwrap()
+        .try_into()
+        .unwrap()
+}
+
+pub fn operators() -> Vec<TestOperator> {
+    [
+        (
+            "axelar1up3vvhxg4swh2lfeh8n84dat86j6hmgz20d6d3",
+            hex::encode(
+                        "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px"
+                            .to_string(),
+                    )
+                    .as_str(),
+            "6C51eec96bf0a8ec799cdD0Bbcb4512f8334Afe8",
+            1u128,
+            None,
+        ),
+        (
+            "axelar10ad5vqhuw2jgp8x6hf59qjjejlna2nh4sfsklc",
+            hex::encode(
+                        "aleo1s3ws5tra87fjycnjrwsjcrnw2qxr8jfqqdugnf0xzqqw29q9m5pqem2u4t"
+                            .to_string(),
+                    )
+                    .as_str(),
+            "7aeB4EEbf1E8DCDE3016d4e1dcA52B4538Cf7aAf",
+            1u128,
+            Some("72b242d7247fc31d14ce82b32f3ea911808f6f600f362150f9904c974315942927c25f9388cecdbbb0b3723164eea92206775870cd28e1ffd8f1cb9655fb3c4a1b"),
+        ),
+        (
+            "axelar14g0tmk5ldxxdqtl0utl69ck43cpcvd0ay4lfyt",
+            hex::encode(
+                        "aleo1ashyu96tjwe63u0gtnnv8z5lhapdu4l5pjsl2kha7fv7hvz2eqxs5dz0rg"
+                            .to_string(),
+                    )
+                    .as_str(),
+            "c5b95c99D883c3204CFc2E73669CE3aa7437f4A6",
+            1u128,
+            Some("86909155a6ba27f173edf15d283da6a0019fb6afe6b223ca68530464813f468f356e70788faf6d1d9ff7bfcfd9021b560d72408bef4c86c66e3a94b9dee0a34a1b"),
+        ),
+        (
+            "axelar1gwd8wd3qkapk8pnwdu4cchah2sjjws6lx694r6",
+            hex::encode(
+                        "aleo12ux3gdauck0v60westgcpqj7v8rrcr3v346e4jtq04q7kkt22czsh808v2"
+                            .to_string(),
+                    )
+                    .as_str(),
+            "ffFfDe829096DfE8b833997E939865FF57422Ea9",
+            1u128,
+            Some("9b2d986652fdebe67554f1b33ae6161b205ea84e0dacb07ffde0889791bcab2e5be3b8229eae01f2c22805c87f15cb7f9642e9cba951489edcac5d12ace399391b"),
+        ),
+    ]
+        .into_iter()
+        .map(
+            |(address, pub_key, operator, weight, signature)| TestOperator {
+                address: Addr::unchecked(address),
+                pub_key: (KeyType::AleoSchnorr, HexBinary::from_hex(pub_key).unwrap())
+                    .try_into()
+                    .unwrap(),
+                operator: HexBinary::from_hex(operator).unwrap(),
+                weight: Uint128::from(weight),
+                signature: signature.map(|sig| {
+                    (KeyType::AleoSchnorr, HexBinary::from_hex(sig).unwrap())
+                        .try_into()
+                        .unwrap()
+                }),
+            },
+        )
+        .collect()
+}
+
+pub fn quorum() -> Uint128 {
+    3u128.into()
+}
+
+// Generate a verifier set matches axelar-gmp-sdk-solidity repo test data
+pub fn curr_verifier_set() -> VerifierSet {
+    let pub_keys = vec![
+        "038318535b54105d4a7aae60c08fc45f9687181b4fdfc625bd1a753fa7397fed75",
+        "02ba5734d8f7091719471e7f7ed6b9df170dc70cc661ca05e688601ad984f068b0",
+        "039d9031e97dd78ff8c15aa86939de9b1e791066a0224e331bc962a2099a7b1f04",
+        "0220b871f3ced029e14472ec4ebc3c0448164942b123aa6af91a3386c1c403e0eb",
+        "03bf6ee64a8d2fdc551ec8bb9ef862ef6b4bcb1805cdc520c3aa5866c0575fd3b5",
+    ];
+
+    verifier_set_from_pub_keys(pub_keys)
+}
+
+pub fn verifier_set_from_pub_keys(pub_keys: Vec<&str>) -> VerifierSet {
+    let participants: Vec<(_, _)> = (0..pub_keys.len())
+        .map(|i| {
+            (
+                Participant {
+                    address: MockApi::default().addr_make(format!("verifier{i}").as_str()),
+                    weight: nonempty::Uint128::one(),
+                },
+                multisig::key::PublicKey::AleoSchnorr(HexBinary::from_hex(pub_keys[i]).unwrap()),
+            )
+        })
+        .collect();
+    VerifierSet::new(participants, Uint128::from(3u128), 1)
+}
+
+// Domain separator matches axelar-gmp-sdk-solidity repo test data
+pub fn domain_separator() -> [u8; 32] {
+    HexBinary::from_hex("3593643a7d7e917a099eef6c52d1420bb4f33eb074b16439556de5984791262b")
+        .unwrap()
+        .to_array()
+        .unwrap()
+}

--- a/contracts/multisig-prover/src/test/mod.rs
+++ b/contracts/multisig-prover/src/test/mod.rs
@@ -1,4 +1,6 @@
 #[cfg(test)]
+pub mod aleo_test_data;
+#[cfg(test)]
 pub mod test_data;
 #[cfg(test)]
 pub mod test_utils;

--- a/contracts/multisig/Cargo.toml
+++ b/contracts/multisig/Cargo.toml
@@ -65,6 +65,7 @@ thiserror = { workspace = true }
 
 multisig-aleo = { path = "../multisig-aleo" }
 snarkvm-cosmwasm = { workspace = true }
+rand_chacha = "0.3"
 
 [dev-dependencies]
 curve25519-dalek = "4.1.3"
@@ -72,7 +73,6 @@ cw-multi-test = { workspace = true }
 ed25519-dalek = { workspace = true, features = ["digest", "rand_core"] }
 goldie = { workspace = true }
 hex = "0.4"
-rand_chacha = "0.3"
 
 [lints]
 workspace = true

--- a/contracts/multisig/src/key.rs
+++ b/contracts/multisig/src/key.rs
@@ -160,6 +160,16 @@ where
     Ok(pk)
 }
 
+impl PublicKey {
+    pub fn inner(&self) -> &HexBinary {
+        match &self {
+            PublicKey::Ecdsa(hex_binary)
+            | PublicKey::Ed25519(hex_binary)
+            | PublicKey::AleoSchnorr(hex_binary) => hex_binary,
+        }
+    }
+}
+
 pub trait KeyTyped {
     fn matches_type<T>(&self, other: &T) -> bool
     where

--- a/contracts/multisig/src/key.rs
+++ b/contracts/multisig/src/key.rs
@@ -160,8 +160,9 @@ where
     Ok(pk)
 }
 
-impl PublicKey {
-    pub fn inner(&self) -> &HexBinary {
+impl std::ops::Deref for PublicKey {
+    type Target = HexBinary;
+    fn deref(&self) -> &Self::Target {
         match &self {
             PublicKey::Ecdsa(hex_binary)
             | PublicKey::Ed25519(hex_binary)

--- a/contracts/multisig/src/test/common.rs
+++ b/contracts/multisig/src/test/common.rs
@@ -131,7 +131,6 @@ pub mod ed25519_test_data {
     }
 }
 
-#[cfg(test)]
 pub mod aleo_schnorr_test_data {
     // APrivateKey1zkpEjXSofaQtApqm33wYLmHiGNLb99VZqLeRW19xWKHQWZW
     // AViewKey1gmHkeDm2NEvJSWUTRf9SCwaEU6uSjdYnaSXa7dsn67QW

--- a/contracts/rewards/src/state.rs
+++ b/contracts/rewards/src/state.rs
@@ -522,8 +522,8 @@ mod test {
         };
         assert_err_contains!(
             PoolId::try_from_msg_pool_id(&api, pool_id),
-            axelar_wasm_std::address::Error,
-            axelar_wasm_std::address::Error::InvalidAddress(_)
+            axelar_wasm_addresses::address::Error,
+            axelar_wasm_addresses::address::Error::InvalidAddress(_)
         );
     }
 

--- a/contracts/rewards/src/state.rs
+++ b/contracts/rewards/src/state.rs
@@ -62,7 +62,10 @@ impl PoolId {
     ) -> Result<Self, axelar_wasm_addresses::address::Error> {
         Ok(Self::new(
             pool_id.chain_name,
-            axelar_wasm_addresses::address::validate_cosmwasm_address(api, pool_id.contract.as_str())?,
+            axelar_wasm_addresses::address::validate_cosmwasm_address(
+                api,
+                pool_id.contract.as_str(),
+            )?,
         ))
     }
 }

--- a/contracts/router/src/contract.rs
+++ b/contracts/router/src/contract.rs
@@ -1,5 +1,5 @@
-use axelar_wasm_std::{killswitch, permission_control, FnExt};
 use axelar_wasm_addresses::address;
+use axelar_wasm_std::{killswitch, permission_control, FnExt};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{

--- a/contracts/service-registry/src/contract.rs
+++ b/contracts/service-registry/src/contract.rs
@@ -1,5 +1,5 @@
-use axelar_wasm_std::{permission_control, FnExt};
 use axelar_wasm_addresses::address;
+use axelar_wasm_std::{permission_control, FnExt};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{

--- a/integration-tests/tests/bond_unbond.rs
+++ b/integration-tests/tests/bond_unbond.rs
@@ -34,7 +34,6 @@ fn verifier_should_not_unbond_while_in_active_set() {
 }
 
 #[test]
-#[ignore = "This should be enabled when the functionality of signers rotation is reset"]
 fn claim_stake_after_rotation_success() {
     let chains: Vec<router_api::ChainName> = vec![
         "Ethereum".try_into().unwrap(),
@@ -149,7 +148,6 @@ fn claim_stake_when_in_all_active_verifier_sets_fails() {
 }
 
 #[test]
-#[ignore = "This should be enabled when the functionality of signers rotation is reset"]
 fn claim_stake_when_in_some_active_verifier_sets_fails() {
     let chains: Vec<router_api::ChainName> = vec![
         "Ethereum".try_into().unwrap(),
@@ -244,7 +242,6 @@ fn claim_stake_after_deregistering_before_rotation_fails() {
 }
 
 #[test]
-#[ignore = "this should be enabled when the functionality of signers rotation is reset"]
 fn claim_stake_when_jailed_fails() {
     let chains: Vec<router_api::ChainName> = vec![
         "Ethereum".try_into().unwrap(),

--- a/integration-tests/tests/message_routing.rs
+++ b/integration-tests/tests/message_routing.rs
@@ -10,7 +10,6 @@ pub mod test_utils;
 /// gateway, votes on the poll, routes the message to the outgoing gateway, triggers signing at the prover
 /// and signs via multisig. Also tests that rewards are distributed as expected for voting and signing.
 #[test]
-#[ignore = "This should be enabled when the functionality of signers rotation is reset"]
 fn single_message_can_be_verified_and_routed_and_proven_and_rewards_are_distributed() {
     let test_utils::TestCase {
         mut protocol,

--- a/integration-tests/tests/update_worker_set.rs
+++ b/integration-tests/tests/update_worker_set.rs
@@ -8,7 +8,6 @@ use service_registry_api::msg::QueryMsg as ServiceRegistryQueryMsg;
 pub mod test_utils;
 
 #[test]
-#[ignore = "This should be enabled when the functionality of signers rotation is reset"]
 fn verifier_set_can_be_initialized_and_then_manually_updated() {
     let chains: Vec<router_api::ChainName> = vec![
         "Ethereum".try_into().unwrap(),
@@ -106,7 +105,6 @@ fn verifier_set_can_be_initialized_and_then_manually_updated() {
 }
 
 #[test]
-#[ignore = "This should be enabled when the functionality of signers rotation is reset"]
 fn verifier_set_cannot_be_updated_again_while_pending_verifier_is_not_yet_confirmed() {
     let chains = vec![
         "Ethereum".try_into().unwrap(),
@@ -227,7 +225,6 @@ fn verifier_set_cannot_be_updated_again_while_pending_verifier_is_not_yet_confir
 }
 
 #[test]
-#[ignore = "This should be enabled when the functionality of signers rotation is reset"]
 fn verifier_set_update_can_be_resigned() {
     let chains = vec![
         "Ethereum".try_into().unwrap(),
@@ -323,7 +320,6 @@ fn verifier_set_update_can_be_resigned() {
 }
 
 #[test]
-#[ignore = "This should be enabled when the functionality of signers rotation is reset"]
 fn governance_should_confirm_new_verifier_set_without_verification() {
     let chains: Vec<router_api::ChainName> = vec!["Ethereum".try_into().unwrap()];
     let test_utils::TestCase {
@@ -373,7 +369,6 @@ fn governance_should_confirm_new_verifier_set_without_verification() {
 }
 
 #[test]
-#[ignore = "this should be enabled when the functionality of signers rotation is reset"]
 fn rotate_signers_should_filter_out_signers_without_pubkey() {
     let test_utils::TestCase {
         mut protocol,

--- a/packages/aleo-gateway/Cargo.toml
+++ b/packages/aleo-gateway/Cargo.toml
@@ -13,6 +13,8 @@ thiserror = { workspace = true }
 cosmwasm-std = { workspace = true }
 hex = { workspace = true }
 multisig = { workspace = true, features = ["library"] }
+serde = { version = "1.0.147", features = ["derive"] }
+serde_with = "3.12.0"
 snarkvm-cosmwasm = { workspace = true, features = ["program", "network"]}
 
 [dev-dependencies]

--- a/packages/aleo-gateway/src/execute_data.rs
+++ b/packages/aleo-gateway/src/execute_data.rs
@@ -27,14 +27,14 @@ impl AleoValue for ExecuteDataMessages {
     }
 }
 
-pub struct ExecuteDataVerifierSet<const GROUP_SIZE: usize = 2, const GROUPS: usize = 2> {
+pub struct ExecuteDataVerifierSet {
     proof: Proof,
-    payload: WeightedSigners<GROUP_SIZE, GROUPS>,
+    payload: WeightedSigners,
 }
 
-impl<const GROUP_SIZE: usize, const GROUPS: usize> ExecuteDataVerifierSet<GROUP_SIZE, GROUPS> {
-    pub fn new(proof: Proof, payload: VerifierSet) -> ExecuteDataVerifierSet<GROUP_SIZE, GROUPS> {
-        let payload = WeightedSigners::<GROUP_SIZE, GROUPS>::try_from(&payload).unwrap();
+impl ExecuteDataVerifierSet {
+    pub fn new(proof: Proof, payload: VerifierSet) -> ExecuteDataVerifierSet {
+        let payload = WeightedSigners::try_from(&payload).unwrap();
         ExecuteDataVerifierSet { proof, payload }
     }
 }

--- a/packages/aleo-gateway/src/execute_data.rs
+++ b/packages/aleo-gateway/src/execute_data.rs
@@ -1,23 +1,48 @@
 use error_stack::Report;
+use multisig::verifier_set::VerifierSet;
 
 use crate::proof::Proof;
-use crate::{AleoValue, Error, Message};
+use crate::{AleoValue, Error, Messages, WeightedSigners};
 
-pub struct ExecuteData {
+pub struct ExecuteDataMessages {
     proof: Proof,
-    payload: Message,
+    payload: Messages,
 }
 
-impl ExecuteData {
-    pub fn new(proof: Proof, payload: Message) -> ExecuteData {
-        ExecuteData { proof, payload }
+impl ExecuteDataMessages {
+    pub fn new(proof: Proof, payload: Messages) -> ExecuteDataMessages {
+        ExecuteDataMessages { proof, payload }
     }
 }
 
-impl AleoValue for ExecuteData {
+impl AleoValue for ExecuteDataMessages {
     fn to_aleo_string(&self) -> Result<String, Report<Error>> {
         let res = format!(
             r#"{{ proof: {}, message: {} }}"#,
+            self.proof.to_aleo_string()?,
+            self.payload.to_aleo_string()?
+        );
+
+        Ok(res)
+    }
+}
+
+pub struct ExecuteDataVerifierSet<const GROUP_SIZE: usize = 2, const GROUPS: usize = 2> {
+    proof: Proof,
+    payload: WeightedSigners<GROUP_SIZE, GROUPS>,
+}
+
+impl<const GROUP_SIZE: usize, const GROUPS: usize> ExecuteDataVerifierSet<GROUP_SIZE, GROUPS> {
+    pub fn new(proof: Proof, payload: VerifierSet) -> ExecuteDataVerifierSet<GROUP_SIZE, GROUPS> {
+        let payload = WeightedSigners::<GROUP_SIZE, GROUPS>::try_from(&payload).unwrap();
+        ExecuteDataVerifierSet { proof, payload }
+    }
+}
+
+impl AleoValue for ExecuteDataVerifierSet {
+    fn to_aleo_string(&self) -> Result<String, Report<Error>> {
+        let res = format!(
+            r#"{{ proof: {}, payload: {} }}"#,
             self.proof.to_aleo_string()?,
             self.payload.to_aleo_string()?
         );

--- a/packages/aleo-gateway/src/lib.rs
+++ b/packages/aleo-gateway/src/lib.rs
@@ -46,6 +46,8 @@ pub enum Error {
     InvalidAscii,
     #[error("StringEncoder: {0}")]
     StringEncoder(#[from] aleo_utils::string_encoder::Error),
+    #[error("InvalidMessageGroupLength: expected: {max}, actual: {actual}")]
+    InvalidMessageGroupLength { max: usize, actual: usize },
 }
 
 pub trait AleoValue {
@@ -74,12 +76,6 @@ pub fn aleo_hash<T: AsRef<str>, N: Network>(input: T) -> Result<Group<N>, Report
                 .attach_printable(format!("input: '{:?}'", input.as_ref().to_owned()))
         })?
         .to_bits_le();
-
-    // TODO: remove the keccak256 hash if not needed
-    // let bits = N::hash_keccak256(&aleo_value).map_err(|e| {
-    //     Report::new(Error::Aleo(e))
-    //         .attach_printable(format!("input2: '{:?}'", input.as_ref().to_owned()))
-    // })?;
 
     let group = N::hash_to_group_bhp256(&aleo_value).map_err(|e| {
         Report::new(Error::Aleo(e)).attach_printable(format!(

--- a/packages/aleo-gateway/src/lib.rs
+++ b/packages/aleo-gateway/src/lib.rs
@@ -28,6 +28,15 @@ pub use signer_with_signature::*;
 pub use weighted_signer::*;
 pub use weighted_signers::*;
 
+// Generics are not used in the code becasue of this issue:
+// https://github.com/rust-lang/rust/issues/61956
+// For this we will use this const variables, just to be easy for as to adapt during development.
+// TODO: When our solution is ready, we will need to rethink it.
+pub const GROUP_SIZE: usize = 2;
+pub const GROUPS: usize = 2;
+
+type Array2D<T> = [[T; GROUP_SIZE]; GROUPS];
+
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("AleoGateway: {0}")]

--- a/packages/aleo-gateway/src/lib.rs
+++ b/packages/aleo-gateway/src/lib.rs
@@ -53,6 +53,10 @@ pub enum Error {
         address_signatures: usize,
         signer_signatures: usize,
     },
+    #[error("Checked division failed: {0} / {1}")]
+    CheckedDivision(usize, usize),
+    #[error("Checked remainder failed: {0} % {1}")]
+    CheckedRemainder(usize, usize),
 }
 
 pub trait AleoValue {

--- a/packages/aleo-gateway/src/lib.rs
+++ b/packages/aleo-gateway/src/lib.rs
@@ -48,6 +48,11 @@ pub enum Error {
     StringEncoder(#[from] aleo_utils::string_encoder::Error),
     #[error("InvalidMessageGroupLength: expected: {max}, actual: {actual}")]
     InvalidMessageGroupLength { max: usize, actual: usize },
+    #[error("The number of address signatures ({address_signatures}) does not match the number of signer signatures ({signer_signatures}).")]
+    MismatchedSignerCount {
+        address_signatures: usize,
+        signer_signatures: usize,
+    },
 }
 
 pub trait AleoValue {

--- a/packages/aleo-gateway/src/lib.rs
+++ b/packages/aleo-gateway/src/lib.rs
@@ -3,10 +3,12 @@ use std::str::FromStr as _;
 use error_stack::Report;
 use snarkvm_cosmwasm::network::Network;
 use snarkvm_cosmwasm::program::ToBits;
+use snarkvm_cosmwasm::types::Group;
 use thiserror::Error;
 
 mod execute_data;
 mod message;
+mod message_group;
 mod messages;
 mod payload_digest;
 mod proof;
@@ -17,6 +19,7 @@ mod weighted_signers;
 
 pub use execute_data::*;
 pub use message::*;
+pub use message_group::*;
 pub use messages::*;
 pub use payload_digest::*;
 pub use proof::*;
@@ -53,13 +56,18 @@ pub trait AleoValue {
         hash::<std::string::String, N>(input)
     }
 
-    fn bhp<N: Network>(&self) -> Result<String, Report<Error>> {
+    fn bhp<N: Network>(&self) -> Result<Group<N>, Report<Error>> {
         let input = self.to_aleo_string()?;
         aleo_hash::<std::string::String, N>(input)
     }
+
+    fn bhp_string<N: Network>(&self) -> Result<String, Report<Error>> {
+        let input = self.to_aleo_string()?;
+        aleo_hash::<std::string::String, N>(input).map(|g| g.to_string())
+    }
 }
 
-pub fn aleo_hash<T: AsRef<str>, N: Network>(input: T) -> Result<String, Report<Error>> {
+pub fn aleo_hash<T: AsRef<str>, N: Network>(input: T) -> Result<Group<N>, Report<Error>> {
     let aleo_value: Vec<bool> = snarkvm_cosmwasm::program::Value::<N>::from_str(input.as_ref())
         .map_err(|e| {
             Report::new(Error::Aleo(e))
@@ -67,19 +75,20 @@ pub fn aleo_hash<T: AsRef<str>, N: Network>(input: T) -> Result<String, Report<E
         })?
         .to_bits_le();
 
-    let bits = N::hash_keccak256(&aleo_value).map_err(|e| {
-        Report::new(Error::Aleo(e))
-            .attach_printable(format!("input2: '{:?}'", input.as_ref().to_owned()))
-    })?;
+    // TODO: remove the keccak256 hash if not needed
+    // let bits = N::hash_keccak256(&aleo_value).map_err(|e| {
+    //     Report::new(Error::Aleo(e))
+    //         .attach_printable(format!("input2: '{:?}'", input.as_ref().to_owned()))
+    // })?;
 
-    let group = N::hash_to_group_bhp256(&bits).map_err(|e| {
+    let group = N::hash_to_group_bhp256(&aleo_value).map_err(|e| {
         Report::new(Error::Aleo(e)).attach_printable(format!(
             "Failed to get bhp256 hash: '{:?}'",
             input.as_ref().to_owned()
         ))
     })?;
 
-    Ok(group.to_string())
+    Ok(group)
 }
 
 pub fn hash<T: AsRef<str>, N: Network>(input: T) -> Result<[u8; 32], Report<Error>> {

--- a/packages/aleo-gateway/src/message.rs
+++ b/packages/aleo-gateway/src/message.rs
@@ -115,7 +115,10 @@ impl AleoValue for Message {
                 .consume()
                 .into_iter()
                 .map(|c| format!("{}u128", c))
-                .chain(std::iter::repeat("0u128".to_string()).take(MESSAGE_ID_LEN.saturating_sub(message_id_len)))
+                .chain(
+                    std::iter::repeat("0u128".to_string())
+                        .take(MESSAGE_ID_LEN.saturating_sub(message_id_len))
+                )
                 .collect::<Vec<_>>()
                 .join(", "),
             source_address

--- a/packages/aleo-gateway/src/message_group.rs
+++ b/packages/aleo-gateway/src/message_group.rs
@@ -1,0 +1,60 @@
+// Match the representation of a message group in the Aleo gateway.
+
+use error_stack::Report;
+use snarkvm_cosmwasm::program::{Network, Zero};
+use snarkvm_cosmwasm::types::Group;
+
+use crate::{AleoValue, Error, Message};
+
+/// MN: Number of messages in a message group
+/// MG: Number of message groups
+#[derive(Debug)]
+pub struct MessageGroup<N: Network, const MN: usize = 16, const MG: usize = 3> {
+    messages: [[Group<N>; MN]; MG],
+}
+
+impl<N: Network, const MN: usize, const MG: usize> MessageGroup<N, MN, MG> {
+    pub fn new(messages: Vec<Message>) -> Result<Self, Report<Error>> {
+        let max_messages = MN * MG;
+        if messages.len() > max_messages {
+            todo!()
+        }
+
+        let messages = messages
+            .iter()
+            .map(|m| m.bhp::<N>())
+            .collect::<Result<Vec<Group<N>>, Report<Error>>>()?;
+
+        let mut message_groups = [[Group::<N>::zero(); MN]; MG];
+
+        for (i, message) in messages.iter().enumerate() {
+            message_groups[i / MN][i % MN] = *message;
+        }
+
+        Ok(Self {
+            messages: message_groups,
+        })
+    }
+}
+
+impl<N: Network, const MN: usize, const MG: usize> AleoValue for MessageGroup<N, MN, MG> {
+    fn to_aleo_string(&self) -> Result<String, Report<Error>> {
+        let res = self
+            .messages
+            .iter()
+            .map(|message_group| {
+                format!(
+                    r#"[{}]"#,
+                    message_group
+                        .iter()
+                        .map(Group::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        Ok(format!(r#"[{}]"#, res))
+    }
+}

--- a/packages/aleo-gateway/src/payload_digest.rs
+++ b/packages/aleo-gateway/src/payload_digest.rs
@@ -1,13 +1,12 @@
-use aleo_types::address::Address;
 use error_stack::Report;
 use multisig::verifier_set::VerifierSet;
 
-use crate::{AleoValue, Error};
+use crate::{AleoValue, Error, WeightedSigners};
 
 #[derive(Debug)]
 pub struct PayloadDigest<'a> {
     domain_separator: &'a [u128; 2],
-    signer: Address,
+    signers: WeightedSigners,
     data_hash: String,
 }
 
@@ -17,31 +16,11 @@ impl<'a> PayloadDigest<'a> {
         verifier_set: &VerifierSet,
         data_hash: String,
     ) -> Result<PayloadDigest<'a>, Report<Error>> {
-        let address = verifier_set
-            .signers
-            .values()
-            .next()
-            .map(|verifier| match &verifier.pub_key {
-                multisig::key::PublicKey::AleoSchnorr(key) => {
-                    Ok(Address::try_from(key).map_err(|e| {
-                        Report::new(Error::AleoGateway(format!(
-                            "Failed to parse address: {}",
-                            e
-                        )))
-                    })?)
-                }
-                multisig::key::PublicKey::Ecdsa(_) => Err(Report::new(
-                    Error::UnsupportedPublicKey("received Ecdsa".to_string()),
-                )),
-                multisig::key::PublicKey::Ed25519(_) => Err(Report::new(
-                    Error::UnsupportedPublicKey("received Ed25519".to_string()),
-                )),
-            })
-            .ok_or_else(|| Report::new(Error::AleoGateway("No signers found".to_string())))??;
+        let signers = WeightedSigners::try_from(verifier_set)?;
 
         Ok(PayloadDigest {
             domain_separator,
-            signer: address,
+            signers,
             data_hash,
         })
     }
@@ -56,7 +35,7 @@ impl AleoValue for PayloadDigest<'_> {
                 .map(|b| format!("{}u128", b))
                 .collect::<Vec<_>>()
                 .join(", "),
-            self.signer,
+            self.signers.to_aleo_string()?,
             self.data_hash
         );
 

--- a/packages/aleo-gateway/src/proof.rs
+++ b/packages/aleo-gateway/src/proof.rs
@@ -11,7 +11,6 @@ use multisig::verifier_set::VerifierSet;
 use crate::raw_signature::RawSignature;
 use crate::{AleoValue, Array2D, Error, WeightedSigners};
 
-
 #[derive(Clone, Debug)]
 pub struct Proof {
     pub weighted_signers: WeightedSigners,
@@ -27,7 +26,7 @@ impl Proof {
         let weighted_signers = WeightedSigners::try_from(&verifier_set)?;
 
         let signer_with_signature_len = signer_with_signature.len();
-        let address_signature: HashMap<Address, HexBinary> = signer_with_signature
+        let mut address_signature: HashMap<Address, HexBinary> = signer_with_signature
             .into_iter()
             .filter_map(|signer_with_signature| {
                 let (key, sig) = match (
@@ -56,9 +55,9 @@ impl Proof {
 
         for (group_idx, signer_group) in weighted_signers.signers.iter().enumerate() {
             for (signer_idx, weighted_signer) in signer_group.iter().enumerate() {
-                if let Some(sig) = address_signature.get(&weighted_signer.signer) {
+                if let Some(sig) = address_signature.remove(&weighted_signer.signer) {
                     signature[group_idx][signer_idx].write(RawSignature {
-                        signature: sig.as_slice().to_vec(),
+                        signature: sig.into(),
                     });
                 } else {
                     signature[group_idx][signer_idx].write(RawSignature::default());

--- a/packages/aleo-gateway/src/proof.rs
+++ b/packages/aleo-gateway/src/proof.rs
@@ -65,10 +65,6 @@ impl<const GROUP_SIZE: usize, const GROUPS: usize> Proof<GROUP_SIZE, GROUPS> {
 
         for (group_idx, signer_group) in weighted_signers.signers.iter().enumerate() {
             for (signer_idx, weighted_signer) in signer_group.iter().enumerate() {
-                if weighted_signer.signer == *ZERO_ADDRESS {
-                    break;
-                }
-
                 if let Some(sig) = address_signature.get(&weighted_signer.signer) {
                     signature[group_idx][signer_idx].write(RawSignature {
                         signature: sig.as_slice().to_vec(),

--- a/packages/aleo-gateway/src/proof.rs
+++ b/packages/aleo-gateway/src/proof.rs
@@ -1,60 +1,93 @@
+use std::collections::HashMap;
+
 use aleo_types::address::Address;
+use cosmwasm_std::HexBinary;
 use error_stack::Report;
+use multisig::key::{PublicKey, Signature};
 use multisig::msg::SignerWithSig;
 use multisig::verifier_set::VerifierSet;
 
 use crate::raw_signature::RawSignature;
-use crate::{AleoValue, Error};
+use crate::{AleoValue, Error, WeightedSigners};
 
 #[derive(Clone, Debug)]
-pub struct Proof {
-    pub weighted_signer: Address,
-    pub signature: RawSignature,
-    pub nonce: [u128; 2],
+pub struct Proof<const GROUP_SIZE: usize = 2, const GROUPS: usize = 2> {
+    pub weighted_signers: WeightedSigners<GROUP_SIZE, GROUPS>,
+    pub signature: [[RawSignature; GROUP_SIZE]; GROUPS],
+    // pub nonce: [u128; 2],
 }
 
-impl Proof {
+impl<const GROUP_SIZE: usize, const GROUPS: usize> Proof<GROUP_SIZE, GROUPS> {
     pub fn new(
         verifier_set: VerifierSet,
-        signer_with_signature: SignerWithSig,
+        signer_with_signature: Vec<SignerWithSig>,
     ) -> Result<Self, Report<Error>> {
-        let address = verifier_set
-            .signers
-            .values()
-            .next()
-            .map(|verifier| match &verifier.pub_key {
-                multisig::key::PublicKey::AleoSchnorr(key) => {
-                    Ok(Address::try_from(key).map_err(|e| {
-                        Report::new(Error::AleoGateway(format!(
-                            "Failed to parse address: {}",
-                            e
-                        )))
-                    })?)
-                }
-                multisig::key::PublicKey::Ecdsa(_) => Err(Report::new(
-                    Error::UnsupportedPublicKey("received Ecdsa".to_string()),
-                )),
-                multisig::key::PublicKey::Ed25519(_) => Err(Report::new(
-                    Error::UnsupportedPublicKey("received Ed25519".to_string()),
-                )),
-            })
-            .ok_or_else(|| Report::new(Error::AleoGateway("No signers found".to_string())))??;
+        let weighted_signers = WeightedSigners::try_from(&verifier_set)?;
 
-        let signature = RawSignature {
-            signature: match signer_with_signature.signature {
-                multisig::key::Signature::AleoSchnorr(sig) => sig.to_vec(),
-                _ => {
-                    return Err(Report::new(Error::UnsupportedPublicKey(
-                        "Missing Aleo schnorr signature".to_string(),
-                    )))
+        let mut signer_with_signature = signer_with_signature;
+        signer_with_signature.sort_by(|signer1, signer2| {
+            let PublicKey::AleoSchnorr(pub_key1) = signer1.signer.pub_key.clone() else {
+                todo!();
+            };
+
+            let PublicKey::AleoSchnorr(pub_key2) = signer2.signer.pub_key.clone() else {
+                todo!();
+            };
+
+            let pub_key1 = Address::try_from(&pub_key1).unwrap();
+            let pub_key2 = Address::try_from(&pub_key2).unwrap();
+
+            /* give the lowest priority to the default address */
+            if pub_key1 == Address::default() {
+                std::cmp::Ordering::Greater
+            } else if pub_key2 == Address::default() {
+                std::cmp::Ordering::Less
+            } else {
+                pub_key1.cmp(&pub_key2)
+            }
+        });
+
+        let my_map: HashMap<Address, HexBinary> = signer_with_signature
+            .iter()
+            .filter_map(|signer_with_signature| {
+                // TODO: refactor this to be more efficient
+                let PublicKey::AleoSchnorr(key) = signer_with_signature.signer.pub_key.clone()
+                else {
+                    return None;
+                };
+
+                let Signature::AleoSchnorr(sig) = signer_with_signature.signature.clone() else {
+                    return None;
+                };
+
+                let addr = Address::try_from(&key).ok()?;
+                Some((addr, sig))
+            })
+            .collect();
+
+        // TODO: refactor this to be more efficient
+        let mut signature: [[RawSignature; GROUP_SIZE]; GROUPS] =
+            core::array::from_fn(|_| core::array::from_fn(|_| RawSignature::default()));
+
+        for (group_idx, signer_group) in weighted_signers.signers.iter().enumerate() {
+            for (signer_idx, weighted_signer) in signer_group.iter().enumerate() {
+                if weighted_signer.signer == Address::default() {
+                    // TODO: break outer
+                    break;
                 }
-            },
-        };
+
+                if let Some(sig) = my_map.get(&weighted_signer.signer) {
+                    signature[group_idx][signer_idx] = RawSignature {
+                        signature: sig.as_slice().to_vec(),
+                    };
+                }
+            }
+        }
 
         Ok(Proof {
-            weighted_signer: address,
+            weighted_signers,
             signature,
-            nonce: [3, 1],
+            // nonce: [3, 1],
         })
     }
 }
@@ -62,11 +95,25 @@ impl Proof {
 impl AleoValue for Proof {
     fn to_aleo_string(&self) -> Result<String, Report<Error>> {
         let res = format!(
-            r#"{{ weighted_signer: {}, signaturee: {}, nonce: [ {}u128, {}u128 ] }}"#,
-            self.weighted_signer,
-            self.signature.to_aleo_string()?,
-            self.nonce[0],
-            self.nonce[1],
+            r#"{{ weighted_signer: {}, signatures: [ {} ] }}"#,
+            // r#"{{ weighted_signer: {}, signatures: [ {} ], nonce: [ {}u128, {}u128 ] }}"#,
+            self.weighted_signers.to_aleo_string()?,
+            self.signature
+                .iter()
+                .map(|sig| {
+                    format!(
+                        "[{}]",
+                        sig.iter()
+                            .map(|s| s.to_aleo_string())
+                            .collect::<Result<Vec<_>, Report<Error>>>()
+                            .unwrap() // TODO: remove unwrap
+                            .join(", ")
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(", "),
+            // self.nonce[0],
+            // self.nonce[1],
         );
 
         Ok(res)

--- a/packages/aleo-gateway/src/proof.rs
+++ b/packages/aleo-gateway/src/proof.rs
@@ -25,7 +25,6 @@ impl<const GROUP_SIZE: usize, const GROUPS: usize> Proof<GROUP_SIZE, GROUPS> {
     ) -> Result<Self, Report<Error>> {
         let weighted_signers = WeightedSigners::try_from(&verifier_set)?;
 
-
         let signer_with_signature_len = signer_with_signature.len();
         let address_signature: HashMap<Address, HexBinary> = signer_with_signature
             .into_iter()
@@ -45,7 +44,7 @@ impl<const GROUP_SIZE: usize, const GROUPS: usize> Proof<GROUP_SIZE, GROUPS> {
 
         ensure!(
             address_signature.len() == signer_with_signature_len,
-            Error:: MismatchedSignerCount {
+            Error::MismatchedSignerCount {
                 address_signatures: address_signature.len(),
                 signer_signatures: signer_with_signature_len
             },

--- a/packages/aleo-gateway/src/proof.rs
+++ b/packages/aleo-gateway/src/proof.rs
@@ -15,7 +15,7 @@ use crate::{AleoValue, Error, WeightedSigners};
 pub struct Proof<const GROUP_SIZE: usize = 2, const GROUPS: usize = 2> {
     pub weighted_signers: WeightedSigners<GROUP_SIZE, GROUPS>,
     pub signature: [[RawSignature; GROUP_SIZE]; GROUPS],
-    // pub nonce: [u128; 2],
+    // pub nonce: [u128; 2], // TODO: this should be included before going to mainnet
 }
 
 impl<const GROUP_SIZE: usize, const GROUPS: usize> Proof<GROUP_SIZE, GROUPS> {
@@ -50,7 +50,6 @@ impl<const GROUP_SIZE: usize, const GROUPS: usize> Proof<GROUP_SIZE, GROUPS> {
             },
         );
 
-        // TODO: refactor this to be more efficient
         let mut signature: [[MaybeUninit<RawSignature>; GROUP_SIZE]; GROUPS] =
             unsafe { MaybeUninit::uninit().assume_init() };
 
@@ -82,7 +81,6 @@ impl AleoValue for Proof {
     fn to_aleo_string(&self) -> Result<String, Report<Error>> {
         let res = format!(
             r#"{{ weighted_signer: {}, signatures: [ {} ] }}"#,
-            // r#"{{ weighted_signer: {}, signatures: [ {} ], nonce: [ {}u128, {}u128 ] }}"#,
             self.weighted_signers.to_aleo_string()?,
             self.signature
                 .iter()
@@ -98,8 +96,6 @@ impl AleoValue for Proof {
                 })
                 .collect::<Vec<_>>()
                 .join(", "),
-            // self.nonce[0],
-            // self.nonce[1],
         );
 
         Ok(res)

--- a/packages/aleo-gateway/src/raw_signature.rs
+++ b/packages/aleo-gateway/src/raw_signature.rs
@@ -2,11 +2,6 @@ use error_stack::Report;
 
 use crate::{AleoValue, Error};
 
-/*
-sign1tg9nwza05k89vyspuemc8r5vkz54f3v3gl4s6x05atqtgwnyyvq8ccamwql5txztuevplttghu5eyprlmth6ysgvsz9mgzjslf8guq5r22qjwn4zc0pzv87twjygsz9m7ekljmuw4jpzf68rwuq99r0tp735vs6220q7tp60nr7llkwstcvu49wdhydx5x2s3sftjskzawhqvnvcgml
-*/
-
-// TODO: nonce is skipped
 #[derive(Clone, Debug)]
 pub struct RawSignature {
     pub signature: Vec<u8>,

--- a/packages/aleo-gateway/src/raw_signature.rs
+++ b/packages/aleo-gateway/src/raw_signature.rs
@@ -2,10 +2,27 @@ use error_stack::Report;
 
 use crate::{AleoValue, Error};
 
+/*
+sign1tg9nwza05k89vyspuemc8r5vkz54f3v3gl4s6x05atqtgwnyyvq8ccamwql5txztuevplttghu5eyprlmth6ysgvsz9mgzjslf8guq5r22qjwn4zc0pzv87twjygsz9m7ekljmuw4jpzf68rwuq99r0tp735vs6220q7tp60nr7llkwstcvu49wdhydx5x2s3sftjskzawhqvnvcgml
+*/
+
 // TODO: nonce is skipped
 #[derive(Clone, Debug)]
 pub struct RawSignature {
     pub signature: Vec<u8>,
+}
+
+impl RawSignature {
+    pub fn new(sig: &str) -> Self {
+        let signature = sig.as_bytes().to_vec();
+        RawSignature { signature }
+    }
+}
+
+impl Default for RawSignature {
+    fn default() -> Self {
+        RawSignature::new("sign1tg9nwza05k89vyspuemc8r5vkz54f3v3gl4s6x05atqtgwnyyvq8ccamwql5txztuevplttghu5eyprlmth6ysgvsz9mgzjslf8guq5r22qjwn4zc0pzv87twjygsz9m7ekljmuw4jpzf68rwuq99r0tp735vs6220q7tp60nr7llkwstcvu49wdhydx5x2s3sftjskzawhqvnvcgml")
+    }
 }
 
 impl AleoValue for RawSignature {

--- a/packages/aleo-gateway/src/weighted_signer.rs
+++ b/packages/aleo-gateway/src/weighted_signer.rs
@@ -1,9 +1,10 @@
 use aleo_types::address::Address;
 use error_stack::Report;
+use serde::{Deserialize, Serialize};
 
 use crate::{AleoValue, Error};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub struct WeightedSigner {
     pub signer: Address,
     pub weight: u128,
@@ -12,7 +13,7 @@ pub struct WeightedSigner {
 impl AleoValue for WeightedSigner {
     fn to_aleo_string(&self) -> Result<String, Report<Error>> {
         let res = format!(
-            r#"{{signer: {}, weight: {}u128}}"#,
+            r#"{{addr: {}, weight: {}u128}}"#,
             self.signer.0, self.weight
         );
 

--- a/packages/aleo-gateway/src/weighted_signers.rs
+++ b/packages/aleo-gateway/src/weighted_signers.rs
@@ -1,4 +1,4 @@
-use aleo_types::address::Address;
+use aleo_types::address::{Address, ZERO_ADDRESS};
 use cosmwasm_std::Uint128;
 use error_stack::Report;
 use multisig::key::PublicKey;
@@ -59,12 +59,11 @@ impl<const GROUP_SIZE: usize, const GROUPS: usize> TryFrom<&VerifierSet>
             .take(GROUP_SIZE * GROUPS)
             .collect::<Result<Vec<_>, _>>()?;
 
-        // signers.sort_by(|signer1, signer2| signer1.signer.cmp(&signer2.signer));
         signers.sort_by(|signer1, signer2| {
             /* give the lowest priority to the default address */
-            if signer1.signer == Address::default() {
+            if signer1.signer == *ZERO_ADDRESS {
                 std::cmp::Ordering::Greater
-            } else if signer2.signer == Address::default() {
+            } else if signer2.signer == *ZERO_ADDRESS {
                 std::cmp::Ordering::Less
             } else {
                 signer1.signer.cmp(&signer2.signer)
@@ -133,27 +132,4 @@ impl<const GROUP_SIZE: usize, const GROUPS: usize> AleoValue
 
         Ok(res)
     }
-    // fn to_aleo_string(&self) -> Result<String, Report<Error>> {
-    //     let res = format!(
-    //         r#"{{ signers: [ [{}], [{}] ], threshold: {}u128 }}"#,
-    //         // r#"{{ signers: [ {}, {} ], threshold: {}u128, nonce: [ {}u64, {}u64, {}u64, {}u64 ] }}"#,
-    //         self.signers[0]
-    //             .iter()
-    //             .map(|s| s.to_aleo_string())
-    //             .collect::<Result<Vec<_>, _>>()?
-    //             .join(", "),
-    //         self.signers[1]
-    //             .iter()
-    //             .map(|s| s.to_aleo_string())
-    //             .collect::<Result<Vec<_>, _>>()?
-    //             .join(", "),
-    //         self.threshold,
-    //         // self.nonce[0],
-    //         // self.nonce[1],
-    //         // self.nonce[2],
-    //         // self.nonce[3]
-    //     );
-    //
-    //     Ok(res)
-    // }
 }

--- a/packages/aleo-gateway/src/weighted_signers.rs
+++ b/packages/aleo-gateway/src/weighted_signers.rs
@@ -3,21 +3,33 @@ use cosmwasm_std::Uint128;
 use error_stack::Report;
 use multisig::key::PublicKey;
 use multisig::verifier_set::VerifierSet;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
 use crate::weighted_signer::WeightedSigner;
 use crate::{AleoValue, Error};
 
-#[derive(Debug, Clone)]
-pub struct WeightedSigners {
-    signers: Vec<WeightedSigner>, // TODO: [WeightedSigner; 32],
+#[serde_as]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct WeightedSigners<const GROUP_SIZE: usize = 2, const GROUPS: usize = 2> {
+    #[serde_as(as = "[[_; GROUP_SIZE]; GROUPS]")]
+    pub signers: [[WeightedSigner; GROUP_SIZE]; GROUPS],
     threshold: Uint128,
-    nonce: [u64; 4],
+    // nonce: [u64; 4], // TODO: this should be included before going to main net
 }
 
-impl TryFrom<&VerifierSet> for WeightedSigners {
+impl<const GROUP_SIZE: usize, const GROUPS: usize> TryFrom<&VerifierSet>
+    for WeightedSigners<GROUP_SIZE, GROUPS>
+{
     type Error = Report<Error>;
 
     fn try_from(value: &VerifierSet) -> Result<Self, Self::Error> {
+        if value.signers.len() > GROUP_SIZE * GROUPS {
+            return Err(Report::new(Error::AleoGateway(
+                "Too many signers in the verifier set".to_string(),
+            )));
+        }
+
         let mut signers = value
             .signers
             .values()
@@ -44,35 +56,104 @@ impl TryFrom<&VerifierSet> for WeightedSigners {
                     weight: Default::default(),
                 })
             }))
-            .take(32)
+            .take(GROUP_SIZE * GROUPS)
             .collect::<Result<Vec<_>, _>>()?;
 
-        signers.sort_by(|signer1, signer2| signer1.signer.cmp(&signer2.signer));
+        // signers.sort_by(|signer1, signer2| signer1.signer.cmp(&signer2.signer));
+        signers.sort_by(|signer1, signer2| {
+            /* give the lowest priority to the default address */
+            if signer1.signer == Address::default() {
+                std::cmp::Ordering::Greater
+            } else if signer2.signer == Address::default() {
+                std::cmp::Ordering::Less
+            } else {
+                signer1.signer.cmp(&signer2.signer)
+            }
+        });
 
         let threshold = value.threshold;
-        let nonce = [0, 0, 0, value.created_at];
+        let _nonce = [0, 0, 0, value.created_at];
+
+        // Distribute signers across groups
+        let mut grouped_signers = Vec::with_capacity(GROUPS);
+        for group_idx in 0..GROUPS {
+            let start = group_idx * GROUP_SIZE;
+            let end = start + GROUP_SIZE;
+
+            let group_vec: Vec<_> = signers[start..end].to_vec();
+            let group_array: [WeightedSigner; GROUP_SIZE] = group_vec.try_into().expect(&format!(
+                "Group {} should have exactly {} elements",
+                group_idx, GROUP_SIZE
+            ));
+
+            grouped_signers.push(group_array);
+        }
+
+        // Convert Vec<[WeightedSigner; GROUP_SIZE]> to [[WeightedSigner; GROUP_SIZE]; GROUPS]
+        let signers_array: [[WeightedSigner; GROUP_SIZE]; GROUPS] = grouped_signers
+            .try_into()
+            .unwrap_or_else(|_| panic!("Failed to convert to array of size {}", GROUPS));
 
         Ok(WeightedSigners {
-            signers,
+            signers: signers_array,
             threshold,
-            nonce,
+            // nonce,
         })
     }
 }
 
-impl AleoValue for WeightedSigners {
+impl<const GROUP_SIZE: usize, const GROUPS: usize> AleoValue
+    for WeightedSigners<GROUP_SIZE, GROUPS>
+{
     fn to_aleo_string(&self) -> Result<String, Report<Error>> {
-        let signers = self
-            .signers
-            .iter()
-            .map(WeightedSigner::to_aleo_string)
-            .collect::<Result<Vec<_>, Report<Error>>>()?
-            .join(", ");
-        let res = format!(
-            r#"{{ signers: [ {} ], threshold: {}u128, nonce: [ {}u64, {}u64, {}u64, {}u64 ] }}"#,
-            signers, self.threshold, self.nonce[0], self.nonce[1], self.nonce[2], self.nonce[3]
-        );
+        // Start with the opening part of the string
+        let mut res = String::from("{ signers: [ ");
+
+        // Add each group's formatted string
+        for (i, group) in self.signers.iter().enumerate() {
+            let group_str = format!(
+                "[{}]",
+                group
+                    .iter()
+                    .map(|s| s.to_aleo_string())
+                    .collect::<Result<Vec<_>, _>>()?
+                    .join(", ")
+            );
+
+            res.push_str(&group_str);
+
+            // Add comma if not the last group
+            if i < self.signers.len() - 1 {
+                res.push_str(", ");
+            }
+        }
+
+        // Add the threshold and closing part
+        res.push_str(&format!(" ], quorum: {}u128 }}", self.threshold));
 
         Ok(res)
     }
+    // fn to_aleo_string(&self) -> Result<String, Report<Error>> {
+    //     let res = format!(
+    //         r#"{{ signers: [ [{}], [{}] ], threshold: {}u128 }}"#,
+    //         // r#"{{ signers: [ {}, {} ], threshold: {}u128, nonce: [ {}u64, {}u64, {}u64, {}u64 ] }}"#,
+    //         self.signers[0]
+    //             .iter()
+    //             .map(|s| s.to_aleo_string())
+    //             .collect::<Result<Vec<_>, _>>()?
+    //             .join(", "),
+    //         self.signers[1]
+    //             .iter()
+    //             .map(|s| s.to_aleo_string())
+    //             .collect::<Result<Vec<_>, _>>()?
+    //             .join(", "),
+    //         self.threshold,
+    //         // self.nonce[0],
+    //         // self.nonce[1],
+    //         // self.nonce[2],
+    //         // self.nonce[3]
+    //     );
+    //
+    //     Ok(res)
+    // }
 }

--- a/packages/aleo-gateway/src/weighted_signers.rs
+++ b/packages/aleo-gateway/src/weighted_signers.rs
@@ -73,6 +73,7 @@ impl<const GROUP_SIZE: usize, const GROUPS: usize> TryFrom<&VerifierSet>
         let threshold = value.threshold;
         let _nonce = [0, 0, 0, value.created_at];
 
+        // TODO: make this using 2d array
         // Distribute signers across groups
         let mut grouped_signers = Vec::with_capacity(GROUPS);
         for group_idx in 0..GROUPS {

--- a/packages/aleo-gateway/src/weighted_signers.rs
+++ b/packages/aleo-gateway/src/weighted_signers.rs
@@ -106,7 +106,7 @@ impl<const GROUP_SIZE: usize, const GROUPS: usize> AleoValue
             .map(|group| {
                 let group_str = group
                     .iter()
-                    // Weighted Signer to_aleo_string does  not produce an error
+                    // Weighted Signer to_aleo_string does not produce an error
                     .map(|s| s.to_aleo_string().unwrap())
                     .collect::<Vec<_>>()
                     .join(", ");

--- a/packages/aleo-types/Cargo.toml
+++ b/packages/aleo-types/Cargo.toml
@@ -13,7 +13,6 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 bech32 = { workspace = true }
 hex = { workspace = true }
-lazy_static = "1.4.0"
 
 [dev-dependencies]
 axelar-wasm-std = { workspace = true }

--- a/packages/aleo-types/Cargo.toml
+++ b/packages/aleo-types/Cargo.toml
@@ -13,6 +13,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 bech32 = { workspace = true }
 hex = { workspace = true }
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 axelar-wasm-std = { workspace = true }

--- a/packages/aleo-types/src/address.rs
+++ b/packages/aleo-types/src/address.rs
@@ -1,18 +1,16 @@
 use std::fmt::Display;
 use std::str::FromStr;
+use std::sync::LazyLock;
 
 use axelar_wasm_std::nonempty;
 use cosmwasm_std::HexBinary;
 use error_stack::{ensure, Report, Result};
-use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 
 use crate::{verify_becnh32, Error};
 
 pub const ALEO_ADDRESS_LEN: usize = 63;
-lazy_static! {
-    pub static ref ZERO_ADDRESS: Address = Address::default();
-}
+pub static ZERO_ADDRESS: LazyLock<Address> = LazyLock::new(|| Address::default());
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
 pub struct Address(pub nonempty::String);

--- a/packages/aleo-types/src/address.rs
+++ b/packages/aleo-types/src/address.rs
@@ -4,11 +4,15 @@ use std::str::FromStr;
 use axelar_wasm_std::nonempty;
 use cosmwasm_std::HexBinary;
 use error_stack::{ensure, Report, Result};
+use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 
 use crate::{verify_becnh32, Error};
 
 pub const ALEO_ADDRESS_LEN: usize = 63;
+lazy_static! {
+    pub static ref ZERO_ADDRESS: Address = Address::default();
+}
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
 pub struct Address(pub nonempty::String);
@@ -17,7 +21,7 @@ impl Default for Address {
     fn default() -> Self {
         Self(
             nonempty::String::try_from(
-                "aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc".to_string(),
+                "aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc",
             )
             .unwrap(),
         )

--- a/packages/aleo-types/src/address.rs
+++ b/packages/aleo-types/src/address.rs
@@ -10,14 +10,14 @@ use crate::{verify_becnh32, Error};
 
 pub const ALEO_ADDRESS_LEN: usize = 63;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, PartialOrd, Ord)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
 pub struct Address(pub nonempty::String);
 
 impl Default for Address {
     fn default() -> Self {
         Self(
             nonempty::String::try_from(
-                "aleo1qtrn0h0pakusngjemdehzljqthu3e8vfwl5qj2zccc5cgasutq8qjy2afr".to_string(),
+                "aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc".to_string(),
             )
             .unwrap(),
         )

--- a/packages/aleo-types/src/program.rs
+++ b/packages/aleo-types/src/program.rs
@@ -1,3 +1,4 @@
+use std::ops::Deref;
 use std::str::FromStr;
 
 use axelar_wasm_std::nonempty;
@@ -14,6 +15,14 @@ impl TryFrom<String> for Program {
 
     fn try_from(name: String) -> Result<Self, Error> {
         Program::from_str(&name)
+    }
+}
+
+impl Deref for Program {
+    type Target = axelar_wasm_std::nonempty::String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 

--- a/packages/aleo-utils/src/block_processor.rs
+++ b/packages/aleo-utils/src/block_processor.rs
@@ -50,4 +50,3 @@ pub struct GatewayOutput {
     pub destination_address: [u8; 20],
     pub destination_chain: [u8; 32],
 }
-

--- a/packages/aleo-utils/src/json_like.rs
+++ b/packages/aleo-utils/src/json_like.rs
@@ -1,12 +1,10 @@
-use nom::{
-    IResult, Parser,
-    branch::alt,
-    bytes::complete::{tag, take_while_m_n},
-    character::complete::{alpha1, alphanumeric1, char, digit1, multispace0},
-    combinator::{all_consuming, map_parser, map_res, recognize},
-    multi::{many0, separated_list1},
-    sequence::{delimited, pair, preceded, separated_pair, terminated},
-};
+use nom::branch::alt;
+use nom::bytes::complete::{tag, take_while_m_n};
+use nom::character::complete::{alpha1, alphanumeric1, char, digit1, multispace0};
+use nom::combinator::{all_consuming, map_parser, map_res, recognize};
+use nom::multi::{many0, separated_list1};
+use nom::sequence::{delimited, pair, preceded, separated_pair, terminated};
+use nom::{IResult, Parser};
 
 /// Translate a Leo-like JSON string into a JSON string
 pub fn into_json(i: &str) -> Result<String, String> {
@@ -25,7 +23,8 @@ fn record(i: &str) -> IResult<&str, String> {
             preceded(multispace0, char('}')),
         ),
         |values| -> Result<String, ()> { Ok(format!("{{{}}}", values.join(","))) },
-    ).parse(i)
+    )
+    .parse(i)
 }
 
 fn field(i: &str) -> IResult<&str, String> {
@@ -36,7 +35,8 @@ fn field(i: &str) -> IResult<&str, String> {
             preceded(multispace0, expression),
         ),
         |(name, value)| -> Result<String, ()> { Ok(format!("\"{name}\":{value}")) },
-    ).parse(i)
+    )
+    .parse(i)
 }
 
 /// From Leo's grammar:
@@ -64,7 +64,8 @@ fn array_expression(i: &str) -> IResult<&str, String> {
             terminated(tag("]"), multispace0),
         ),
         |values| -> Result<String, ()> { Ok(format!("[{}]", values.join(","))) },
-    ).parse(i)
+    )
+    .parse(i)
 }
 
 fn expression(i: &str) -> IResult<&str, String> {
@@ -117,7 +118,8 @@ fn numeric_literal(i: &str) -> IResult<&str, String> {
             )),
         ),
         into,
-    ).parse(i)
+    )
+    .parse(i)
 }
 
 /// From Leo's grammar:
@@ -137,7 +139,8 @@ fn explicit_address_literal(i: &str) -> IResult<&str, String> {
             take_while_m_n(58, 58, is_ascii_lowercase_or_ascii_digit),
         )),
         quote,
-    ).parse(i)
+    )
+    .parse(i)
 }
 
 fn is_ascii_lowercase_or_ascii_digit(i: char) -> bool {

--- a/packages/aleo-utils/src/lib.rs
+++ b/packages/aleo-utils/src/lib.rs
@@ -1,4 +1,3 @@
 pub mod block_processor;
 pub mod json_like;
 pub mod string_encoder;
-

--- a/packages/aleo-utils/src/string_encoder.rs
+++ b/packages/aleo-utils/src/string_encoder.rs
@@ -23,7 +23,7 @@ impl StringEncoder {
         }
 
         let bytes = input.as_bytes();
-        let mut buf = Vec::with_capacity((bytes.len() + 15) / 16);
+        let mut buf = Vec::with_capacity(bytes.len().div_ceil(16));
         let mut current_value: u128 = 0;
         let mut position = 0;
 

--- a/packages/axelar-wasm-addresses/src/lib.rs
+++ b/packages/axelar-wasm-addresses/src/lib.rs
@@ -79,8 +79,8 @@ pub mod address {
 #[cfg(test)]
 mod tests {
     use assert_ok::assert_ok;
-    use cosmwasm_std::testing::MockApi;
     use axelar_wasm_std::assert_err_contains;
+    use cosmwasm_std::testing::MockApi;
 
     use crate::address;
 


### PR DESCRIPTION
2. format changes.
3. Signers sorting is messy
4. ampd
4. verify-verifier-set simple unit-test
5. first aleo unit-test in multisig-prover

## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `exported` mod. If those types have already been defined somewhere else, then they should get re-exported in the `exported` mod


## Steps to Test

## Expected Behaviour

## Notes
