### PR TITLE
refactor: ChainNameRaw moved from router_api to axelar_wasm_std::chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,8 +135,8 @@ name = "aleo-gmp-types"
 version = "0.1.0"
 dependencies = [
  "aleo-string-encoder",
+ "axelar-wasm-std",
  "error-stack",
- "router-api",
  "thiserror 1.0.69",
 ]
 

--- a/packages/aleo-gmp-types/Cargo.toml
+++ b/packages/aleo-gmp-types/Cargo.toml
@@ -7,8 +7,8 @@ license.workspace = true
 
 [dependencies]
 aleo-string-encoder = { workspace = true }
+axelar-wasm-std = { workspace = true }
 error-stack = { workspace = true }
-router-api = { workspace = true }
 thiserror = { workspace = true }
 
 [lints]

--- a/packages/aleo-gmp-types/src/error.rs
+++ b/packages/aleo-gmp-types/src/error.rs
@@ -5,7 +5,7 @@ pub enum Error {
     #[error(transparent)]
     StringEncoderError(#[from] aleo_string_encoder::Error),
     #[error(transparent)]
-    RouterApi(#[from] router_api::error::Error),
+    AxelarInvalidChainName(#[from] axelar_wasm_std::chain::Error),
     #[error("Invalid chain name: {0}")]
     InvalidChainName(String),
 }

--- a/packages/aleo-gmp-types/src/safe_gmp_chain_name.rs
+++ b/packages/aleo-gmp-types/src/safe_gmp_chain_name.rs
@@ -1,8 +1,8 @@
 use std::str::FromStr;
 
 use aleo_string_encoder::StringEncoder;
+use axelar_wasm_std::chain::ChainNameRaw;
 use error_stack::{ensure, Report};
-use router_api::ChainNameRaw;
 
 use super::GmpChainName;
 use crate::error::Error;


### PR DESCRIPTION
## Description

After yesterday's PR, I synced the branch with `axelar-amplifier` `main` branch. 
In their latest version, they moved `ChainNameRaw` from `router_api` to `axelar_wasm_std::chain`, and our code needs to adapt accordingly. 