### PR TITLE
feat: aleo address check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "aleo-gateway"
+version = "0.1.0"
+dependencies = [
+ "cosmwasm-schema",
+ "snarkvm-cosmwasm",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "aleo-std"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d2fd9bf7b4949480ce03d1f4dfce6e2956bde268808a05ac8e667f0e1ed9907"
+dependencies = [
+ "aleo-std-cpu",
+ "aleo-std-profiler",
+ "aleo-std-storage",
+ "aleo-std-time",
+ "aleo-std-timed",
+ "aleo-std-timer",
+ "walkdir",
+]
+
+[[package]]
+name = "aleo-std-cpu"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b957faa45f9be4488020abcb689dfe91a4bcd9993bed454b55df5c1f4beb19"
+
+[[package]]
+name = "aleo-std-profiler"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3437b42d4334bfcabdec55a5fb5f423ba21de9d7a8dec3cf7857f01a46d50afc"
+
+[[package]]
+name = "aleo-std-storage"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfd8973bd8bc50f7b1110ca51a00b57a4f4dd61d5cfc2d7a3f5ad0f98418726a"
+dependencies = [
+ "dirs 4.0.0",
+ "tempfile",
+]
+
+[[package]]
+name = "aleo-std-time"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8127eaa610f323cb882c78b625fab0d7752cee741faa3e0b9d50b5c71c6f2d8d"
+dependencies = [
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "aleo-std-timed"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a410927dec807eef79e31718bbc7f506356b8bdcbed210f670d91a09a629041"
+dependencies = [
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "aleo-std-timer"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14edf4007a98323f763701688bcbe3bc6ecf33e20c3a81b3eb8d6661ff01b217"
+
+[[package]]
 name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,7 +336,7 @@ dependencies = [
  "cosmwasm-std",
  "der 0.7.10",
  "deref-derive",
- "dirs",
+ "dirs 5.0.1",
  "ed25519-dalek 2.1.1",
  "elliptic-curve",
  "enum-display-derive",
@@ -1060,6 +1134,7 @@ dependencies = [
 name = "axelar-wasm-std"
 version = "1.0.0"
 dependencies = [
+ "aleo-gateway",
  "alloy-primitives",
  "assert_ok",
  "axelar-wasm-std-derive",
@@ -2623,6 +2698,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "curl"
+version = "0.4.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e2d5c8f48d9c0c23250e52b55e82a6ab4fdba6650c931f5a0a57a43abda812b"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.82+curl-8.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4d63638b5ec65f1a4ae945287b3fd035be4554bbaf211901159c9a2a74fb5be"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3016,11 +3121,20 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -3031,6 +3145,17 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -3348,6 +3473,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c280b9e6b3ae19e152d8e31cf47f18389781e119d4013a2a2bb0180e5facc635"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
 name = "enum-iterator-derive"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3368,6 +3502,22 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "enum_index"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5532bdea562e7be83060c36185eecccba82fe16729d2eaad2891d65417656dd"
+
+[[package]]
+name = "enum_index_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ab22c8085548bf06190113dca556e149ecdbb05ae5b972a2b9899f26b944ee4"
+dependencies = [
+ "quote 0.3.15",
+ "syn 0.11.11",
 ]
 
 [[package]]
@@ -5855,6 +6005,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-sys"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8152,6 +8314,12 @@ dependencies = [
 
 [[package]]
 name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+
+[[package]]
+name = "quote"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
@@ -9907,10 +10075,345 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "snap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
+name = "snarkvm-algorithms"
+version = "3.8.0"
+source = "git+https://github.com/eigerco/snarkVM?tag=snarkvm-with-cosmwasm#379958aeb4914e16985f79d420041b490613a50a"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "blake2",
+ "cfg-if",
+ "fxhash",
+ "hashbrown 0.14.5",
+ "hex",
+ "indexmap 2.9.0",
+ "itertools 0.11.0",
+ "num-traits",
+ "parking_lot",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "rayon",
+ "serde",
+ "sha2 0.10.9",
+ "smallvec",
+ "snarkvm-curves",
+ "snarkvm-fields",
+ "snarkvm-parameters",
+ "snarkvm-utilities",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "snarkvm-console"
+version = "3.8.0"
+source = "git+https://github.com/eigerco/snarkVM?tag=snarkvm-with-cosmwasm#379958aeb4914e16985f79d420041b490613a50a"
+dependencies = [
+ "snarkvm-console-account",
+ "snarkvm-console-algorithms",
+ "snarkvm-console-collections",
+ "snarkvm-console-network",
+ "snarkvm-console-program",
+ "snarkvm-console-types",
+]
+
+[[package]]
+name = "snarkvm-console-account"
+version = "3.8.0"
+source = "git+https://github.com/eigerco/snarkVM?tag=snarkvm-with-cosmwasm#379958aeb4914e16985f79d420041b490613a50a"
+dependencies = [
+ "bs58 0.5.1",
+ "snarkvm-console-network",
+ "snarkvm-console-types",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-console-algorithms"
+version = "3.8.0"
+source = "git+https://github.com/eigerco/snarkVM?tag=snarkvm-with-cosmwasm#379958aeb4914e16985f79d420041b490613a50a"
+dependencies = [
+ "blake2s_simd",
+ "smallvec",
+ "snarkvm-console-types",
+ "snarkvm-fields",
+ "snarkvm-utilities",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "snarkvm-console-collections"
+version = "3.8.0"
+source = "git+https://github.com/eigerco/snarkVM?tag=snarkvm-with-cosmwasm#379958aeb4914e16985f79d420041b490613a50a"
+dependencies = [
+ "aleo-std",
+ "rayon",
+ "snarkvm-console-algorithms",
+ "snarkvm-console-types",
+]
+
+[[package]]
+name = "snarkvm-console-network"
+version = "3.8.0"
+source = "git+https://github.com/eigerco/snarkVM?tag=snarkvm-with-cosmwasm#379958aeb4914e16985f79d420041b490613a50a"
+dependencies = [
+ "anyhow",
+ "indexmap 2.9.0",
+ "itertools 0.11.0",
+ "lazy_static",
+ "once_cell",
+ "paste",
+ "serde",
+ "snarkvm-algorithms",
+ "snarkvm-console-algorithms",
+ "snarkvm-console-collections",
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types",
+ "snarkvm-curves",
+ "snarkvm-fields",
+ "snarkvm-parameters",
+ "snarkvm-utilities",
+]
+
+[[package]]
+name = "snarkvm-console-network-environment"
+version = "3.8.0"
+source = "git+https://github.com/eigerco/snarkVM?tag=snarkvm-with-cosmwasm#379958aeb4914e16985f79d420041b490613a50a"
+dependencies = [
+ "anyhow",
+ "bech32 0.9.1",
+ "itertools 0.11.0",
+ "nom",
+ "num-traits",
+ "rand 0.8.5",
+ "serde",
+ "snarkvm-curves",
+ "snarkvm-fields",
+ "snarkvm-utilities",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-console-program"
+version = "3.8.0"
+source = "git+https://github.com/eigerco/snarkVM?tag=snarkvm-with-cosmwasm#379958aeb4914e16985f79d420041b490613a50a"
+dependencies = [
+ "enum-iterator 2.1.0",
+ "enum_index",
+ "enum_index_derive",
+ "indexmap 2.9.0",
+ "num-derive",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "serde_json",
+ "snarkvm-console-account",
+ "snarkvm-console-algorithms",
+ "snarkvm-console-collections",
+ "snarkvm-console-network",
+ "snarkvm-console-types",
+ "snarkvm-utilities",
+]
+
+[[package]]
+name = "snarkvm-console-types"
+version = "3.8.0"
+source = "git+https://github.com/eigerco/snarkVM?tag=snarkvm-with-cosmwasm#379958aeb4914e16985f79d420041b490613a50a"
+dependencies = [
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-address",
+ "snarkvm-console-types-boolean",
+ "snarkvm-console-types-field",
+ "snarkvm-console-types-group",
+ "snarkvm-console-types-integers",
+ "snarkvm-console-types-scalar",
+ "snarkvm-console-types-string",
+]
+
+[[package]]
+name = "snarkvm-console-types-address"
+version = "3.8.0"
+source = "git+https://github.com/eigerco/snarkVM?tag=snarkvm-with-cosmwasm#379958aeb4914e16985f79d420041b490613a50a"
+dependencies = [
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-boolean",
+ "snarkvm-console-types-field",
+ "snarkvm-console-types-group",
+]
+
+[[package]]
+name = "snarkvm-console-types-boolean"
+version = "3.8.0"
+source = "git+https://github.com/eigerco/snarkVM?tag=snarkvm-with-cosmwasm#379958aeb4914e16985f79d420041b490613a50a"
+dependencies = [
+ "snarkvm-console-network-environment",
+]
+
+[[package]]
+name = "snarkvm-console-types-field"
+version = "3.8.0"
+source = "git+https://github.com/eigerco/snarkVM?tag=snarkvm-with-cosmwasm#379958aeb4914e16985f79d420041b490613a50a"
+dependencies = [
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-boolean",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-console-types-group"
+version = "3.8.0"
+source = "git+https://github.com/eigerco/snarkVM?tag=snarkvm-with-cosmwasm#379958aeb4914e16985f79d420041b490613a50a"
+dependencies = [
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-boolean",
+ "snarkvm-console-types-field",
+ "snarkvm-console-types-scalar",
+]
+
+[[package]]
+name = "snarkvm-console-types-integers"
+version = "3.8.0"
+source = "git+https://github.com/eigerco/snarkVM?tag=snarkvm-with-cosmwasm#379958aeb4914e16985f79d420041b490613a50a"
+dependencies = [
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-boolean",
+ "snarkvm-console-types-field",
+ "snarkvm-console-types-scalar",
+]
+
+[[package]]
+name = "snarkvm-console-types-scalar"
+version = "3.8.0"
+source = "git+https://github.com/eigerco/snarkVM?tag=snarkvm-with-cosmwasm#379958aeb4914e16985f79d420041b490613a50a"
+dependencies = [
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-boolean",
+ "snarkvm-console-types-field",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-console-types-string"
+version = "3.8.0"
+source = "git+https://github.com/eigerco/snarkVM?tag=snarkvm-with-cosmwasm#379958aeb4914e16985f79d420041b490613a50a"
+dependencies = [
+ "snarkvm-console-network-environment",
+ "snarkvm-console-types-boolean",
+ "snarkvm-console-types-field",
+ "snarkvm-console-types-integers",
+]
+
+[[package]]
+name = "snarkvm-cosmwasm"
+version = "3.8.0"
+source = "git+https://github.com/eigerco/snarkVM?tag=snarkvm-with-cosmwasm#379958aeb4914e16985f79d420041b490613a50a"
+dependencies = [
+ "snarkvm-console",
+]
+
+[[package]]
+name = "snarkvm-curves"
+version = "3.8.0"
+source = "git+https://github.com/eigerco/snarkVM?tag=snarkvm-with-cosmwasm#379958aeb4914e16985f79d420041b490613a50a"
+dependencies = [
+ "rand 0.8.5",
+ "rayon",
+ "rustc_version 0.4.1",
+ "serde",
+ "snarkvm-fields",
+ "snarkvm-utilities",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "snarkvm-fields"
+version = "3.8.0"
+source = "git+https://github.com/eigerco/snarkVM?tag=snarkvm-with-cosmwasm#379958aeb4914e16985f79d420041b490613a50a"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "itertools 0.11.0",
+ "num-traits",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "snarkvm-utilities",
+ "thiserror 2.0.12",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-parameters"
+version = "3.8.0"
+source = "git+https://github.com/eigerco/snarkVM?tag=snarkvm-with-cosmwasm#379958aeb4914e16985f79d420041b490613a50a"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "bincode",
+ "cfg-if",
+ "colored",
+ "curl",
+ "getrandom 0.2.16",
+ "hex",
+ "indexmap 2.9.0",
+ "itertools 0.11.0",
+ "lazy_static",
+ "parking_lot",
+ "paste",
+ "rand 0.8.5",
+ "serde_json",
+ "sha2 0.10.9",
+ "snarkvm-curves",
+ "snarkvm-utilities",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "snarkvm-utilities"
+version = "3.8.0"
+source = "git+https://github.com/eigerco/snarkVM?tag=snarkvm-with-cosmwasm#379958aeb4914e16985f79d420041b490613a50a"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "bincode",
+ "cosmwasm-std",
+ "num-bigint 0.4.6",
+ "num_cpus",
+ "rand 0.8.5",
+ "rand_xorshift",
+ "rayon",
+ "serde",
+ "serde_json",
+ "smol_str",
+ "snarkvm-utilities-derives",
+ "thiserror 2.0.12",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-utilities-derives"
+version = "3.8.0"
+source = "git+https://github.com/eigerco/snarkVM?tag=snarkvm-with-cosmwasm#379958aeb4914e16985f79d420041b490613a50a"
+dependencies = [
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "socket2"
@@ -10549,7 +11052,7 @@ checksum = "7702436e95dadea0553a5b29b42271b81da61c2ae78e4425c74fadd7ce2252b5"
 dependencies = [
  "base64 0.22.1",
  "bincode",
- "enum-iterator",
+ "enum-iterator 1.5.0",
  "itertools 0.12.1",
  "libc",
  "log",
@@ -11005,7 +11508,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a4cb26e92fe54cff708393ea63cb4b5c983cd1c86c5b5d4962523f57e95239e"
 dependencies = [
  "eager",
- "enum-iterator",
+ "enum-iterator 1.5.0",
  "solana-sdk",
 ]
 
@@ -12106,6 +12609,17 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+dependencies = [
+ "quote 0.3.15",
+ "synom",
+ "unicode-xid 0.0.4",
+]
+
+[[package]]
+name = "syn"
 version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
@@ -12162,6 +12676,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 dependencies = [
  "futures-core",
+]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+dependencies = [
+ "unicode-xid 0.0.4",
 ]
 
 [[package]]
@@ -13363,6 +13886,12 @@ checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+
+[[package]]
+name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
@@ -13545,6 +14074,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 name = "voting-verifier"
 version = "1.1.0"
 dependencies = [
+ "aleo-gateway",
  "alloy-primitives",
  "assert_ok",
  "axelar-wasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ pattern = "amplifier-lints"
 rev = "ebfed5dde7990739367c182338a3b6c2dd11ef09"
 
 [workspace.dependencies]
+aleo-gateway = { path = "packages/aleo-gateway" }
 alloy-primitives = { version = "0.7.6", default-features = false, features = [
   "std",
 ] }
@@ -100,6 +101,7 @@ service-registry = { version = "^1.1.0", path = "contracts/service-registry" }
 service-registry-api = { version = "^1.0.0", path = "packages/service-registry-api" }
 sha3 = { version = "0.10.8", default-features = false, features = [] }
 signature-verifier-api = { version = "^1.0.0", path = "packages/signature-verifier-api" }
+snarkvm-cosmwasm = { git = "https://github.com/eigerco/snarkVM", tag = "snarkvm-with-cosmwasm" }
 starknet-checked-felt = { version = "^1.0.0", path = "packages/starknet-checked-felt" }
 starknet-core = "0.12.0"
 starknet-providers = "0.12.0"

--- a/contracts/voting-verifier/Cargo.toml
+++ b/contracts/voting-verifier/Cargo.toml
@@ -42,6 +42,7 @@ thiserror = { workspace = true }
 voting-verifier-api = { workspace = true }
 
 [dev-dependencies]
+aleo-gateway = { workspace = true }
 alloy-primitives = { version = "0.7.7", features = ["getrandom"] }
 assert_ok = { workspace = true }
 bech32 = { workspace = true }

--- a/contracts/voting-verifier/src/contract.rs
+++ b/contracts/voting-verifier/src/contract.rs
@@ -1,4 +1,4 @@
-use axelar_wasm_std::address::validate_address;
+use axelar_wasm_std::address::validate_contract_address;
 use axelar_wasm_std::{address, permission_control, FnExt};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
@@ -32,7 +32,7 @@ pub fn instantiate(
     let governance = address::validate_cosmwasm_address(deps.api, &msg.governance_address)?;
     permission_control::set_governance(deps.storage, &governance)?;
 
-    validate_address(&msg.source_gateway_address, &msg.address_format)
+    validate_contract_address(&msg.source_gateway_address, &msg.address_format)
         .change_context(ContractError::InvalidSourceGatewayAddress)?;
 
     let config = Config {
@@ -338,6 +338,25 @@ mod test {
                 should_fail: false,
             },
             TestCase {
+                source_gateway_address: "gateway.aleo".to_string(),
+                address_format: AddressFormat::Aleo(
+                    aleo_gateway::network::NetworkConfig::TestnetV0,
+                ),
+                should_fail: false,
+            },
+            TestCase {
+                source_gateway_address: "gateway.aleo".to_string(),
+                address_format: AddressFormat::Aleo(
+                    aleo_gateway::network::NetworkConfig::MainnetV0,
+                ),
+                should_fail: false,
+            },
+            TestCase {
+                source_gateway_address: "gateway.aleo".to_string(),
+                address_format: AddressFormat::Aleo(aleo_gateway::network::NetworkConfig::CanaryV0),
+                should_fail: false,
+            },
+            TestCase {
                 source_gateway_address: "0x4f4495243837681061C4743b74B3eEdf548D56A5".to_string(),
                 address_format: AddressFormat::Eip55,
                 should_fail: true,
@@ -410,6 +429,28 @@ mod test {
                         .to_string()
                         .to_uppercase(),
                 address_format: AddressFormat::Sui,
+                should_fail: true,
+            },
+            TestCase {
+                source_gateway_address:
+                    "aleo1q3t7cjwk9ncxcdxfm8r5ax83mzudd923gffncv5egfjyevfevuyscvcvz".to_string(),
+                address_format: AddressFormat::Aleo(
+                    aleo_gateway::network::NetworkConfig::TestnetV0,
+                ),
+                should_fail: true,
+            },
+            TestCase {
+                source_gateway_address:
+                    "aleo1q3t7cjwk9ncxcdxfm8r5ax83mzudd923gffncv5egfjyevfevuyscvcvz".to_string(),
+                address_format: AddressFormat::Aleo(
+                    aleo_gateway::network::NetworkConfig::MainnetV0,
+                ),
+                should_fail: true,
+            },
+            TestCase {
+                source_gateway_address:
+                    "aleo1q3t7cjwk9ncxcdxfm8r5ax83mzudd923gffncv5egfjyevfevuyscvcvz".to_string(),
+                address_format: AddressFormat::Aleo(aleo_gateway::network::NetworkConfig::CanaryV0),
                 should_fail: true,
             },
         ];

--- a/packages/aleo-gateway/Cargo.toml
+++ b/packages/aleo-gateway/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "aleo-gateway"
+version = "0.1.0"
+rust-version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+cosmwasm-schema = { workspace = true }
+snarkvm-cosmwasm = { workspace = true }
+thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/packages/aleo-gateway/src/error.rs
+++ b/packages/aleo-gateway/src/error.rs
@@ -1,0 +1,7 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum AleoError {
+    #[error(transparent)]
+    SnarkVm(#[from] snarkvm_cosmwasm::prelude::Error),
+}

--- a/packages/aleo-gateway/src/lib.rs
+++ b/packages/aleo-gateway/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod error;
+pub mod network;
+pub mod utils;

--- a/packages/aleo-gateway/src/network.rs
+++ b/packages/aleo-gateway/src/network.rs
@@ -1,0 +1,38 @@
+use std::fmt;
+
+use cosmwasm_schema::cw_serde;
+use snarkvm_cosmwasm::prelude::{CanaryV0, MainnetV0, Network, TestnetV0};
+
+/// Represents the Aleo network configuration.
+///
+/// To reduce the dependencies on Aleo crates we will define our own type here for representing
+/// Aleo Network
+#[cw_serde]
+pub enum NetworkConfig {
+    #[serde(rename = "testnet")]
+    TestnetV0,
+    #[serde(rename = "mainnet")]
+    MainnetV0,
+    #[serde(rename = "canary")]
+    CanaryV0,
+}
+
+impl NetworkConfig {
+    pub fn id(&self) -> u16 {
+        match self {
+            NetworkConfig::TestnetV0 => TestnetV0::ID,
+            NetworkConfig::MainnetV0 => MainnetV0::ID,
+            NetworkConfig::CanaryV0 => CanaryV0::ID,
+        }
+    }
+}
+
+impl fmt::Display for NetworkConfig {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            NetworkConfig::TestnetV0 => write!(f, "testnet"),
+            NetworkConfig::MainnetV0 => write!(f, "mainnet"),
+            NetworkConfig::CanaryV0 => write!(f, "canary"),
+        }
+    }
+}

--- a/packages/aleo-gateway/src/utils.rs
+++ b/packages/aleo-gateway/src/utils.rs
@@ -1,0 +1,38 @@
+use std::str::FromStr as _;
+
+use snarkvm_cosmwasm::prelude::{Address, CanaryV0, MainnetV0, ProgramID, TestnetV0};
+
+use crate::error::AleoError;
+use crate::network::NetworkConfig;
+
+pub fn validate_program_name(network: &NetworkConfig, address: &str) -> Result<(), AleoError> {
+    match network {
+        NetworkConfig::TestnetV0 => {
+            ProgramID::<TestnetV0>::from_str(address)?;
+        }
+        NetworkConfig::MainnetV0 => {
+            ProgramID::<MainnetV0>::from_str(address)?;
+        }
+        NetworkConfig::CanaryV0 => {
+            ProgramID::<CanaryV0>::from_str(address)?;
+        }
+    }
+
+    Ok(())
+}
+
+pub fn validate_address(network: &NetworkConfig, address: &str) -> Result<(), AleoError> {
+    match network {
+        NetworkConfig::TestnetV0 => {
+            Address::<TestnetV0>::from_str(address)?;
+        }
+        NetworkConfig::MainnetV0 => {
+            Address::<MainnetV0>::from_str(address)?;
+        }
+        NetworkConfig::CanaryV0 => {
+            Address::<CanaryV0>::from_str(address)?;
+        }
+    }
+
+    Ok(())
+}

--- a/packages/axelar-wasm-std/Cargo.toml
+++ b/packages/axelar-wasm-std/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["rlib"]
 derive = ["dep:axelar-wasm-std-derive"]
 
 [dependencies]
+aleo-gateway = { workspace = true }
 alloy-primitives = { workspace = true }
 axelar-wasm-std-derive = { workspace = true, optional = true }
 bech32 = { workspace = true }

--- a/packages/axelar-wasm-std/src/address.rs
+++ b/packages/axelar-wasm-std/src/address.rs
@@ -1,5 +1,9 @@
 use std::str::FromStr;
 
+use aleo_gateway::network::NetworkConfig;
+use aleo_gateway::utils::{
+    validate_address as validate_aleo_address, validate_program_name as validate_aleo_program_name,
+};
 use alloy_primitives::Address;
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Api};
@@ -21,6 +25,19 @@ pub enum AddressFormat {
     Sui,
     Stellar,
     Starknet,
+    Aleo(NetworkConfig),
+}
+
+/// This function validates the contract address based on the provided format.
+///
+/// Note: This is implemented because Aleo has different id for programs
+/// Each program has an associated Aleo address, but the program name is used as the program id when is needed to find the program.
+pub fn validate_contract_address(address: &str, format: &AddressFormat) -> Result<(), Error> {
+    match format {
+        AddressFormat::Aleo(network) => validate_aleo_program_name(network, address)
+            .change_context(Error::InvalidAddress(address.to_string())),
+        _ => validate_address(address, format),
+    }
 }
 
 pub fn validate_address(address: &str, format: &AddressFormat) -> Result<(), Error> {
@@ -38,6 +55,10 @@ pub fn validate_address(address: &str, format: &AddressFormat) -> Result<(), Err
                 bail!(Error::InvalidAddress(address.to_string()))
             }
             ScAddress::from_str(address)
+                .change_context(Error::InvalidAddress(address.to_string()))?;
+        }
+        AddressFormat::Aleo(network) => {
+            validate_aleo_address(network, address)
                 .change_context(Error::InvalidAddress(address.to_string()))?;
         }
         AddressFormat::Starknet => {


### PR DESCRIPTION
## Description
Support for Aleo at voting-verifier

To support Aleo in voting-verifier we need to parse and validate the Aleo program name and aleo addresses. 

Scope:
The PR introduces the functionality needed to parse and validate Aleo program names and aleo addresses using `snarkvm-cosmwasm`. 

Test Plan:
The code is tested only in unit-tests of `voting-verifier`. 
