### PR TITLE
chore(ampd): add name to task runs (axelarnetwork#1055)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 ## [Unreleased](https://github.com/axelarnetwork/axelar-amplifier/tree/HEAD)
 
-[Full Changelog](https://github.com/axelarnetwork/axelar-amplifier/compare/ampd-v1.12.1..HEAD)
+[Full Changelog](https://github.com/axelarnetwork/axelar-amplifier/compare/ampd-v1.12.2..HEAD)
+
+## [v1.12.2](https://github.com/axelarnetwork/axelar-amplifier/tree/ampd-v1.12.2) (2025-10-03)
+
+[Full Changelog](https://github.com/axelarnetwork/axelar-amplifier/compare/ampd-v1.12.1..ampd-v1.12.2)
+
+- add cancellation token to confirmer and broadcaster [#1056](https://github.com/axelarnetwork/axelar-amplifier/pull/1056)
+- add name to task runs [#1055](https://github.com/axelarnetwork/axelar-amplifier/pull/1055)
+- rotate out blastapi rpcs [#1054](https://github.com/axelarnetwork/axelar-amplifier/pull/1054)
 
 ## [v1.12.1](https://github.com/axelarnetwork/axelar-amplifier/tree/ampd-v1.12.1) (2025-09-25)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "ampd"
-version = "1.12.1"
+version = "1.12.2"
 dependencies = [
  "ampd-proto",
  "assert_ok",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8449,6 +8449,7 @@ dependencies = [
  "error-stack",
  "eyre",
  "itertools 0.14.0",
+ "temp-env",
  "thiserror 1.0.69",
  "tracing",
  "tracing-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,6 +319,7 @@ dependencies = [
  "sui-json-rpc-types",
  "sui-types 0.1.0",
  "sysinfo",
+ "temp-env",
  "tendermint 0.35.0",
  "tendermint-proto 0.40.4",
  "tendermint-rpc",
@@ -2852,7 +2853,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -12287,6 +12288,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
 dependencies = [
+ "futures",
  "parking_lot",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ strum = { version = "0.25", default-features = false, features = ["derive"] }
 sui-gateway = { version = "^1.0.0", path = "packages/sui-gateway" }
 sui-types = { version = "^1.0.0", path = "packages/sui-types" }
 syn = "2.0.92"
+temp-env = "0.3.6"
 tendermint = "0.35.0"
 thiserror = "1.0.61"
 tofn = { version = "1.1" }

--- a/ampd/Cargo.toml
+++ b/ampd/Cargo.toml
@@ -122,6 +122,7 @@ goldie = { workspace = true }
 multisig = { workspace = true, features = ["test", "library"] }
 rand = { workspace = true }
 random-string = "1.0.0"
+temp-env = { workspace = true, features = ["async_closure"] }
 tendermint-proto = { version = "0.40.3" }
 test-log = { version = "0.2", features = ["trace"], default-features = false }
 tokio = { workspace = true, features = ["test-util"] }

--- a/ampd/Cargo.toml
+++ b/ampd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ampd"
 edition = { workspace = true }
-version = "1.12.1"
+version = "1.12.2"
 rust-version = { workspace = true }
 license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/ampd/src/asyncutil/task.rs
+++ b/ampd/src/asyncutil/task.rs
@@ -2,11 +2,12 @@ use std::future::Future;
 use std::pin::Pin;
 
 use axelar_wasm_std::error::extend_err;
-use error_stack::{Context, Result, ResultExt};
+use error_stack::{report, Context, Result, ResultExt};
 use thiserror::Error;
+use tokio::io::Error as IoError;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{info, warn};
 
 type PinnedFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
 /// This type represents an awaitable action that can be cancelled. It abstracts away the necessary boxing and pinning
@@ -33,15 +34,15 @@ impl<T> CancellableTask<T> {
 
 pub struct TaskGroup<E>
 where
-    E: From<TaskError> + Context,
+    E: Context,
 {
     name: String,
-    tasks: Vec<CancellableTask<Result<(), E>>>,
+    tasks: Vec<(String, CancellableTask<Result<(), E>>)>,
 }
 
 impl<E> TaskGroup<E>
 where
-    E: From<TaskError> + Context,
+    E: Context,
 {
     pub fn new(name: impl Into<String>) -> Self {
         TaskGroup {
@@ -51,42 +52,53 @@ where
     }
 
     /// The added tasks won't be started until [Self::run] is called
-    pub fn add_task(mut self, task: CancellableTask<Result<(), E>>) -> Self {
-        self.tasks.push(task);
+    pub fn add_task(
+        mut self,
+        task_name: impl Into<String>,
+        task: CancellableTask<Result<(), E>>,
+    ) -> Self {
+        self.tasks.push((task_name.into(), task));
         self
     }
 
     /// Runs all tasks concurrently. If one task fails, all others are cancelled and the collection of errors is returned.
     /// If a task panics, it still returns an error to the manager, so the parent process can shut down all tasks gracefully.
-    pub async fn run(self, token: CancellationToken) -> Result<(), E> {
+    pub async fn run(self, token: CancellationToken) -> Result<(), TaskGroupError> {
         // running tasks and waiting for them is tightly coupled, so they both share a cloned token
         let mut running_tasks = start_tasks(self.tasks, token.clone());
         wait_for_completion(self.name, &mut running_tasks, &token).await
     }
 }
 
-fn start_tasks<T>(tasks: Vec<CancellableTask<T>>, token: CancellationToken) -> JoinSet<T>
+fn start_tasks<T>(
+    tasks: Vec<(String, CancellableTask<T>)>,
+    token: CancellationToken,
+) -> JoinSet<(String, T)>
 where
     T: Send + 'static,
 {
     let mut join_set = JoinSet::new();
 
-    for task in tasks.into_iter() {
+    for (task_name, task) in tasks.into_iter() {
         // tasks clean up on their own after the cancellation token is triggered, so we discard the abort handles.
         // However, we don't know what tasks will do with their token, so we need to create new child tokens here,
         // so each task can act independently
-        join_set.spawn(task.run(token.child_token()));
+        let child_token = token.child_token();
+        join_set.spawn(async move {
+            let result = task.run(child_token).await;
+            (task_name, result)
+        });
     }
     join_set
 }
 
 async fn wait_for_completion<E>(
     group_name: String,
-    running_tasks: &mut JoinSet<Result<(), E>>,
+    running_tasks: &mut JoinSet<(String, Result<(), E>)>,
     token: &CancellationToken,
-) -> Result<(), E>
+) -> Result<(), TaskGroupError>
 where
-    E: From<TaskError> + Context,
+    E: Context,
 {
     let mut final_result = Ok(());
     let total_task_count = running_tasks.len();
@@ -94,29 +106,55 @@ where
         // if one task stops, all others should stop as well, so we cancel the token.
         // Any call to this after the first is a no-op, so no need to guard it.
         token.cancel();
-        info!(
-            "shutting down {} sub-tasks ({}/{})",
-            group_name,
-            total_task_count.saturating_sub(running_tasks.len()),
-            total_task_count
-        );
 
-        final_result = match task_result.change_context(E::from(TaskError {})) {
-            Err(err) | Ok(Err(err)) => extend_err(final_result, err),
-            Ok(_) => final_result,
-        };
+        match task_result {
+            Ok((task_name, task_result)) => {
+                info!(
+                    "shutting down {} sub-tasks ({}/{}) - task '{}' completed",
+                    group_name,
+                    total_task_count.saturating_sub(running_tasks.len()),
+                    total_task_count,
+                    task_name
+                );
+
+                final_result = match task_result {
+                    Err(err) => extend_err(final_result, err.change_context(TaskError {})),
+                    Ok(()) => final_result,
+                };
+            }
+            Err(join_error) => {
+                warn!(
+                    "shutting down {} sub-tasks ({}/{}) - task aborted or panicked: {}",
+                    group_name,
+                    total_task_count.saturating_sub(running_tasks.len()),
+                    total_task_count,
+                    join_error
+                );
+
+                final_result = extend_err(
+                    final_result,
+                    report!(IoError::from(join_error)).change_context(TaskError {}),
+                );
+            }
+        }
     }
 
-    final_result
+    final_result.change_context(TaskGroupError {})
 }
 
 #[derive(Error, Debug)]
 #[error("task failed")]
 pub struct TaskError;
 
+#[derive(Error, Debug)]
+#[error("task group execution failed")]
+pub struct TaskGroupError;
+
 #[cfg(test)]
 mod test {
-    use error_stack::report;
+    use error_stack::fmt::ColorMode;
+    use error_stack::{report, Report};
+    use temp_env::async_with_vars;
     use tokio_util::sync::CancellationToken;
 
     use crate::asyncutil::task::{CancellableTask, TaskError, TaskGroup};
@@ -135,53 +173,93 @@ mod test {
         };
 
         let tasks: TaskGroup<TaskError> = TaskGroup::new("test")
-            .add_task(CancellableTask::create(waiting_task))
-            .add_task(CancellableTask::create(waiting_task))
-            .add_task(CancellableTask::create(|_| async { Ok(()) }))
-            .add_task(CancellableTask::create(waiting_task));
+            .add_task("waiting_task_1", CancellableTask::create(waiting_task))
+            .add_task("waiting_task_2", CancellableTask::create(waiting_task))
+            .add_task(
+                "immediate_task",
+                CancellableTask::create(|_| async { Ok(()) }),
+            )
+            .add_task("waiting_task_3", CancellableTask::create(waiting_task));
         assert!(tasks.run(CancellationToken::new()).await.is_ok());
     }
 
     #[tokio::test]
     async fn collect_all_errors_on_completion() {
-        let tasks = TaskGroup::new("test")
-            .add_task(CancellableTask::create(|token| async move {
-                token.cancelled().await;
-                Err(report!(TaskError {}))
-            }))
-            .add_task(CancellableTask::create(|token| async move {
-                token.cancelled().await;
-                Err(report!(TaskError {}))
-            }))
-            .add_task(CancellableTask::create(|_| async { Ok(()) }))
-            .add_task(CancellableTask::create(|token| async move {
-                token.cancelled().await;
-                Err(report!(TaskError {}))
-            }))
-            .add_task(CancellableTask::create(|_| async { Ok(()) }))
-            .add_task(CancellableTask::create(|token| async move {
-                token.cancelled().await;
-                Err(report!(TaskError {}))
-            }));
-        let result = tasks.run(CancellationToken::new()).await;
-        let err = result.unwrap_err();
-        assert_eq!(err.current_frames().len(), 4);
+        async_with_vars([("RUST_BACKTRACE", Some("0"))], async {
+            let tasks = TaskGroup::new("test")
+                .add_task(
+                    "error_task_1",
+                    CancellableTask::create(|token| async move {
+                        token.cancelled().await;
+                        Err(report!(TaskError {}))
+                    }),
+                )
+                .add_task(
+                    "error_task_2",
+                    CancellableTask::create(|token| async move {
+                        token.cancelled().await;
+                        Err(report!(TaskError {}))
+                    }),
+                )
+                .add_task(
+                    "success_task_1",
+                    CancellableTask::create(|_| async { Ok(()) }),
+                )
+                .add_task(
+                    "error_task_3",
+                    CancellableTask::create(|token| async move {
+                        token.cancelled().await;
+                        Err(report!(TaskError {}))
+                    }),
+                )
+                .add_task(
+                    "success_task_2",
+                    CancellableTask::create(|_| async { Ok(()) }),
+                )
+                .add_task(
+                    "error_task_4",
+                    CancellableTask::create(|token| async move {
+                        token.cancelled().await;
+                        Err(report!(TaskError {}))
+                    }),
+                );
+            let result = tasks.run(CancellationToken::new()).await;
+            let err = result.unwrap_err();
+            Report::set_color_mode(ColorMode::None);
+            goldie::assert_debug!(err);
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn shutdown_gracefully_on_task_panic() {
-        let tasks = TaskGroup::new("test")
-            .add_task(CancellableTask::create(|_| async { Ok(()) }))
-            .add_task(CancellableTask::create(|_| async { panic!("panic") }))
-            .add_task(CancellableTask::create(|_| async {
-                Err(report!(TaskError {}))
-            }))
-            .add_task(CancellableTask::create(|_| async { Ok(()) }))
-            .add_task(CancellableTask::create(|_| async {
-                Err(report!(TaskError {}))
-            }));
-        let result = tasks.run(CancellationToken::new()).await;
-        let err = result.unwrap_err();
-        assert_eq!(err.current_frames().len(), 3);
+        async_with_vars([("RUST_BACKTRACE", Some("0"))], async {
+            let tasks = TaskGroup::new("test")
+                .add_task(
+                    "success_task_1",
+                    CancellableTask::create(|_| async { Ok(()) }),
+                )
+                .add_task(
+                    "panic_task",
+                    CancellableTask::create(|_| async { panic!("panic") }),
+                )
+                .add_task(
+                    "error_task",
+                    CancellableTask::create(|_| async { Err(report!(TaskError {})) }),
+                )
+                .add_task(
+                    "success_task_2",
+                    CancellableTask::create(|_| async { Ok(()) }),
+                )
+                .add_task(
+                    "error_task_2",
+                    CancellableTask::create(|_| async { Err(report!(TaskError {})) }),
+                );
+            let result = tasks.run(CancellationToken::new()).await;
+            let err = result.unwrap_err();
+            Report::set_color_mode(ColorMode::None);
+            goldie::assert_debug!(err);
+        })
+        .await;
     }
 }

--- a/ampd/src/asyncutil/testdata/collect_all_errors_on_completion.golden
+++ b/ampd/src/asyncutil/testdata/collect_all_errors_on_completion.golden
@@ -1,0 +1,26 @@
+task group execution failed
+├╴at ampd/src/asyncutil/task.rs:142:18
+│
+╰┬▶ task failed
+ │  ├╴at ampd/src/asyncutil/task.rs:121:62
+ │  │
+ │  ╰─▶ task failed
+ │      ╰╴at ampd/src/asyncutil/task.rs:212:29
+ │
+ ├▶ task failed
+ │  ├╴at ampd/src/asyncutil/task.rs:121:62
+ │  │
+ │  ╰─▶ task failed
+ │      ╰╴at ampd/src/asyncutil/task.rs:223:29
+ │
+ ├▶ task failed
+ │  ├╴at ampd/src/asyncutil/task.rs:121:62
+ │  │
+ │  ╰─▶ task failed
+ │      ╰╴at ampd/src/asyncutil/task.rs:201:29
+ │
+ ╰▶ task failed
+    ├╴at ampd/src/asyncutil/task.rs:121:62
+    │
+    ╰─▶ task failed
+        ╰╴at ampd/src/asyncutil/task.rs:194:29

--- a/ampd/src/asyncutil/testdata/shutdown_gracefully_on_task_panic.golden
+++ b/ampd/src/asyncutil/testdata/shutdown_gracefully_on_task_panic.golden
@@ -1,0 +1,20 @@
+task group execution failed
+├╴at ampd/src/asyncutil/task.rs:142:18
+│
+╰┬▶ task failed
+ │  ├╴at ampd/src/asyncutil/task.rs:136:56
+ │  │
+ │  ╰─▶ task panicked
+ │      ╰╴at ampd/src/asyncutil/task.rs:136:21
+ │
+ ├▶ task failed
+ │  ├╴at ampd/src/asyncutil/task.rs:121:62
+ │  │
+ │  ╰─▶ task failed
+ │      ╰╴at ampd/src/asyncutil/task.rs:248:61
+ │
+ ╰▶ task failed
+    ├╴at ampd/src/asyncutil/task.rs:121:62
+    │
+    ╰─▶ task failed
+        ╰╴at ampd/src/asyncutil/task.rs:256:61

--- a/ampd/src/broadcast/mod.rs
+++ b/ampd/src/broadcast/mod.rs
@@ -10,6 +10,7 @@ use prost::encoding::{decode_key, decode_varint, WireType};
 use thiserror::Error;
 use tokio::sync::oneshot;
 use tokio_stream::StreamExt;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info, instrument};
 use typed_builder::TypedBuilder;
 
@@ -89,7 +90,7 @@ pub enum Error {
 pub struct BroadcasterTask<T, Q, S>
 where
     T: cosmos::CosmosClient,
-    Q: futures::Stream<Item = nonempty::Vec<msg_queue::QueueMsg>> + Unpin + Debug,
+    Q: futures::Stream<Item = nonempty::Vec<msg_queue::QueueMsg>> + Debug,
     S: tofnd::Multisig,
 {
     broadcaster: broadcaster::Broadcaster<T>,
@@ -104,7 +105,7 @@ where
 impl<T, Q, S> BroadcasterTask<T, Q, S>
 where
     T: cosmos::CosmosClient + Debug,
-    Q: futures::Stream<Item = nonempty::Vec<msg_queue::QueueMsg>> + Unpin + Debug,
+    Q: futures::Stream<Item = nonempty::Vec<msg_queue::QueueMsg>> + Debug,
     S: tofnd::Multisig + Debug,
 {
     /// Runs the broadcaster task until the message queue is exhausted
@@ -125,10 +126,25 @@ where
     /// A Result indicating whether the task completed successfully.
     /// Note that individual transaction failures don't cause the task to return an error.
     #[instrument(skip_all)]
-    pub async fn run(mut self) -> Result<()> {
-        while let Some(msgs) = self.msg_queue.next().await {
+    pub async fn run(self, token: CancellationToken) -> Result<()> {
+        let Self {
+            mut broadcaster,
+            msg_queue,
+            mut signer,
+            key_id,
+            tx_confirmer_client,
+            monitoring_client,
+        } = self;
+
+        let stream = futures::StreamExt::take_until(msg_queue, token.cancelled());
+
+        tokio::pin!(stream);
+        while let Some(msgs) = stream.next().await {
             let (res, elapsed) = metrics::timed(|| async {
-                self.broadcast(
+                broadcast(
+                    &mut broadcaster,
+                    &mut signer,
+                    &key_id,
                     msgs.as_ref()
                         .iter()
                         .map(|msg| msg.msg.clone())
@@ -140,116 +156,125 @@ where
             })
             .await;
 
-            self.monitoring_client
-                .metrics()
-                .record_metric(Msg::StageResult {
-                    stage: Stage::TransactionBroadcast,
-                    success: res.is_ok(),
-                    duration: elapsed,
-                });
-
-            self.handle_tx_res(res.map(|res| res.txhash), msgs).await?;
-        }
-
-        Ok(())
-    }
-
-    /// Broadcasts a collection of messages as a single transaction to the Cosmos blockchain.
-    ///
-    /// This method handles the complete transaction lifecycle:
-    /// 1. Packages messages into a BatchRequest
-    /// 2. Estimates appropriate gas and fee based on simulation
-    /// 3. Signs the transaction using the configured signer
-    /// 4. Broadcasts the signed transaction to the network
-    /// 5. Logs the results of the broadcast operation
-    ///
-    /// The gas calculation applies the configured gas adjustment factor to the
-    /// simulated gas, and calculates fees based on the gas price denomination.
-    ///
-    /// # Parameters
-    /// * `msgs` - A non-empty vector of Any-encoded protocol messages to broadcast
-    ///
-    /// # Returns
-    /// * On success: TxResponse containing the transaction hash and execution results
-    /// * On failure: Error indicating what part of the broadcast process failed
-    ///
-    /// # Errors
-    /// This method can fail with various error types depending on where in the process it fails:
-    /// * `Error::EstimateGas` - If the gas estimation simulation fails
-    /// * `Error::FeeAdjustment` - If fee calculation encounters numeric conversion issues
-    /// * `Error::SignTx` - If transaction signing fails
-    /// * `Error::BroadcastTx` - If the network rejects the transaction
-    #[instrument(skip_all)]
-    pub async fn broadcast(&mut self, msgs: nonempty::Vec<Any>) -> Result<TxResponse> {
-        let msgs: Vec<_> = msgs.into();
-        let msg_count = msgs.len();
-        info!(msg_count, "broadcasting messages");
-
-        let batch_req = Any::from_msg(&proto::axelar::auxiliary::v1beta1::BatchRequest {
-            sender: self.broadcaster.address.as_ref().to_bytes(),
-            messages: msgs,
-        })
-        .expect("failed to serialize proto message for batch request");
-        let pub_key = self.broadcaster.pub_key;
-
-        self.broadcaster
-            .broadcast(vec![batch_req], |sign_doc| {
-                let mut hasher = Sha256::new();
-                hasher.update(sign_doc);
-
-                let sign_digest: [u8; 32] = hasher
-                    .finalize()
-                    .to_vec()
-                    .try_into()
-                    .expect("hash size must be 32");
-
-                self.signer.sign(
-                    &self.key_id,
-                    sign_digest,
-                    pub_key.into(),
-                    tofnd::Algorithm::Ecdsa,
-                )
-            })
-            .await
-            .inspect(|res| {
-                info!(
-                    tx_hash = res.txhash,
-                    msg_count, "successfully broadcasted tx"
-                );
-            })
-    }
-
-    #[instrument(skip(self))]
-    async fn handle_tx_res(
-        &self,
-        tx_hash: Result<String>,
-        msgs: nonempty::Vec<msg_queue::QueueMsg>,
-    ) -> Result<()> {
-        if let (Some(confirmer), Ok(tx_hash)) = (&self.tx_confirmer_client, &tx_hash) {
-            confirmer
-                .send(tx_hash.clone())
-                .await
-                .change_context(Error::ConfirmTx(tx_hash.clone()))?;
-        }
-
-        let tx_hash = tx_hash.map_err(Arc::new);
-
-        Vec::from(msgs)
-            .into_iter()
-            .enumerate()
-            .for_each(|(i, msg)| {
-                match &tx_hash {
-                    Ok(tx_hash) => {
-                        let _ = msg.tx_res_callback.send(Ok((tx_hash.clone(), i as u64)));
-                    }
-                    Err(err) => {
-                        let _ = msg.tx_res_callback.send(Err(err.clone()));
-                    }
-                };
+            monitoring_client.metrics().record_metric(Msg::StageResult {
+                stage: Stage::TransactionBroadcast,
+                success: res.is_ok(),
+                duration: elapsed,
             });
 
+            handle_tx_res(
+                tx_confirmer_client.as_ref(),
+                res.map(|res| res.txhash),
+                msgs,
+            )
+            .await?;
+        }
+
+        info!("broadcaster task exited");
+
         Ok(())
     }
+}
+
+/// Broadcasts a collection of messages as a single transaction to the Cosmos blockchain.
+///
+/// This method handles the complete transaction lifecycle:
+/// 1. Packages messages into a BatchRequest
+/// 2. Estimates appropriate gas and fee based on simulation
+/// 3. Signs the transaction using the configured signer
+/// 4. Broadcasts the signed transaction to the network
+/// 5. Logs the results of the broadcast operation
+///
+/// The gas calculation applies the configured gas adjustment factor to the
+/// simulated gas, and calculates fees based on the gas price denomination.
+///
+/// # Parameters
+/// * `msgs` - A non-empty vector of Any-encoded protocol messages to broadcast
+///
+/// # Returns
+/// * On success: TxResponse containing the transaction hash and execution results
+/// * On failure: Error indicating what part of the broadcast process failed
+///
+/// # Errors
+/// This method can fail with various error types depending on where in the process it fails:
+/// * `Error::EstimateGas` - If the gas estimation simulation fails
+/// * `Error::FeeAdjustment` - If fee calculation encounters numeric conversion issues
+/// * `Error::SignTx` - If transaction signing fails
+/// * `Error::BroadcastTx` - If the network rejects the transaction
+#[instrument(skip_all)]
+pub async fn broadcast<T, S>(
+    broadcaster: &mut Broadcaster<T>,
+    signer: &mut S,
+    key_id: &str,
+    msgs: nonempty::Vec<Any>,
+) -> Result<TxResponse>
+where
+    T: cosmos::CosmosClient + Debug,
+    S: tofnd::Multisig + Debug,
+{
+    let msgs: Vec<_> = msgs.into();
+    let msg_count = msgs.len();
+    info!(msg_count, "broadcasting messages");
+
+    let batch_req = Any::from_msg(&proto::axelar::auxiliary::v1beta1::BatchRequest {
+        sender: broadcaster.address.as_ref().to_bytes(),
+        messages: msgs,
+    })
+    .expect("failed to serialize proto message for batch request");
+    let pub_key = broadcaster.pub_key;
+
+    broadcaster
+        .broadcast(vec![batch_req], |sign_doc| {
+            let mut hasher = Sha256::new();
+            hasher.update(sign_doc);
+
+            let sign_digest: [u8; 32] = hasher
+                .finalize()
+                .to_vec()
+                .try_into()
+                .expect("hash size must be 32");
+
+            signer.sign(key_id, sign_digest, pub_key.into(), tofnd::Algorithm::Ecdsa)
+        })
+        .await
+        .inspect(|res| {
+            info!(
+                tx_hash = res.txhash,
+                msg_count, "successfully broadcasted tx"
+            );
+        })
+}
+
+#[instrument]
+async fn handle_tx_res(
+    tx_confirmer_client: Option<&confirmer::TxConfirmerClient>,
+    tx_hash: Result<String>,
+    msgs: nonempty::Vec<msg_queue::QueueMsg>,
+) -> Result<()> {
+    if let (Some(confirmer), Ok(tx_hash)) = (tx_confirmer_client, &tx_hash) {
+        confirmer
+            .send(tx_hash.clone())
+            .await
+            .change_context(Error::ConfirmTx(tx_hash.clone()))?;
+    }
+
+    let tx_hash = tx_hash.map_err(Arc::new);
+
+    Vec::from(msgs)
+        .into_iter()
+        .enumerate()
+        .for_each(|(i, msg)| {
+            match &tx_hash {
+                Ok(tx_hash) => {
+                    let _ = msg.tx_res_callback.send(Ok((tx_hash.clone(), i as u64)));
+                }
+                Err(err) => {
+                    let _ = msg.tx_res_callback.send(Err(err.clone()));
+                }
+            };
+        });
+
+    Ok(())
 }
 
 // TODO: Remove this function once all handlers are migrated to the new sdk
@@ -358,6 +383,8 @@ pub(crate) mod test_utils {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use axelar_wasm_std::{assert_err_contains, err_contains};
     use cosmos_sdk_proto::cosmos::base::v1beta1::Coin;
     use cosmrs::proto::cosmos::auth::v1beta1::QueryAccountResponse;
@@ -369,12 +396,13 @@ mod tests {
     use futures::StreamExt;
     use mockall::{predicate, Sequence};
     use tokio::sync::{mpsc, oneshot};
+    use tokio_stream::iter;
     use tokio_stream::wrappers::ReceiverStream;
-    use tokio_stream::{empty, iter};
+    use tokio_util::sync::CancellationToken;
 
     use crate::broadcast::dec_coin::DecCoin;
     use crate::broadcast::msg_queue::QueueMsg;
-    use crate::broadcast::{broadcaster, BroadcasterTask, Error};
+    use crate::broadcast::{broadcaster, BroadcasterTask, Error, MsgQueue};
     use crate::monitoring::metrics::{Msg, Stage};
     use crate::tofnd::{self, MockMultisig};
     use crate::types::random_cosmos_public_key;
@@ -385,6 +413,70 @@ mod tests {
             type_url: "/cosmos.bank.v1beta1.MsgSend".to_string(),
             value: vec![1, 2, 3],
         }
+    }
+
+    #[tokio::test]
+    async fn broadcaster_task_should_exit_when_token_is_cancelled() {
+        let pub_key = random_cosmos_public_key();
+        let address = pub_key.account_id(PREFIX).unwrap().into();
+        let chain_id: tendermint::chain::Id = "test-chain-id".parse().unwrap();
+        let base_account = broadcast::test_utils::create_base_account(&address);
+        let gas_adjustment = 1.5;
+        let gas_price_amount = 0.025;
+        let gas_price_denom = "uaxl";
+
+        let mock_signer = MockMultisig::new();
+
+        let mut mock_client = cosmos::MockCosmosClient::new();
+        mock_client
+            .expect_clone()
+            .return_once(cosmos::MockCosmosClient::default);
+
+        let mut seq = Sequence::new();
+
+        mock_successful_account_and_balance_queries(
+            &mut mock_client,
+            &mut seq,
+            base_account,
+            &address,
+        );
+
+        let broadcaster = broadcaster::Broadcaster::builder()
+            .client(mock_client)
+            .chain_id(chain_id)
+            .pub_key(pub_key)
+            .gas_adjustment(gas_adjustment)
+            .gas_price(DecCoin::new(gas_price_amount, gas_price_denom).unwrap())
+            .build()
+            .await
+            .unwrap();
+        let (tx, _rx) = mpsc::channel(1);
+        let (monitoring_client, _) = monitoring::test_utils::monitoring_client();
+        let (msg_queue, _msg_queue_client) = MsgQueue::new_msg_queue_and_client(
+            broadcaster.clone(),
+            10,
+            1000u64,
+            tokio::time::Duration::from_secs(1),
+            monitoring_client.clone(),
+        );
+        let broadcaster_task = BroadcasterTask::builder()
+            .broadcaster(broadcaster)
+            .msg_queue(msg_queue)
+            .signer(mock_signer)
+            .key_id("test-key".to_string())
+            .tx_confirmer_client(tx)
+            .monitoring_client(monitoring_client)
+            .build();
+
+        let token = CancellationToken::new();
+        let handle = tokio::spawn(broadcaster_task.run(token.child_token()));
+        token.cancel();
+
+        let result = tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("Task timed out")
+            .unwrap();
+        assert!(result.is_ok());
     }
 
     #[tokio::test]
@@ -451,7 +543,8 @@ mod tests {
             .monitoring_client(monitoring_client)
             .build();
 
-        let result = tokio::spawn(async move { broadcaster_task.run().await })
+        // token doesn't need to be cancelled because the message queue is a `Vec` and gets exhausted
+        let result = tokio::spawn(broadcaster_task.run(CancellationToken::new()))
             .await
             .unwrap();
         assert!(result.is_ok());
@@ -526,7 +619,8 @@ mod tests {
             .monitoring_client(monitoring_client)
             .build();
 
-        let result = tokio::spawn(async move { broadcaster_task.run().await })
+        // token doesn't need to be cancelled because the message queue is a `Vec` and gets exhausted
+        let result = tokio::spawn(broadcaster_task.run(CancellationToken::new()))
             .await
             .unwrap();
         assert!(result.is_ok());
@@ -622,7 +716,8 @@ mod tests {
             .monitoring_client(monitoring_client)
             .build();
 
-        let result = tokio::spawn(async move { broadcaster_task.run().await })
+        // token doesn't need to be cancelled because the message queue is a `Vec` and gets exhausted
+        let result = tokio::spawn(broadcaster_task.run(CancellationToken::new()))
             .await
             .unwrap();
         assert!(result.is_ok());
@@ -699,7 +794,8 @@ mod tests {
             .monitoring_client(monitoring_client)
             .build();
 
-        let result = tokio::spawn(async move { broadcaster_task.run().await })
+        // token doesn't need to be cancelled because the message queue is a `Vec` and gets exhausted
+        let result = tokio::spawn(broadcaster_task.run(CancellationToken::new()))
             .await
             .unwrap();
         assert!(result.is_ok());
@@ -823,7 +919,8 @@ mod tests {
             .monitoring_client(monitoring_client)
             .build();
 
-        let result = tokio::spawn(async move { broadcaster_task.run().await })
+        // token doesn't need to be cancelled because the message queue is a `Vec` and gets exhausted
+        let result = tokio::spawn(broadcaster_task.run(CancellationToken::new()))
             .await
             .unwrap();
         assert!(result.is_ok());
@@ -954,7 +1051,8 @@ mod tests {
             .monitoring_client(monitoring_client)
             .build();
 
-        let result = tokio::spawn(async move { broadcaster_task.run().await })
+        // token doesn't need to be cancelled because the message queue is a `Vec` and gets exhausted
+        let result = tokio::spawn(broadcaster_task.run(CancellationToken::new()))
             .await
             .unwrap();
         assert!(result.is_ok());
@@ -1034,7 +1132,7 @@ mod tests {
                 })
             });
 
-        let broadcaster = broadcaster::Broadcaster::builder()
+        let mut broadcaster = broadcaster::Broadcaster::builder()
             .client(mock_client)
             .chain_id(chain_id)
             .pub_key(pub_key)
@@ -1043,18 +1141,10 @@ mod tests {
             .build()
             .await
             .unwrap();
-        let (monitoring_client, _) = monitoring::test_utils::monitoring_client();
-        let msg_queue = empty();
-        let mut broadcaster_task = BroadcasterTask::builder()
-            .broadcaster(broadcaster)
-            .msg_queue(msg_queue)
-            .signer(mock_signer)
-            .key_id("test-key".to_string())
-            .monitoring_client(monitoring_client)
-            .build();
 
         let messages = vec![dummy_msg()].try_into().unwrap();
-        let result = broadcaster_task.broadcast(messages).await;
+        let result =
+            broadcast::broadcast(&mut broadcaster, &mut mock_signer, "test-key", messages).await;
         assert!(result.is_ok());
 
         let response = result.unwrap();
@@ -1116,7 +1206,7 @@ mod tests {
                 })
             });
 
-        let broadcaster = broadcaster::Broadcaster::builder()
+        let mut broadcaster = broadcaster::Broadcaster::builder()
             .client(mock_client)
             .chain_id(chain_id)
             .pub_key(pub_key)
@@ -1125,20 +1215,12 @@ mod tests {
             .build()
             .await
             .unwrap();
-        let msg_queue = empty();
-        let (monitoring_client, _) = monitoring::test_utils::monitoring_client();
-        let mut broadcaster_task = BroadcasterTask::builder()
-            .broadcaster(broadcaster)
-            .msg_queue(msg_queue)
-            .signer(mock_signer)
-            .key_id("test-key".to_string())
-            .monitoring_client(monitoring_client)
-            .build();
 
         let messages = vec![dummy_msg(), dummy_msg(), dummy_msg()]
             .try_into()
             .unwrap();
-        let result = broadcaster_task.broadcast(messages).await;
+        let result =
+            broadcast::broadcast(&mut broadcaster, &mut mock_signer, "test-key", messages).await;
         assert!(result.is_ok());
 
         let response = result.unwrap();
@@ -1168,7 +1250,7 @@ mod tests {
 
         mock_simulate_failure(&mut mock_client, &mut seq);
 
-        let broadcaster = broadcaster::Broadcaster::builder()
+        let mut broadcaster = broadcaster::Broadcaster::builder()
             .client(mock_client)
             .chain_id(chain_id)
             .pub_key(pub_key)
@@ -1177,18 +1259,15 @@ mod tests {
             .build()
             .await
             .unwrap();
-        let msg_queue = empty();
-        let (monitoring_client, _) = monitoring::test_utils::monitoring_client();
-        let mut broadcaster_task = BroadcasterTask::builder()
-            .broadcaster(broadcaster)
-            .msg_queue(msg_queue)
-            .signer(MockMultisig::new())
-            .key_id("test-key".to_string())
-            .monitoring_client(monitoring_client)
-            .build();
 
         let messages = vec![dummy_msg()].try_into().unwrap();
-        let result = broadcaster_task.broadcast(messages).await;
+        let result = broadcast::broadcast(
+            &mut broadcaster,
+            &mut MockMultisig::new(),
+            "test-key",
+            messages,
+        )
+        .await;
         assert!(result.is_err());
         assert_err_contains!(result, Error, Error::EstimateGas);
     }
@@ -1234,7 +1313,7 @@ mod tests {
                 })
             });
 
-        let broadcaster = broadcaster::Broadcaster::builder()
+        let mut broadcaster = broadcaster::Broadcaster::builder()
             .client(mock_client)
             .chain_id(chain_id)
             .pub_key(pub_key)
@@ -1243,18 +1322,10 @@ mod tests {
             .build()
             .await
             .unwrap();
-        let msg_queue = empty();
-        let (monitoring_client, _) = monitoring::test_utils::monitoring_client();
-        let mut broadcaster_task = BroadcasterTask::builder()
-            .broadcaster(broadcaster)
-            .msg_queue(msg_queue)
-            .signer(mock_signer)
-            .key_id("test-key".to_string())
-            .monitoring_client(monitoring_client)
-            .build();
 
         let messages = vec![dummy_msg()].try_into().unwrap();
-        let result = broadcaster_task.broadcast(messages).await;
+        let result =
+            broadcast::broadcast(&mut broadcaster, &mut mock_signer, "test-key", messages).await;
         assert!(result.is_err());
         assert_err_contains!(result, Error, Error::SignTx);
     }
@@ -1315,7 +1386,7 @@ mod tests {
                 )))
             });
 
-        let broadcaster = broadcaster::Broadcaster::builder()
+        let mut broadcaster = broadcaster::Broadcaster::builder()
             .client(mock_client)
             .chain_id(chain_id)
             .pub_key(pub_key)
@@ -1324,18 +1395,10 @@ mod tests {
             .build()
             .await
             .unwrap();
-        let msg_queue = empty();
-        let (monitoring_client, _) = monitoring::test_utils::monitoring_client();
-        let mut broadcaster_task = BroadcasterTask::builder()
-            .broadcaster(broadcaster)
-            .msg_queue(msg_queue)
-            .signer(mock_signer)
-            .key_id("test-key".to_string())
-            .monitoring_client(monitoring_client)
-            .build();
 
         let messages = vec![dummy_msg()].try_into().unwrap();
-        let result = broadcaster_task.broadcast(messages).await;
+        let result =
+            broadcast::broadcast(&mut broadcaster, &mut mock_signer, "test-key", messages).await;
         assert!(result.is_err());
         assert_err_contains!(result, Error, Error::BroadcastTx);
     }
@@ -1388,7 +1451,8 @@ mod tests {
             .key_id("test-key".to_string())
             .monitoring_client(monitoring_client)
             .build();
-        let _ = tokio::spawn(async move { broadcaster_task.run().await }).await;
+        // token doesn't need to be cancelled because the message queue is a `Vec` and gets exhausted
+        let _ = tokio::spawn(broadcaster_task.run(CancellationToken::new())).await;
 
         let msg_success_broadcast = receiver.recv().await.unwrap();
         assert!(matches!(

--- a/ampd/src/event_processor.rs
+++ b/ampd/src/event_processor.rs
@@ -35,6 +35,8 @@ pub enum Error {
     EventStream,
     #[error("handler stopped prematurely")]
     Tasks(#[from] TaskError),
+    #[error("task group execution failed")]
+    TaskGroup(#[from] crate::asyncutil::task::TaskGroupError),
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]

--- a/ampd/src/lib.rs
+++ b/ampd/src/lib.rs
@@ -285,8 +285,8 @@ impl App {
                 )
                 .await
             {
-                Ok(task) => {
-                    self.event_processor = self.event_processor.add_task(task);
+                Ok((task_name, task)) => {
+                    self.event_processor = self.event_processor.add_task(task_name, task);
                 }
                 Err(e) => {
                     tracing::warn!(error = %e, config = ?config,
@@ -305,7 +305,7 @@ impl App {
         verifier: &TMAddress,
         event_processor_config: &event_processor::Config,
         default_rpc_timeout: Duration,
-    ) -> Result<CancellableTask<Result<(), event_processor::Error>>, Error> {
+    ) -> Result<(String, CancellableTask<Result<(), event_processor::Error>>), Error> {
         match config {
             handlers::config::Config::EvmMsgVerifier {
                 chain,
@@ -325,19 +325,23 @@ impl App {
 
                 check_finalizer(&chain.name, &chain.finalization, &rpc_client).await?;
 
-                Ok(self.create_handler_task(
-                    format!("{}-msg-verifier", chain.name),
-                    handlers::evm_verify_msg::Handler::new(
-                        verifier.clone(),
-                        cosmwasm_contract.clone(),
-                        chain.name.clone(),
-                        chain.finalization.clone(),
-                        rpc_client,
-                        self.block_height_monitor.latest_block_height(),
+                let task_name = format!("{}-msg-verifier", chain.name);
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::evm_verify_msg::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            chain.name.clone(),
+                            chain.finalization.clone(),
+                            rpc_client,
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        ),
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
                     ),
-                    event_processor_config.clone(),
-                    self.monitoring_client.clone(),
                 ))
             }
             handlers::config::Config::EvmVerifierSetVerifier {
@@ -358,61 +362,77 @@ impl App {
 
                 check_finalizer(&chain.name, &chain.finalization, &rpc_client).await?;
 
-                Ok(self.create_handler_task(
-                    format!("{}-verifier-set-verifier", chain.name),
-                    handlers::evm_verify_verifier_set::Handler::new(
-                        verifier.clone(),
-                        cosmwasm_contract.clone(),
-                        chain.name.clone(),
-                        chain.finalization.clone(),
-                        rpc_client,
-                        self.block_height_monitor.latest_block_height(),
+                let task_name = format!("{}-verifier-set-verifier", chain.name);
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::evm_verify_verifier_set::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            chain.name.clone(),
+                            chain.finalization.clone(),
+                            rpc_client,
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        ),
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
                     ),
-                    event_processor_config.clone(),
-                    self.monitoring_client.clone(),
                 ))
             }
             handlers::config::Config::MultisigSigner {
                 cosmwasm_contract,
                 chain_name,
-            } => Ok(self.create_handler_task(
-                "multisig-signer",
-                handlers::multisig::Handler::new(
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    chain_name.clone(),
-                    self.multisig_client.clone(),
-                    self.block_height_monitor.latest_block_height(),
-                ),
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+            } => {
+                let task_name = "multisig-signer".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::multisig::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            chain_name.clone(),
+                            self.multisig_client.clone(),
+                            self.block_height_monitor.latest_block_height(),
+                        ),
+                        event_processor_config.clone(),
+                        self.monitoring_client.clone(),
+                    ),
+                ))
+            }
             handlers::config::Config::SuiMsgVerifier {
                 cosmwasm_contract,
                 rpc_url,
                 rpc_timeout,
-            } => Ok(self.create_handler_task(
-                "sui-msg-verifier",
-                handlers::sui_verify_msg::Handler::new(
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    json_rpc::Client::new_http(
-                        rpc_url.clone(),
-                        reqwest::ClientBuilder::new()
-                            .connect_timeout(rpc_timeout.unwrap_or(default_rpc_timeout))
-                            .timeout(rpc_timeout.unwrap_or(default_rpc_timeout))
-                            .build()
-                            .change_context(Error::Connection)?,
+            } => {
+                let task_name = "sui-msg-verifier".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::sui_verify_msg::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            json_rpc::Client::new_http(
+                                rpc_url.clone(),
+                                reqwest::ClientBuilder::new()
+                                    .connect_timeout(rpc_timeout.unwrap_or(default_rpc_timeout))
+                                    .timeout(rpc_timeout.unwrap_or(default_rpc_timeout))
+                                    .build()
+                                    .change_context(Error::Connection)?,
+                                self.monitoring_client.clone(),
+                                SUI_CHAIN_NAME.clone(),
+                            ),
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        ),
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
-                        SUI_CHAIN_NAME.clone(),
                     ),
-                    self.block_height_monitor.latest_block_height(),
-                    self.monitoring_client.clone(),
-                ),
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+                ))
+            }
             handlers::config::Config::XRPLMsgVerifier {
                 cosmwasm_contract,
                 chain_name,
@@ -436,278 +456,358 @@ impl App {
                     chain_name.clone(),
                 );
 
-                Ok(self.create_handler_task(
-                    format!("{}-msg-verifier", chain_name),
-                    handlers::xrpl_verify_msg::Handler::new(
-                        verifier.clone(),
-                        cosmwasm_contract.clone(),
-                        rpc_client,
-                        self.block_height_monitor.latest_block_height(),
+                let task_name = format!("{}-msg-verifier", chain_name);
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::xrpl_verify_msg::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            rpc_client,
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        ),
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
                     ),
-                    event_processor_config.clone(),
-                    self.monitoring_client.clone(),
                 ))
             }
             handlers::config::Config::XRPLMultisigSigner {
                 cosmwasm_contract,
                 chain_name,
-            } => Ok(self.create_handler_task(
-                "xrpl-multisig-signer",
-                handlers::xrpl_multisig::Handler::new(
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    chain_name.clone(),
-                    self.multisig_client.clone(),
-                    self.block_height_monitor.latest_block_height(),
-                ),
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+            } => {
+                let task_name = "xrpl-multisig-signer".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::xrpl_multisig::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            chain_name.clone(),
+                            self.multisig_client.clone(),
+                            self.block_height_monitor.latest_block_height(),
+                        ),
+                        event_processor_config.clone(),
+                        self.monitoring_client.clone(),
+                    ),
+                ))
+            }
             handlers::config::Config::SuiVerifierSetVerifier {
                 cosmwasm_contract,
                 rpc_url,
                 rpc_timeout,
-            } => Ok(self.create_handler_task(
-                "sui-verifier-set-verifier",
-                handlers::sui_verify_verifier_set::Handler::new(
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    json_rpc::Client::new_http(
-                        rpc_url.clone(),
-                        reqwest::ClientBuilder::new()
-                            .connect_timeout(rpc_timeout.unwrap_or(default_rpc_timeout))
-                            .timeout(rpc_timeout.unwrap_or(default_rpc_timeout))
-                            .build()
-                            .change_context(Error::Connection)?,
+            } => {
+                let task_name = "sui-verifier-set-verifier".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::sui_verify_verifier_set::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            json_rpc::Client::new_http(
+                                rpc_url.clone(),
+                                reqwest::ClientBuilder::new()
+                                    .connect_timeout(rpc_timeout.unwrap_or(default_rpc_timeout))
+                                    .timeout(rpc_timeout.unwrap_or(default_rpc_timeout))
+                                    .build()
+                                    .change_context(Error::Connection)?,
+                                self.monitoring_client.clone(),
+                                SUI_CHAIN_NAME.clone(),
+                            ),
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        ),
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
-                        SUI_CHAIN_NAME.clone(),
                     ),
-                    self.block_height_monitor.latest_block_height(),
-                    self.monitoring_client.clone(),
-                ),
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+                ))
+            }
             handlers::config::Config::MvxMsgVerifier {
                 cosmwasm_contract,
                 proxy_url,
-            } => Ok(self.create_handler_task(
-                "mvx-msg-verifier",
-                handlers::mvx_verify_msg::Handler::new(
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    mvx::proxy::Client::new(
-                        GatewayProxy::new(proxy_url.to_string().trim_end_matches('/').into()),
+            } => {
+                let task_name = "mvx-msg-verifier".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::mvx_verify_msg::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            mvx::proxy::Client::new(
+                                GatewayProxy::new(
+                                    proxy_url.to_string().trim_end_matches('/').into(),
+                                ),
+                                self.monitoring_client.clone(),
+                                MULTIVERSX_CHAIN_NAME.clone(),
+                            ),
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        ),
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
-                        MULTIVERSX_CHAIN_NAME.clone(),
                     ),
-                    self.block_height_monitor.latest_block_height(),
-                    self.monitoring_client.clone(),
-                ),
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+                ))
+            }
             handlers::config::Config::MvxVerifierSetVerifier {
                 cosmwasm_contract,
                 proxy_url,
-            } => Ok(self.create_handler_task(
-                "mvx-worker-set-verifier",
-                handlers::mvx_verify_verifier_set::Handler::new(
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    mvx::proxy::Client::new(
-                        GatewayProxy::new(proxy_url.to_string().trim_end_matches('/').into()),
+            } => {
+                let task_name = "mvx-worker-set-verifier".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::mvx_verify_verifier_set::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            mvx::proxy::Client::new(
+                                GatewayProxy::new(
+                                    proxy_url.to_string().trim_end_matches('/').into(),
+                                ),
+                                self.monitoring_client.clone(),
+                                MULTIVERSX_CHAIN_NAME.clone(),
+                            ),
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        ),
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
-                        MULTIVERSX_CHAIN_NAME.clone(),
                     ),
-                    self.block_height_monitor.latest_block_height(),
-                    self.monitoring_client.clone(),
-                ),
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+                ))
+            }
             handlers::config::Config::StellarMsgVerifier {
                 cosmwasm_contract,
                 rpc_url,
-            } => Ok(self.create_handler_task(
-                "stellar-msg-verifier",
-                handlers::stellar_verify_msg::Handler::new(
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    stellar::rpc_client::Client::new(
-                        rpc_url.clone(),
+            } => {
+                let task_name = "stellar-msg-verifier".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::stellar_verify_msg::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            stellar::rpc_client::Client::new(
+                                rpc_url.clone(),
+                                self.monitoring_client.clone(),
+                                STELLAR_CHAIN_NAME.clone(),
+                            )
+                            .change_context(Error::Connection)?,
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        ),
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
-                        STELLAR_CHAIN_NAME.clone(),
-                    )
-                    .change_context(Error::Connection)?,
-                    self.block_height_monitor.latest_block_height(),
-                    self.monitoring_client.clone(),
-                ),
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+                    ),
+                ))
+            }
             handlers::config::Config::StellarVerifierSetVerifier {
                 cosmwasm_contract,
                 rpc_url,
-            } => Ok(self.create_handler_task(
-                "stellar-verifier-set-verifier",
-                handlers::stellar_verify_verifier_set::Handler::new(
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    stellar::rpc_client::Client::new(
-                        rpc_url.clone(),
+            } => {
+                let task_name = "stellar-verifier-set-verifier".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::stellar_verify_verifier_set::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            stellar::rpc_client::Client::new(
+                                rpc_url.clone(),
+                                self.monitoring_client.clone(),
+                                STELLAR_CHAIN_NAME.clone(),
+                            )
+                            .change_context(Error::Connection)?,
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        ),
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
-                        STELLAR_CHAIN_NAME.clone(),
-                    )
-                    .change_context(Error::Connection)?,
-                    self.block_height_monitor.latest_block_height(),
-                    self.monitoring_client.clone(),
-                ),
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+                    ),
+                ))
+            }
             handlers::config::Config::StarknetMsgVerifier {
                 cosmwasm_contract,
                 rpc_url,
-            } => Ok(self.create_handler_task(
-                "starknet-msg-verifier",
-                handlers::starknet_verify_msg::Handler::new(
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    starknet::json_rpc::Client::new_with_transport(
-                        HttpTransport::new(rpc_url.clone()),
+            } => {
+                let task_name = "starknet-msg-verifier".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::starknet_verify_msg::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            starknet::json_rpc::Client::new_with_transport(
+                                HttpTransport::new(rpc_url.clone()),
+                                self.monitoring_client.clone(),
+                                STARKNET_CHAIN_NAME.clone(),
+                            )
+                            .change_context(Error::Connection)?,
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        ),
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
-                        STARKNET_CHAIN_NAME.clone(),
-                    )
-                    .change_context(Error::Connection)?,
-                    self.block_height_monitor.latest_block_height(),
-                    self.monitoring_client.clone(),
-                ),
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+                    ),
+                ))
+            }
             handlers::config::Config::StarknetVerifierSetVerifier {
                 cosmwasm_contract,
                 rpc_url,
-            } => Ok(self.create_handler_task(
-                "starknet-verifier-set-verifier",
-                handlers::starknet_verify_verifier_set::Handler::new(
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    starknet::json_rpc::Client::new_with_transport(
-                        HttpTransport::new(rpc_url.clone()),
+            } => {
+                let task_name = "starknet-verifier-set-verifier".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::starknet_verify_verifier_set::Handler::new(
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            starknet::json_rpc::Client::new_with_transport(
+                                HttpTransport::new(rpc_url.clone()),
+                                self.monitoring_client.clone(),
+                                STARKNET_CHAIN_NAME.clone(),
+                            )
+                            .change_context(Error::Connection)?,
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        ),
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
-                        STARKNET_CHAIN_NAME.clone(),
-                    )
-                    .change_context(Error::Connection)?,
-                    self.block_height_monitor.latest_block_height(),
-                    self.monitoring_client.clone(),
-                ),
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+                    ),
+                ))
+            }
             handlers::config::Config::SolanaMsgVerifier {
                 chain_name,
                 cosmwasm_contract,
                 rpc_url,
                 rpc_timeout,
-            } => Ok(self.create_handler_task(
-                "solana-msg-verifier",
-                handlers::solana_verify_msg::Handler::new(
-                    chain_name.clone(),
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    solana::Client::new(
-                        RpcClient::new_with_timeout_and_commitment(
-                            rpc_url.to_string(),
-                            rpc_timeout.unwrap_or(default_rpc_timeout),
-                            CommitmentConfig::finalized(),
+            } => {
+                let task_name = "solana-msg-verifier".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::solana_verify_msg::Handler::new(
+                            chain_name.clone(),
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            solana::Client::new(
+                                RpcClient::new_with_timeout_and_commitment(
+                                    rpc_url.to_string(),
+                                    rpc_timeout.unwrap_or(default_rpc_timeout),
+                                    CommitmentConfig::finalized(),
+                                ),
+                                self.monitoring_client.clone(),
+                                chain_name.clone(),
+                            ),
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
                         ),
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
-                        chain_name.clone(),
                     ),
-                    self.block_height_monitor.latest_block_height(),
-                    self.monitoring_client.clone(),
-                ),
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+                ))
+            }
             handlers::config::Config::SolanaVerifierSetVerifier {
                 chain_name,
                 cosmwasm_contract,
                 rpc_url,
                 rpc_timeout,
-            } => Ok(self.create_handler_task(
-                "solana-verifier-set-verifier",
-                handlers::solana_verify_verifier_set::Handler::new(
-                    chain_name.clone(),
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    solana::Client::new(
-                        RpcClient::new_with_timeout_and_commitment(
-                            rpc_url.to_string(),
-                            rpc_timeout.unwrap_or(default_rpc_timeout),
-                            CommitmentConfig::finalized(),
-                        ),
+            } => {
+                let task_name = "solana-verifier-set-verifier".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::solana_verify_verifier_set::Handler::new(
+                            chain_name.clone(),
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            solana::Client::new(
+                                RpcClient::new_with_timeout_and_commitment(
+                                    rpc_url.to_string(),
+                                    rpc_timeout.unwrap_or(default_rpc_timeout),
+                                    CommitmentConfig::finalized(),
+                                ),
+                                self.monitoring_client.clone(),
+                                chain_name.clone(),
+                            ),
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        )
+                        .await,
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
-                        chain_name.clone(),
                     ),
-                    self.block_height_monitor.latest_block_height(),
-                    self.monitoring_client.clone(),
-                )
-                .await,
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+                ))
+            }
             handlers::config::Config::StacksMsgVerifier {
                 chain_name,
                 cosmwasm_contract,
                 rpc_url,
                 rpc_timeout,
-            } => Ok(self.create_handler_task(
-                "stacks-msg-verifier",
-                handlers::stacks_verify_msg::Handler::new(
-                    chain_name.clone(),
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    Client::new_http(
-                        rpc_url.clone(),
-                        rpc_timeout.unwrap_or(default_rpc_timeout),
+            } => {
+                let task_name = "stacks-msg-verifier".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::stacks_verify_msg::Handler::new(
+                            chain_name.clone(),
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            Client::new_http(
+                                rpc_url.clone(),
+                                rpc_timeout.unwrap_or(default_rpc_timeout),
+                                self.monitoring_client.clone(),
+                                chain_name.clone(),
+                            )?,
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        )
+                        .change_context(Error::Connection)?,
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
-                        chain_name.clone(),
-                    )?,
-                    self.block_height_monitor.latest_block_height(),
-                    self.monitoring_client.clone(),
-                )
-                .change_context(Error::Connection)?,
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+                    ),
+                ))
+            }
             handlers::config::Config::StacksVerifierSetVerifier {
                 chain_name,
                 cosmwasm_contract,
                 rpc_url,
                 rpc_timeout,
-            } => Ok(self.create_handler_task(
-                "stacks-verifier-set-verifier",
-                handlers::stacks_verify_verifier_set::Handler::new(
-                    chain_name.clone(),
-                    verifier.clone(),
-                    cosmwasm_contract.clone(),
-                    Client::new_http(
-                        rpc_url.clone(),
-                        rpc_timeout.unwrap_or(default_rpc_timeout),
+            } => {
+                let task_name = "stacks-verifier-set-verifier".to_string();
+                Ok((
+                    task_name.clone(),
+                    self.create_handler_task(
+                        task_name,
+                        handlers::stacks_verify_verifier_set::Handler::new(
+                            chain_name.clone(),
+                            verifier.clone(),
+                            cosmwasm_contract.clone(),
+                            Client::new_http(
+                                rpc_url.clone(),
+                                rpc_timeout.unwrap_or(default_rpc_timeout),
+                                self.monitoring_client.clone(),
+                                chain_name.clone(),
+                            )?,
+                            self.block_height_monitor.latest_block_height(),
+                            self.monitoring_client.clone(),
+                        )
+                        .change_context(Error::Connection)?,
+                        event_processor_config.clone(),
                         self.monitoring_client.clone(),
-                        chain_name.clone(),
-                    )?,
-                    self.block_height_monitor.latest_block_height(),
-                    self.monitoring_client.clone(),
-                )
-                .change_context(Error::Connection)?,
-                event_processor_config.clone(),
-                self.monitoring_client.clone(),
-            )),
+                    ),
+                ))
+            }
         }
     }
 
@@ -775,35 +875,57 @@ impl App {
         });
 
         TaskGroup::new("ampd")
-            .add_task(CancellableTask::create(|token| {
-                block_height_monitor
-                    .run(token)
-                    .change_context(Error::BlockHeightMonitor)
-            }))
-            .add_task(CancellableTask::create(|token| {
-                event_publisher
-                    .run(token)
-                    .change_context(Error::EventPublisher)
-            }))
-            .add_task(CancellableTask::create(|token| {
-                monitoring_server.run(token).change_context(Error::Monitor)
-            }))
-            .add_task(CancellableTask::create(|token| {
-                event_processor
-                    .run(token)
-                    .change_context(Error::EventProcessor)
-            }))
-            .add_task(CancellableTask::create(|token| {
-                grpc_server.run(token).change_context(Error::GrpcServer)
-            }))
-            .add_task(CancellableTask::create(|_| {
-                tx_confirmer.run().change_context(Error::TxConfirmation)
-            }))
-            .add_task(CancellableTask::create(|_| {
-                broadcaster_task.run().change_context(Error::Broadcaster)
-            }))
+            .add_task(
+                "block-height-monitor",
+                CancellableTask::create(|token| {
+                    block_height_monitor
+                        .run(token)
+                        .change_context(Error::BlockHeightMonitor)
+                }),
+            )
+            .add_task(
+                "event-publisher",
+                CancellableTask::create(|token| {
+                    event_publisher
+                        .run(token)
+                        .change_context(Error::EventPublisher)
+                }),
+            )
+            .add_task(
+                "monitoring-server",
+                CancellableTask::create(|token| {
+                    monitoring_server.run(token).change_context(Error::Monitor)
+                }),
+            )
+            .add_task(
+                "event-processor",
+                CancellableTask::create(|token| {
+                    event_processor
+                        .run(token)
+                        .change_context(Error::EventProcessor)
+                }),
+            )
+            .add_task(
+                "grpc-server",
+                CancellableTask::create(|token| {
+                    grpc_server.run(token).change_context(Error::GrpcServer)
+                }),
+            )
+            .add_task(
+                "tx-confirmer",
+                CancellableTask::create(|_| {
+                    tx_confirmer.run().change_context(Error::TxConfirmation)
+                }),
+            )
+            .add_task(
+                "broadcaster-task",
+                CancellableTask::create(|_| {
+                    broadcaster_task.run().change_context(Error::Broadcaster)
+                }),
+            )
             .run(main_token)
             .await
+            .change_context(Error::AppFailure)
     }
 }
 
@@ -823,6 +945,8 @@ pub enum Error {
     Connection,
     #[error("task execution failed")]
     Task(#[from] TaskError),
+    #[error("app failed")]
+    AppFailure,
     #[error("failed to return updated state")]
     ReturnState,
     #[error("failed to load config")]

--- a/contracts/coordinator/src/contract/migrations/mod.rs
+++ b/contracts/coordinator/src/contract/migrations/mod.rs
@@ -20,8 +20,8 @@ use crate::state::{
 enum MigrationError {
     #[error("contract config before migration not found")]
     OldConfigNotFound,
-    #[error("missing contracts to register for chain {0}")]
-    MissingContracts(ChainName),
+    #[error("missing contracts to register for chains {0:?}")]
+    MissingContracts(Vec<ChainName>),
     #[error("extra or duplicate chains provided in message")]
     ExtraChainProvided,
     #[error("chain contracts provided for chain {0} do not match with current state")]
@@ -115,7 +115,7 @@ fn migrate_chain_contracts(
     mut deps: DepsMut,
     chain_contracts: Vec<ChainContracts>,
 ) -> Result<(), axelar_wasm_std::error::ContractError> {
-    let provers_by_chain: Vec<_> = OLD_CHAIN_PROVER_INDEXED_MAP
+    let provers_by_chain: HashMap<_, _> = OLD_CHAIN_PROVER_INDEXED_MAP
         .range(deps.storage, None, None, Order::Ascending)
         .try_collect()?;
 
@@ -131,60 +131,33 @@ fn migrate_chain_contracts(
         })
         .collect::<Result<HashMap<ChainName, ChainContracts>, MigrationError>>()?;
 
-    migrate_registered_provers(&mut deps, provers_by_chain, &mut contracts_map)?;
-
-    migrate_remaining_chains(&mut deps, &mut contracts_map)
+    migrate_all_provers(&mut deps, provers_by_chain, &mut contracts_map)
 }
 
-fn migrate_registered_provers(
+fn migrate_all_provers(
     deps: &mut DepsMut,
-    provers_by_chain: Vec<(ChainName, Addr)>,
+    mut provers_by_chain: HashMap<ChainName, Addr>,
     contracts_map: &mut HashMap<ChainName, ChainContracts>,
 ) -> Result<(), axelar_wasm_std::error::ContractError> {
-    for (chain_name, prover_addr) in provers_by_chain {
-        // If the migration script is used, a chain will be missing only if
-        // that prover does not have a corresponding gateway and verifier.
-        // Consequently, we can safely ignore missing chain contracts.
-        let contracts: ChainContracts = match contracts_for_chain(chain_name.clone(), contracts_map)
-        {
-            Err(..) => continue,
-            Ok(c) => c,
-        };
+    for contracts in contracts_map.values() {
+        let prover_address = contracts
+            .prover_address
+            .as_ref()
+            .map(|addr| {
+                address::validate_cosmwasm_address(deps.api, addr)
+                    .change_context(MigrationError::InvalidChainContracts)
+            })
+            .transpose()?
+            .or_else(|| provers_by_chain.get(&contracts.chain_name).cloned());
 
-        save_contracts_to_state(
-            deps.storage,
-            ChainContractsRecord {
-                chain_name: contracts.chain_name.clone(),
-                prover_address: prover_addr,
-                verifier_address: address::validate_cosmwasm_address(
-                    deps.api,
-                    &contracts.verifier_address,
-                )
-                .change_context(MigrationError::InvalidChainContracts)?,
-                gateway_address: address::validate_cosmwasm_address(
-                    deps.api,
-                    &contracts.gateway_address,
-                )
-                .change_context(MigrationError::InvalidChainContracts)?,
-            },
-        )?;
-    }
+        provers_by_chain.remove(&contracts.chain_name);
 
-    Ok(())
-}
-
-fn migrate_remaining_chains(
-    deps: &mut DepsMut,
-    contracts_map: &mut HashMap<ChainName, ChainContracts>,
-) -> Result<(), axelar_wasm_std::error::ContractError> {
-    for contracts in contracts_map.values_mut() {
-        if let Some(prover_address) = &contracts.prover_address {
+        if let Some(addr) = prover_address {
             save_contracts_to_state(
                 deps.storage,
                 ChainContractsRecord {
                     chain_name: contracts.chain_name.clone(),
-                    prover_address: address::validate_cosmwasm_address(deps.api, prover_address)
-                        .change_context(MigrationError::InvalidChainContracts)?,
+                    prover_address: addr,
                     verifier_address: address::validate_cosmwasm_address(
                         deps.api,
                         &contracts.verifier_address,
@@ -200,18 +173,13 @@ fn migrate_remaining_chains(
         }
     }
 
+    if !provers_by_chain.is_empty() {
+        return Err(
+            MigrationError::MissingContracts(provers_by_chain.into_keys().collect()).into(),
+        );
+    }
+
     Ok(())
-}
-
-fn contracts_for_chain(
-    chain_name: ChainName,
-    contracts_map: &mut HashMap<ChainName, ChainContracts>,
-) -> Result<ChainContracts, axelar_wasm_std::error::ContractError> {
-    let contracts = contracts_map
-        .remove(&chain_name)
-        .ok_or_else(|| MigrationError::MissingContracts(chain_name.clone()))?;
-
-    Ok(contracts)
 }
 
 fn save_contracts_to_state(
@@ -696,5 +664,125 @@ mod tests {
         );
 
         assert!(res.is_ok());
+    }
+
+    #[test]
+    fn migrate_uses_provided_prover_address_over_state_prover() {
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+        let info = message_info(&cosmos_addr!(SENDER), &[]);
+
+        assert!(old_instantiate(
+            deps.as_mut(),
+            env.clone(),
+            info,
+            OldInstantiateMsg {
+                governance_address: cosmos_addr!(GOVERNANCE).to_string(),
+                service_registry: cosmos_addr!(SERVICE_REGISTRY).to_string(),
+            },
+        )
+        .is_ok());
+
+        let chain_name = chain_name!(CHAIN_1);
+        let state_prover_addr = cosmos_addr!(PROVER_1);
+        let provided_prover_addr = cosmos_addr!(PROVER_2);
+        let gateway_addr = cosmos_addr!(GATEWAY_1);
+        let verifier_addr = cosmos_addr!(VERIFIER_1);
+
+        assert!(add_old_prover_registration(
+            deps.as_mut(),
+            vec![(chain_name.clone(), state_prover_addr.clone())]
+        )
+        .is_ok());
+
+        let res = migrate(
+            deps.as_mut(),
+            env,
+            MigrateMsg {
+                router: cosmos_addr!(ROUTER).to_string(),
+                multisig: cosmos_addr!(MULTISIG).to_string(),
+                chain_contracts: vec![ChainContracts {
+                    chain_name: chain_name.clone(),
+                    prover_address: Some(
+                        nonempty::String::try_from(provided_prover_addr.to_string()).unwrap(),
+                    ),
+                    gateway_address: nonempty::String::try_from(gateway_addr.to_string()).unwrap(),
+                    verifier_address: nonempty::String::try_from(verifier_addr.to_string())
+                        .unwrap(),
+                }],
+            },
+        );
+
+        assert!(res.is_ok());
+
+        let contracts = state::contracts_by_chain(&deps.storage, chain_name.clone());
+        assert!(contracts.is_ok());
+        let contracts = contracts.unwrap();
+
+        assert_eq!(contracts.chain_name, chain_name);
+        assert_eq!(contracts.prover_address, provided_prover_addr);
+        assert_eq!(contracts.gateway_address, gateway_addr);
+        assert_eq!(contracts.verifier_address, verifier_addr);
+
+        let contracts_by_prover =
+            state::contracts_by_prover(&deps.storage, provided_prover_addr.clone());
+        assert!(contracts_by_prover.is_ok());
+        assert_eq!(contracts_by_prover.unwrap().chain_name, chain_name);
+    }
+
+    #[test]
+    fn migrate_fails_with_missing_contracts() {
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+        let info = message_info(&cosmos_addr!(SENDER), &[]);
+
+        assert!(old_instantiate(
+            deps.as_mut(),
+            env.clone(),
+            info,
+            OldInstantiateMsg {
+                governance_address: cosmos_addr!(GOVERNANCE).to_string(),
+                service_registry: cosmos_addr!(SERVICE_REGISTRY).to_string(),
+            },
+        )
+        .is_ok());
+
+        let chain_name1 = chain_name!(CHAIN_1);
+        let chain_name2 = chain_name!(CHAIN_2);
+        let prover_addr1 = cosmos_addr!(PROVER_1);
+        let prover_addr2 = cosmos_addr!(PROVER_2);
+        let gateway_addr = cosmos_addr!(GATEWAY_1);
+        let verifier_addr = cosmos_addr!(VERIFIER_1);
+
+        assert!(add_old_prover_registration(
+            deps.as_mut(),
+            vec![
+                (chain_name1.clone(), prover_addr1.clone()),
+                (chain_name2.clone(), prover_addr2.clone())
+            ]
+        )
+        .is_ok());
+
+        let res = migrate(
+            deps.as_mut(),
+            env,
+            MigrateMsg {
+                router: cosmos_addr!(ROUTER).to_string(),
+                multisig: cosmos_addr!(MULTISIG).to_string(),
+                chain_contracts: vec![ChainContracts {
+                    chain_name: chain_name1.clone(),
+                    prover_address: None,
+                    gateway_address: nonempty::String::try_from(gateway_addr.to_string()).unwrap(),
+                    verifier_address: nonempty::String::try_from(verifier_addr.to_string())
+                        .unwrap(),
+                }],
+            },
+        );
+
+        assert!(res.is_err());
+        assert!(res
+            .unwrap_err()
+            .to_string()
+            .contains(&MigrationError::MissingContracts(vec![chain_name2]).to_string()));
     }
 }

--- a/packages/ampd-sdk/Cargo.toml
+++ b/packages/ampd-sdk/Cargo.toml
@@ -34,7 +34,7 @@ valuable = { workspace = true }
 [build-dependencies]
 
 [dev-dependencies]
-temp-env = "0.3.6"
+temp-env = { workspace = true }
 tempfile = "3.21.0"
 tokio = { workspace = true, features = ["test-util"] }
 

--- a/packages/report/Cargo.toml
+++ b/packages/report/Cargo.toml
@@ -10,6 +10,7 @@ edition = { workspace = true }
 error-stack = { workspace = true }
 eyre = "0.6.8"
 itertools = { workspace = true }
+temp-env = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-core = { workspace = true }


### PR DESCRIPTION
Support Aleo at voting-verifier## Description
## Convention Checklist
- [ ] Each contract should have a [client mod](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/voting-verifier/src/client.rs) for others to interact with it.
- [ ] Derive macros
  - [Permissions](https://github.com/axelarnetwork/axelar-amplifier/blob/38321b74f9e3ce1516663b21067fc5a8391c53c2/packages/msgs-derive/src/lib.rs#L81): Contract permission control
  - [IntoContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std-derive/src/lib.rs#L12): Conversion from custom contract errors to [axelar_wasm_std::error::ContractError](https://github.com/axelarnetwork/axelar-amplifier/blob/eeb4406c7a0af04ec3afd8fcc39e65e6f2e69f7d/packages/axelar-wasm-std/src/error.rs#L16)
  - [IntoEvent](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L160): Event serialization
  - [migrate_from_version](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/packages/axelar-wasm-std-derive/src/lib.rs#L349): Contract version management in the migrate function
- [ ] The state mod and msg mod should use separate data structures so that internal state changes do not break the contract interface. Check out the [interchain-token-service](https://github.com/axelarnetwork/axelar-amplifier/blob/27318df3e22e526867c91905d03a6a8b1a41110b/contracts/interchain-token-service/src/contract.rs) for reference.
  - msg.rs should never use any type from the state.rs
  - Shared types must be defined in a separate `shared` mod. If those types have already been defined somewhere else, then they should get re-exported in the `shared` mod
…sses by default (axelarnetwork#1058)