### PR TITLE
fix: ignore `GatewayEvent::CallContractOffchainData` events.

### DIFF
--- a/ampd/src/solana/msg_verifier.rs
+++ b/ampd/src/solana/msg_verifier.rs
@@ -21,14 +21,6 @@ pub fn verify_message(tx: (&Signature, &UiTransactionStatusMeta), message: &Mess
                     &event.destination_chain,
                     &event.destination_contract_address,
                 ),
-                // This event is emitted when a contract call is initiated to an external chain with call data
-                // being passed offchain.
-                GatewayEvent::CallContractOffchainData(event) => (
-                    &event.sender_key,
-                    &event.payload_hash,
-                    &event.destination_chain,
-                    &event.destination_contract_address,
-                ),
                 _ => return false,
             };
 


### PR DESCRIPTION
We've removed offchain processing functionality to match the upstream changes made in https://github.com/eigerco/axelar-amplifier-solana/pull/209.

Initially, we planned to update the `axelar-amplifier-solana` dependency to its latest version, but encountered compilation errors with the `cosmwasm-*` crates during the build process. We'll address that dependency update separately in another PR.