### PR TITLE
use 6 u128 numbers for address in Aleo. update snarkvm-cosmos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,7 @@ version = "0.1.0"
 dependencies = [
  "aleo-types",
  "aleo-utils",
+ "axelar-wasm-std",
  "cosmwasm-std",
  "error-stack",
  "hex",
@@ -145,12 +146,27 @@ version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ec648bb4d936c62d63cb85983059c7fecd92175912c145470da3b03010c7c6"
 dependencies = [
- "aleo-std-cpu",
- "aleo-std-profiler",
- "aleo-std-storage",
- "aleo-std-time",
- "aleo-std-timed",
- "aleo-std-timer",
+ "aleo-std-cpu 0.1.4",
+ "aleo-std-profiler 0.1.15",
+ "aleo-std-storage 0.1.7",
+ "aleo-std-time 0.1.2",
+ "aleo-std-timed 0.1.2",
+ "aleo-std-timer 0.1.2",
+]
+
+[[package]]
+name = "aleo-std"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d2fd9bf7b4949480ce03d1f4dfce6e2956bde268808a05ac8e667f0e1ed9907"
+dependencies = [
+ "aleo-std-cpu 1.0.1",
+ "aleo-std-profiler 1.0.1",
+ "aleo-std-storage 1.0.1",
+ "aleo-std-time 1.0.1",
+ "aleo-std-timed 1.0.1",
+ "aleo-std-timer 1.0.1",
+ "walkdir",
 ]
 
 [[package]]
@@ -160,10 +176,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7527351aa675fdbe6a1902de3cf913ff7d50ccd6822f1562be374bdd85eaefb8"
 
 [[package]]
+name = "aleo-std-cpu"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b957faa45f9be4488020abcb689dfe91a4bcd9993bed454b55df5c1f4beb19"
+
+[[package]]
 name = "aleo-std-profiler"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf055ddb2f54fa86394d19d87e7956df2f3cafff489fc14c0f48f2f80664c3d"
+
+[[package]]
+name = "aleo-std-profiler"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3437b42d4334bfcabdec55a5fb5f423ba21de9d7a8dec3cf7857f01a46d50afc"
 
 [[package]]
 name = "aleo-std-storage"
@@ -175,10 +203,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "aleo-std-storage"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfd8973bd8bc50f7b1110ca51a00b57a4f4dd61d5cfc2d7a3f5ad0f98418726a"
+dependencies = [
+ "dirs 4.0.0",
+ "tempfile",
+]
+
+[[package]]
 name = "aleo-std-time"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f2a841f04c2eaeb5a95312e5201a9e4b7c95b64ca99870d6bd2e2376df540a"
+dependencies = [
+ "proc-macro2 1.0.94",
+ "quote 1.0.40",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "aleo-std-time"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8127eaa610f323cb882c78b625fab0d7752cee741faa3e0b9d50b5c71c6f2d8d"
 dependencies = [
  "proc-macro2 1.0.94",
  "quote 1.0.40",
@@ -197,10 +246,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "aleo-std-timed"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a410927dec807eef79e31718bbc7f506356b8bdcbed210f670d91a09a629041"
+dependencies = [
+ "proc-macro2 1.0.94",
+ "quote 1.0.40",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "aleo-std-timer"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e4f181fc1a372e8ceff89612e5c9b13f72bff5b066da9f8d6827ae65af492c4"
+
+[[package]]
+name = "aleo-std-timer"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14edf4007a98323f763701688bcbe3bc6ecf33e20c3a81b3eb8d6661ff01b217"
 
 [[package]]
 name = "aleo-types"
@@ -10231,41 +10297,11 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "1.1.0"
-source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#58f6f20eaba6bf32959a818e69c2222571b5d457"
-dependencies = [
- "aleo-std",
- "anyhow",
- "blake2",
- "cfg-if",
- "fxhash",
- "hashbrown 0.14.5",
- "hex",
- "indexmap 2.8.0",
- "itertools 0.11.0",
- "num-traits",
- "parking_lot",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
- "rayon",
- "serde",
- "sha2 0.10.8",
- "smallvec",
- "snarkvm-curves 1.1.0",
- "snarkvm-fields 1.1.0",
- "snarkvm-parameters 1.1.0",
- "snarkvm-utilities 1.1.0",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "snarkvm-algorithms"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6d03d5bbfda6b8aac225c4309010f1709cdb82b29b0a4c9b2288cb626b365c"
 dependencies = [
- "aleo-std",
+ "aleo-std 0.1.24",
  "anyhow",
  "blake2",
  "cfg-if",
@@ -10287,6 +10323,36 @@ dependencies = [
  "snarkvm-fields 1.5.0",
  "snarkvm-parameters 1.5.0",
  "snarkvm-utilities 1.5.0",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "snarkvm-algorithms"
+version = "3.7.1"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm-2#18884f09b33a2f4eb01e58ff659647cd2324eb85"
+dependencies = [
+ "aleo-std 1.0.1",
+ "anyhow",
+ "blake2",
+ "cfg-if",
+ "fxhash",
+ "hashbrown 0.14.5",
+ "hex",
+ "indexmap 2.8.0",
+ "itertools 0.11.0",
+ "num-traits",
+ "parking_lot",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "rayon",
+ "serde",
+ "sha2 0.10.8",
+ "smallvec",
+ "snarkvm-curves 3.7.1",
+ "snarkvm-fields 3.7.1",
+ "snarkvm-parameters 3.7.1",
+ "snarkvm-utilities 3.7.1",
  "thiserror 2.0.12",
 ]
 
@@ -10510,17 +10576,6 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "1.1.0"
-source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#58f6f20eaba6bf32959a818e69c2222571b5d457"
-dependencies = [
- "bs58 0.5.1",
- "snarkvm-console-network 1.1.0",
- "snarkvm-console-types 1.1.0",
- "zeroize",
-]
-
-[[package]]
-name = "snarkvm-console-account"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b22d31e941b5cd50ae70b8e428a0c11382a438ac3c3b48fae255a73dd2d6f67f"
@@ -10532,16 +10587,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "snarkvm-console-algorithms"
-version = "1.1.0"
-source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#58f6f20eaba6bf32959a818e69c2222571b5d457"
+name = "snarkvm-console-account"
+version = "3.7.1"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm-2#18884f09b33a2f4eb01e58ff659647cd2324eb85"
 dependencies = [
- "blake2s_simd",
- "smallvec",
- "snarkvm-console-types 1.1.0",
- "snarkvm-fields 1.1.0",
- "snarkvm-utilities 1.1.0",
- "tiny-keccak",
+ "bs58 0.5.1",
+ "snarkvm-console-network 3.7.1",
+ "snarkvm-console-types 3.7.1",
+ "zeroize",
 ]
 
 [[package]]
@@ -10559,14 +10612,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "snarkvm-console-collections"
-version = "1.1.0"
-source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#58f6f20eaba6bf32959a818e69c2222571b5d457"
+name = "snarkvm-console-algorithms"
+version = "3.7.1"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm-2#18884f09b33a2f4eb01e58ff659647cd2324eb85"
 dependencies = [
- "aleo-std",
- "rayon",
- "snarkvm-console-algorithms 1.1.0",
- "snarkvm-console-types 1.1.0",
+ "blake2s_simd",
+ "smallvec",
+ "snarkvm-console-types 3.7.1",
+ "snarkvm-fields 3.7.1",
+ "snarkvm-utilities 3.7.1",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -10575,33 +10630,21 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd380b7e58fecc54395582eae3f20ed7534a4ab37dfb0978657e57c441388d03"
 dependencies = [
- "aleo-std",
+ "aleo-std 0.1.24",
  "rayon",
  "snarkvm-console-algorithms 1.5.0",
  "snarkvm-console-types 1.5.0",
 ]
 
 [[package]]
-name = "snarkvm-console-network"
-version = "1.1.0"
-source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#58f6f20eaba6bf32959a818e69c2222571b5d457"
+name = "snarkvm-console-collections"
+version = "3.7.1"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm-2#18884f09b33a2f4eb01e58ff659647cd2324eb85"
 dependencies = [
- "anyhow",
- "indexmap 2.8.0",
- "itertools 0.11.0",
- "lazy_static",
- "once_cell",
- "paste",
- "serde",
- "snarkvm-algorithms 1.1.0",
- "snarkvm-console-algorithms 1.1.0",
- "snarkvm-console-collections 1.1.0",
- "snarkvm-console-network-environment 1.1.0",
- "snarkvm-console-types 1.1.0",
- "snarkvm-curves 1.1.0",
- "snarkvm-fields 1.1.0",
- "snarkvm-parameters 1.1.0",
- "snarkvm-utilities 1.1.0",
+ "aleo-std 1.0.1",
+ "rayon",
+ "snarkvm-console-algorithms 3.7.1",
+ "snarkvm-console-types 3.7.1",
 ]
 
 [[package]]
@@ -10629,21 +10672,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "snarkvm-console-network-environment"
-version = "1.1.0"
-source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#58f6f20eaba6bf32959a818e69c2222571b5d457"
+name = "snarkvm-console-network"
+version = "3.7.1"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm-2#18884f09b33a2f4eb01e58ff659647cd2324eb85"
 dependencies = [
  "anyhow",
- "bech32 0.9.1",
+ "indexmap 2.8.0",
  "itertools 0.11.0",
- "nom 7.1.3",
- "num-traits",
- "rand 0.8.5",
+ "lazy_static",
+ "once_cell",
+ "paste",
  "serde",
- "snarkvm-curves 1.1.0",
- "snarkvm-fields 1.1.0",
- "snarkvm-utilities 1.1.0",
- "zeroize",
+ "snarkvm-algorithms 3.7.1",
+ "snarkvm-console-algorithms 3.7.1",
+ "snarkvm-console-collections 3.7.1",
+ "snarkvm-console-network-environment 3.7.1",
+ "snarkvm-console-types 3.7.1",
+ "snarkvm-curves 3.7.1",
+ "snarkvm-fields 3.7.1",
+ "snarkvm-parameters 3.7.1",
+ "snarkvm-utilities 3.7.1",
 ]
 
 [[package]]
@@ -10666,25 +10714,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "snarkvm-console-program"
-version = "1.1.0"
-source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#58f6f20eaba6bf32959a818e69c2222571b5d457"
+name = "snarkvm-console-network-environment"
+version = "3.7.1"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm-2#18884f09b33a2f4eb01e58ff659647cd2324eb85"
 dependencies = [
- "enum-iterator 2.1.0",
- "enum_index",
- "enum_index_derive",
- "indexmap 2.8.0",
- "num-derive 0.4.2",
+ "anyhow",
+ "bech32 0.9.1",
+ "itertools 0.11.0",
+ "nom 7.1.3",
  "num-traits",
- "once_cell",
- "paste",
- "serde_json",
- "snarkvm-console-account 1.1.0",
- "snarkvm-console-algorithms 1.1.0",
- "snarkvm-console-collections 1.1.0",
- "snarkvm-console-network 1.1.0",
- "snarkvm-console-types 1.1.0",
- "snarkvm-utilities 1.1.0",
+ "rand 0.8.5",
+ "serde",
+ "snarkvm-curves 3.7.1",
+ "snarkvm-fields 3.7.1",
+ "snarkvm-utilities 3.7.1",
+ "zeroize",
 ]
 
 [[package]]
@@ -10711,18 +10755,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "snarkvm-console-types"
-version = "1.1.0"
-source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#58f6f20eaba6bf32959a818e69c2222571b5d457"
+name = "snarkvm-console-program"
+version = "3.7.1"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm-2#18884f09b33a2f4eb01e58ff659647cd2324eb85"
 dependencies = [
- "snarkvm-console-network-environment 1.1.0",
- "snarkvm-console-types-address 1.1.0",
- "snarkvm-console-types-boolean 1.1.0",
- "snarkvm-console-types-field 1.1.0",
- "snarkvm-console-types-group 1.1.0",
- "snarkvm-console-types-integers 1.1.0",
- "snarkvm-console-types-scalar 1.1.0",
- "snarkvm-console-types-string 1.1.0",
+ "enum-iterator 2.1.0",
+ "enum_index",
+ "enum_index_derive",
+ "indexmap 2.8.0",
+ "num-derive 0.4.2",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "serde_json",
+ "snarkvm-console-account 3.7.1",
+ "snarkvm-console-algorithms 3.7.1",
+ "snarkvm-console-collections 3.7.1",
+ "snarkvm-console-network 3.7.1",
+ "snarkvm-console-types 3.7.1",
+ "snarkvm-utilities 3.7.1",
 ]
 
 [[package]]
@@ -10742,14 +10793,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "snarkvm-console-types-address"
-version = "1.1.0"
-source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#58f6f20eaba6bf32959a818e69c2222571b5d457"
+name = "snarkvm-console-types"
+version = "3.7.1"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm-2#18884f09b33a2f4eb01e58ff659647cd2324eb85"
 dependencies = [
- "snarkvm-console-network-environment 1.1.0",
- "snarkvm-console-types-boolean 1.1.0",
- "snarkvm-console-types-field 1.1.0",
- "snarkvm-console-types-group 1.1.0",
+ "snarkvm-console-network-environment 3.7.1",
+ "snarkvm-console-types-address 3.7.1",
+ "snarkvm-console-types-boolean 3.7.1",
+ "snarkvm-console-types-field 3.7.1",
+ "snarkvm-console-types-group 3.7.1",
+ "snarkvm-console-types-integers 3.7.1",
+ "snarkvm-console-types-scalar 3.7.1",
+ "snarkvm-console-types-string 3.7.1",
 ]
 
 [[package]]
@@ -10765,11 +10820,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "snarkvm-console-types-boolean"
-version = "1.1.0"
-source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#58f6f20eaba6bf32959a818e69c2222571b5d457"
+name = "snarkvm-console-types-address"
+version = "3.7.1"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm-2#18884f09b33a2f4eb01e58ff659647cd2324eb85"
 dependencies = [
- "snarkvm-console-network-environment 1.1.0",
+ "snarkvm-console-network-environment 3.7.1",
+ "snarkvm-console-types-boolean 3.7.1",
+ "snarkvm-console-types-field 3.7.1",
+ "snarkvm-console-types-group 3.7.1",
 ]
 
 [[package]]
@@ -10782,13 +10840,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "snarkvm-console-types-field"
-version = "1.1.0"
-source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#58f6f20eaba6bf32959a818e69c2222571b5d457"
+name = "snarkvm-console-types-boolean"
+version = "3.7.1"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm-2#18884f09b33a2f4eb01e58ff659647cd2324eb85"
 dependencies = [
- "snarkvm-console-network-environment 1.1.0",
- "snarkvm-console-types-boolean 1.1.0",
- "zeroize",
+ "snarkvm-console-network-environment 3.7.1",
 ]
 
 [[package]]
@@ -10803,14 +10859,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "snarkvm-console-types-group"
-version = "1.1.0"
-source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#58f6f20eaba6bf32959a818e69c2222571b5d457"
+name = "snarkvm-console-types-field"
+version = "3.7.1"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm-2#18884f09b33a2f4eb01e58ff659647cd2324eb85"
 dependencies = [
- "snarkvm-console-network-environment 1.1.0",
- "snarkvm-console-types-boolean 1.1.0",
- "snarkvm-console-types-field 1.1.0",
- "snarkvm-console-types-scalar 1.1.0",
+ "snarkvm-console-network-environment 3.7.1",
+ "snarkvm-console-types-boolean 3.7.1",
+ "zeroize",
 ]
 
 [[package]]
@@ -10826,14 +10881,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "snarkvm-console-types-integers"
-version = "1.1.0"
-source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#58f6f20eaba6bf32959a818e69c2222571b5d457"
+name = "snarkvm-console-types-group"
+version = "3.7.1"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm-2#18884f09b33a2f4eb01e58ff659647cd2324eb85"
 dependencies = [
- "snarkvm-console-network-environment 1.1.0",
- "snarkvm-console-types-boolean 1.1.0",
- "snarkvm-console-types-field 1.1.0",
- "snarkvm-console-types-scalar 1.1.0",
+ "snarkvm-console-network-environment 3.7.1",
+ "snarkvm-console-types-boolean 3.7.1",
+ "snarkvm-console-types-field 3.7.1",
+ "snarkvm-console-types-scalar 3.7.1",
 ]
 
 [[package]]
@@ -10849,14 +10904,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "snarkvm-console-types-scalar"
-version = "1.1.0"
-source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#58f6f20eaba6bf32959a818e69c2222571b5d457"
+name = "snarkvm-console-types-integers"
+version = "3.7.1"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm-2#18884f09b33a2f4eb01e58ff659647cd2324eb85"
 dependencies = [
- "snarkvm-console-network-environment 1.1.0",
- "snarkvm-console-types-boolean 1.1.0",
- "snarkvm-console-types-field 1.1.0",
- "zeroize",
+ "snarkvm-console-network-environment 3.7.1",
+ "snarkvm-console-types-boolean 3.7.1",
+ "snarkvm-console-types-field 3.7.1",
+ "snarkvm-console-types-scalar 3.7.1",
 ]
 
 [[package]]
@@ -10872,14 +10927,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "snarkvm-console-types-string"
-version = "1.1.0"
-source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#58f6f20eaba6bf32959a818e69c2222571b5d457"
+name = "snarkvm-console-types-scalar"
+version = "3.7.1"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm-2#18884f09b33a2f4eb01e58ff659647cd2324eb85"
 dependencies = [
- "snarkvm-console-network-environment 1.1.0",
- "snarkvm-console-types-boolean 1.1.0",
- "snarkvm-console-types-field 1.1.0",
- "snarkvm-console-types-integers 1.1.0",
+ "snarkvm-console-network-environment 3.7.1",
+ "snarkvm-console-types-boolean 3.7.1",
+ "snarkvm-console-types-field 3.7.1",
+ "zeroize",
 ]
 
 [[package]]
@@ -10895,29 +10950,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "snarkvm-cosmwasm"
-version = "1.1.0"
-source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#58f6f20eaba6bf32959a818e69c2222571b5d457"
+name = "snarkvm-console-types-string"
+version = "3.7.1"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm-2#18884f09b33a2f4eb01e58ff659647cd2324eb85"
 dependencies = [
- "getrandom 0.2.15",
- "snarkvm-console-account 1.1.0",
- "snarkvm-console-network 1.1.0",
- "snarkvm-console-program 1.1.0",
- "snarkvm-console-types 1.1.0",
+ "snarkvm-console-network-environment 3.7.1",
+ "snarkvm-console-types-boolean 3.7.1",
+ "snarkvm-console-types-field 3.7.1",
+ "snarkvm-console-types-integers 3.7.1",
 ]
 
 [[package]]
-name = "snarkvm-curves"
-version = "1.1.0"
-source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#58f6f20eaba6bf32959a818e69c2222571b5d457"
+name = "snarkvm-cosmwasm"
+version = "3.7.1"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm-2#18884f09b33a2f4eb01e58ff659647cd2324eb85"
 dependencies = [
- "rand 0.8.5",
- "rayon",
- "rustc_version 0.4.1",
- "serde",
- "snarkvm-fields 1.1.0",
- "snarkvm-utilities 1.1.0",
- "thiserror 1.0.69",
+ "getrandom 0.2.15",
+ "snarkvm-console-account 3.7.1",
+ "snarkvm-console-network 3.7.1",
+ "snarkvm-console-program 3.7.1",
+ "snarkvm-console-types 3.7.1",
 ]
 
 [[package]]
@@ -10936,20 +10988,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "snarkvm-fields"
-version = "1.1.0"
-source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#58f6f20eaba6bf32959a818e69c2222571b5d457"
+name = "snarkvm-curves"
+version = "3.7.1"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm-2#18884f09b33a2f4eb01e58ff659647cd2324eb85"
 dependencies = [
- "aleo-std",
- "anyhow",
- "itertools 0.11.0",
- "num-traits",
  "rand 0.8.5",
  "rayon",
+ "rustc_version 0.4.1",
  "serde",
- "snarkvm-utilities 1.1.0",
- "thiserror 1.0.69",
- "zeroize",
+ "snarkvm-fields 3.7.1",
+ "snarkvm-utilities 3.7.1",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -10958,7 +11007,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8802e5384e919ff5942c5b0f70291700a5e8362a85dbc2dee18919e1ca26a824"
 dependencies = [
- "aleo-std",
+ "aleo-std 0.1.24",
  "anyhow",
  "itertools 0.11.0",
  "num-traits",
@@ -10971,12 +11020,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "snarkvm-fields"
+version = "3.7.1"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm-2#18884f09b33a2f4eb01e58ff659647cd2324eb85"
+dependencies = [
+ "aleo-std 1.0.1",
+ "anyhow",
+ "itertools 0.11.0",
+ "num-traits",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "snarkvm-utilities 3.7.1",
+ "thiserror 2.0.12",
+ "zeroize",
+]
+
+[[package]]
 name = "snarkvm-ledger"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67df44c37e78db055e26ca8b5048876992c249923908bbd5d1bd9e8401ce0528"
 dependencies = [
- "aleo-std",
+ "aleo-std 0.1.24",
  "anyhow",
  "indexmap 2.8.0",
  "parking_lot",
@@ -11141,7 +11207,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c5f93abd53ea3ec6b9cbe0797557bebfbdd59b839ca465bb07befa40db51b7a"
 dependencies = [
- "aleo-std",
+ "aleo-std 0.1.24",
  "anyhow",
  "bincode",
  "indexmap 2.8.0",
@@ -11162,7 +11228,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25165caab828aad01d810604ee749c002701a356d9510bc19750043b28bfee24"
 dependencies = [
- "aleo-std",
+ "aleo-std 0.1.24",
  "anyhow",
  "colored",
  "indexmap 2.8.0",
@@ -11198,7 +11264,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9453fac2b84725e263e69e0e5c3b74bf30aeb26ca293e5aa85dc45e386edbd3"
 dependencies = [
- "aleo-std-storage",
+ "aleo-std-storage 0.1.7",
  "anyhow",
  "bincode",
  "indexmap 2.8.0",
@@ -11222,37 +11288,11 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "1.1.0"
-source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#58f6f20eaba6bf32959a818e69c2222571b5d457"
-dependencies = [
- "aleo-std",
- "anyhow",
- "bincode",
- "cfg-if",
- "colored",
- "curl",
- "getrandom 0.2.15",
- "hex",
- "indexmap 2.8.0",
- "itertools 0.11.0",
- "lazy_static",
- "parking_lot",
- "paste",
- "rand 0.8.5",
- "serde_json",
- "sha2 0.10.8",
- "snarkvm-curves 1.1.0",
- "snarkvm-utilities 1.1.0",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "snarkvm-parameters"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc4e2b58b3be26b9de68a12ad0d81606508cbec2b3dff46ea7096ec5f7a83af9"
 dependencies = [
- "aleo-std",
+ "aleo-std 0.1.24",
  "anyhow",
  "bincode",
  "cfg-if",
@@ -11273,12 +11313,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "snarkvm-parameters"
+version = "3.7.1"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm-2#18884f09b33a2f4eb01e58ff659647cd2324eb85"
+dependencies = [
+ "aleo-std 1.0.1",
+ "anyhow",
+ "bincode",
+ "cfg-if",
+ "colored",
+ "curl",
+ "getrandom 0.2.15",
+ "hex",
+ "indexmap 2.8.0",
+ "itertools 0.11.0",
+ "lazy_static",
+ "parking_lot",
+ "paste",
+ "rand 0.8.5",
+ "serde_json",
+ "sha2 0.10.8",
+ "snarkvm-curves 3.7.1",
+ "snarkvm-utilities 3.7.1",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "snarkvm-synthesizer"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a3d89f7876d33933127b1edf150ec84f05541981bbf0e792d7b4659390ae616"
 dependencies = [
- "aleo-std",
+ "aleo-std 0.1.24",
  "anyhow",
  "indexmap 2.8.0",
  "itertools 0.11.0",
@@ -11310,7 +11376,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c0927ecd53ae5c53f7af973cab573777c0aaa5db2f342d12094b8220c23f12"
 dependencies = [
- "aleo-std",
+ "aleo-std 0.1.24",
  "colored",
  "indexmap 2.8.0",
  "once_cell",
@@ -11362,33 +11428,11 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "1.1.0"
-source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#58f6f20eaba6bf32959a818e69c2222571b5d457"
-dependencies = [
- "aleo-std",
- "anyhow",
- "bincode",
- "cosmwasm-std",
- "num-bigint 0.4.6",
- "num_cpus",
- "rand 0.8.5",
- "rand_xorshift",
- "rayon",
- "serde",
- "serde_json",
- "smol_str",
- "snarkvm-utilities-derives 1.1.0",
- "thiserror 1.0.69",
- "zeroize",
-]
-
-[[package]]
-name = "snarkvm-utilities"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf7f21d4639694bac613eb77f48e0e8615dea51249a16e981c3da17b99ca6bad"
 dependencies = [
- "aleo-std",
+ "aleo-std 0.1.24",
  "anyhow",
  "bincode",
  "num-bigint 0.4.6",
@@ -11405,9 +11449,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "snarkvm-utilities"
+version = "3.7.1"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm-2#18884f09b33a2f4eb01e58ff659647cd2324eb85"
+dependencies = [
+ "aleo-std 1.0.1",
+ "anyhow",
+ "bincode",
+ "cosmwasm-std",
+ "num-bigint 0.4.6",
+ "num_cpus",
+ "rand 0.8.5",
+ "rand_xorshift",
+ "rayon",
+ "serde",
+ "serde_json",
+ "smol_str",
+ "snarkvm-utilities-derives 3.7.1",
+ "thiserror 2.0.12",
+ "zeroize",
+]
+
+[[package]]
 name = "snarkvm-utilities-derives"
-version = "1.1.0"
-source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm#58f6f20eaba6bf32959a818e69c2222571b5d457"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcb819302836476d7b1dc4bf8ae0fb5315c6e6a50122ff4bf78e34b1aa6af42"
 dependencies = [
  "proc-macro2 1.0.94",
  "quote 1.0.40",
@@ -11416,9 +11483,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcb819302836476d7b1dc4bf8ae0fb5315c6e6a50122ff4bf78e34b1aa6af42"
+version = "3.7.1"
+source = "git+https://github.com/eigerco/snarkVM?branch=cosmwasm-2#18884f09b33a2f4eb01e58ff659647cd2324eb85"
 dependencies = [
  "proc-macro2 1.0.94",
  "quote 1.0.40",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [
-  "ampd", 
+  "ampd",
   "ampd-handlers",
   "contracts/*",
   "external-gateways/*",
@@ -108,7 +108,7 @@ tokio-util = "0.7.11"
 voting-verifier = { version = "^1.1.0", path = "contracts/voting-verifier" }
 axelar-core-std = { version = "^1.0.0", path = "packages/axelar-core-std" }
 proc-macro2 = "1.0.92"
-snarkvm-cosmwasm = { git = "https://github.com/eigerco/snarkVM", branch = "cosmwasm" }
+snarkvm-cosmwasm = { git = "https://github.com/eigerco/snarkVM", branch = "cosmwasm-2" }
 aleo-utils = { path = "packages/aleo-utils" }
 
 [workspace.lints.clippy]

--- a/packages/aleo-gateway/src/message.rs
+++ b/packages/aleo-gateway/src/message.rs
@@ -60,7 +60,7 @@ impl AleoValue for Message {
             }
         );
 
-        const SOURCE_ADDRESS_LEN: usize = 4;
+        const SOURCE_ADDRESS_LEN: usize = 6;
         let source_address = StringEncoder::encode_string(self.source_address.as_str())
             .map_err(|e| Report::new(Error::from(e)))?;
 
@@ -73,7 +73,7 @@ impl AleoValue for Message {
             }
         );
 
-        const CONTRACT_ADDRESS_LEN: usize = 4;
+        const CONTRACT_ADDRESS_LEN: usize = 6;
         let contract_address = StringEncoder::encode_string(self.destination_address.as_str())
             .map_err(|e| Report::new(Error::from(e)))?;
 


### PR DESCRIPTION
## Description

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues

## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [EnsurePermissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod


## Steps to Test

## Expected Behaviour

## Notes
